### PR TITLE
Add bulk dataset ingestion script using pueue with per-ingestor templates

### DIFF
--- a/scripts/bulk_ingest/ingest_beir.sh
+++ b/scripts/bulk_ingest/ingest_beir.sh
@@ -25,9 +25,9 @@ for ds in "${DATASETS[@]}"; do
   d="${ds//-/_}"
   DB="beir_${d}_test_${M}"
   pueue add -l "beir-${ds}" \
-    "autorag-research ingest --name=beir --extra dataset-name=${ds} --embedding-model=${MODEL} \
+    "autorag-research ingest --name=beir --extra dataset-name=${ds} --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump beir ${ds}_${MODEL}"
+     && autorag-research data upload ${DB}.dump beir ${ds}_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#DATASETS[@]} BEIR tasks."

--- a/scripts/bulk_ingest/ingest_bright.sh
+++ b/scripts/bulk_ingest/ingest_bright.sh
@@ -33,14 +33,11 @@ TASKS=(
 for entry in "${TASKS[@]}"; do
   IFS=: read -r domain mode <<< "${entry}"
   DB="bright_${domain}_${mode}_test_${M}"
-  EXTRA="--extra domain=${domain}"
-  if [[ "${mode}" != "short" ]]; then
-    EXTRA="${EXTRA} --extra document-mode=${mode}"
-  fi
+  EXTRA="--extra domain=${domain} --extra document-mode=${mode}"
   pueue add -l "bright-${domain}-${mode}" \
-    "autorag-research ingest --name=bright ${EXTRA} --embedding-model=${MODEL} \
+    "autorag-research ingest --name=bright ${EXTRA} --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump bright ${domain}_${mode}_${MODEL}"
+     && autorag-research data upload ${DB}.dump bright ${domain}_${mode}_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#TASKS[@]} BRIGHT tasks."

--- a/scripts/bulk_ingest/ingest_mrtydi.sh
+++ b/scripts/bulk_ingest/ingest_mrtydi.sh
@@ -21,9 +21,9 @@ LANGUAGES=(
 for lang in "${LANGUAGES[@]}"; do
   DB="mrtydi_${lang}_test_${M}"
   pueue add -l "mrtydi-${lang}" \
-    "autorag-research ingest --name=mrtydi --extra language=${lang} --embedding-model=${MODEL} \
+    "autorag-research ingest --name=mrtydi --extra language=${lang} --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump mrtydi ${lang}_${MODEL}"
+     && autorag-research data upload ${DB}.dump mrtydi ${lang}_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#LANGUAGES[@]} MrTyDi tasks."

--- a/scripts/bulk_ingest/ingest_mteb.sh
+++ b/scripts/bulk_ingest/ingest_mteb.sh
@@ -27,9 +27,9 @@ for task in "${TASKS[@]}"; do
   t=$(echo "${task}" | tr '[:upper:]' '[:lower:]')
   DB="mteb_${t}_test_${M}"
   pueue add -l "mteb-${task}" \
-    "autorag-research ingest --name=mteb --extra task-name=${task} --embedding-model=${MODEL} \
+    "autorag-research ingest --name=mteb --extra task-name=${task} --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump mteb ${t}_${MODEL}"
+     && autorag-research data upload ${DB}.dump mteb ${t}_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#TASKS[@]} MTEB tasks."

--- a/scripts/bulk_ingest/ingest_open_ragbench.sh
+++ b/scripts/bulk_ingest/ingest_open_ragbench.sh
@@ -8,6 +8,6 @@ DB="open_ragbench_test_${M}"
 pueue add -l "open-ragbench" \
   "autorag-research ingest --name=open-ragbench --db-name=${DB} --embedding-model=${MODEL} \
    && autorag-research data dump --db-name=${DB} \
-   && autorag-research data upload ${DB}.dump open-ragbench ${MODEL}"
+   && autorag-research data upload ${DB}.dump open-ragbench ${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 
 echo "Queued 1 Open-RAGBench task."

--- a/scripts/bulk_ingest/ingest_ragbench.sh
+++ b/scripts/bulk_ingest/ingest_ragbench.sh
@@ -22,9 +22,9 @@ CONFIGS=(
 for c in "${CONFIGS[@]}"; do
   DB="ragbench_${c}_test_${M}"
   pueue add -l "ragbench-${c}" \
-    "autorag-research ingest --name=ragbench --extra config=${c} --embedding-model=${MODEL} \
+    "autorag-research ingest --name=ragbench --extra config=${c} --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump ragbench ${c}_${MODEL}"
+     && autorag-research data upload ${DB}.dump ragbench ${c}_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#CONFIGS[@]} RAGBench tasks."

--- a/scripts/bulk_ingest/ingest_vidore.sh
+++ b/scripts/bulk_ingest/ingest_vidore.sh
@@ -18,12 +18,12 @@ DATASETS=(
 )
 
 for ds in "${DATASETS[@]}"; do
-  d=$(echo "${ds}" | tr '[:upper:]' '[:lower:]')
+  d=$(echo "${ds}" | tr '[:upper:]' '[:lower:]' | tr '-' '_')
   DB="vidore_${d}_test_${M}"
   pueue add -l "vidore-${ds}" \
-    "autorag-research ingest --name=vidore --extra dataset-name=${ds} --embedding-model=${MODEL} \
+    "autorag-research ingest --name=vidore --extra dataset-name=${ds} --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump vidore ${d}_${MODEL}"
+     && autorag-research data upload ${DB}.dump vidore ${d}_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#DATASETS[@]} ViDoRe tasks."

--- a/scripts/bulk_ingest/ingest_vidorev2.sh
+++ b/scripts/bulk_ingest/ingest_vidorev2.sh
@@ -13,9 +13,9 @@ DATASETS=(
 for ds in "${DATASETS[@]}"; do
   DB="vidorev2_${ds}_test_${M}"
   pueue add -l "vidorev2-${ds}" \
-    "autorag-research ingest --name=vidorev2 --extra dataset-name=${ds} --embedding-model=${MODEL} \
+    "autorag-research ingest --name=vidorev2 --extra dataset-name=${ds} --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump vidorev2 ${ds}_${MODEL}"
+     && autorag-research data upload ${DB}.dump vidorev2 ${ds}_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#DATASETS[@]} ViDoReV2 tasks."

--- a/scripts/bulk_ingest/ingest_vidorev3.sh
+++ b/scripts/bulk_ingest/ingest_vidorev3.sh
@@ -18,9 +18,9 @@ CONFIGS=(
 for c in "${CONFIGS[@]}"; do
   DB="vidorev3_${c}_image_test_${M}"
   pueue add -l "vidorev3-${c}" \
-    "autorag-research ingest --name=vidorev3 --extra config-name=${c} --embedding-model=${MODEL} \
+    "autorag-research ingest --name=vidorev3 --extra config-name=${c} --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump vidorev3 ${c}_image_${MODEL}"
+     && autorag-research data upload ${DB}.dump vidorev3 ${c}_image_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#CONFIGS[@]} ViDoReV3 tasks."

--- a/scripts/bulk_ingest/ingest_visrag.sh
+++ b/scripts/bulk_ingest/ingest_visrag.sh
@@ -17,9 +17,9 @@ for ds in "${DATASETS[@]}"; do
   d=$(echo "${ds}" | tr '[:upper:]' '[:lower:]' | tr '-' '_')
   DB="visrag_${d}_train_${M}"
   pueue add -l "visrag-${ds}" \
-    "autorag-research ingest --name=visrag --extra dataset-name=${ds} --subset=train --embedding-model=${MODEL} \
+    "autorag-research ingest --name=visrag --extra dataset-name=${ds} --subset=train --embedding-model=${MODEL} --db-name=${DB} \
      && autorag-research data dump --db-name=${DB} \
-     && autorag-research data upload ${DB}.dump visrag ${d}_${MODEL}"
+     && autorag-research data upload ${DB}.dump visrag ${d}_${MODEL}; ret=\$?; rm -f ${DB}.dump; exit \$ret"
 done
 
 echo "Queued ${#DATASETS[@]} VisRAG tasks."


### PR DESCRIPTION
## Summary

Add 10 per-ingestor shell scripts in `scripts/bulk_ingest/` that queue all datasets into pueue for bulk ingestion. Each script takes an embedding model name as the only argument and loops over an editable array of datasets, queuing chained `ingest && dump && upload` commands via `pueue add`.

**Scripts created:**
- `ingest_beir.sh` (14 datasets)
- `ingest_bright.sh` (20 entries: 12 short + 8 long)
- `ingest_mteb.sh` (15 tasks)
- `ingest_ragbench.sh` (12 configs)
- `ingest_mrtydi.sh` (11 languages)
- `ingest_vidore.sh` (10 datasets)
- `ingest_vidorev2.sh` (3 datasets)
- `ingest_vidorev3.sh` (8 configs)
- `ingest_visrag.sh` (6 datasets)
- `ingest_open_ragbench.sh` (1 dataset)

DB names are verified to match `generate_db_name()` output. Users can comment out unwanted datasets in each script.

## Original Issue

Add script file to bulk ingest many datasets. It must use `pueue` to sequentially try to ingest each datasets. The script files should be existed per ingestor, and it ingests all data types (like domains in BRIGHT) at once using peueu (go to the queue all at once)
You have to consider to edit the script easily by the end user by selecting wanted datasets. But the cli command option not needed since the user can edit the script file itself. The only option to that script file is embedding model name.

close #219