### PR TITLE
Release initial version to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ authors = [{ name = "NomaDamas", email = "vkehfdl1@gmail.com" }]
 readme = "README.md"
 keywords = ['python']
 requires-python = ">=3.10,<4.0"
+license = {text = "Apache-2.0"}
 classifiers = [
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,8 +25,6 @@ dependencies = [
     "bert-score>=0.3.13",
     "datasets<3.0.0",
     "evaluate>=0.4.6",
-    "hydra-core>=1.3.0",
-    "httpx>=0.28.0",
     "hydra-core>=1.3.0",
     "httpx>=0.28.0",
     "huggingface-hub>=0.36.0",
@@ -103,6 +102,27 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/.claude",
+    "/.github",
+    "/.pre-commit-config.yaml",
+    "/.env.template",
+    "/ai_instructions",
+    "/docs",
+    "/tests",
+    "/postgresql",
+    "/scripts",
+    "/Dockerfile",
+    "/docker-compose.yml",
+    "/Makefile",
+    "/mkdocs.yml",
+    "/tox.ini",
+    "/uv.lock",
+    "/CLAUDE.md",
+    "/CONTRIBUTING.md",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["autorag_research"]


### PR DESCRIPTION
## Summary

Prepare `pyproject.toml` for the initial PyPI release of `autorag-research`.

- Remove duplicate dependencies (`hydra-core`, `httpx` listed twice)
- Remove incorrect `Python :: 3.9` classifier (`requires-python` is `>=3.10`)
- Add `license = {text = "Apache-2.0"}` and `License :: OSI Approved :: Apache Software License` classifier
- Add `[tool.hatch.build.targets.sdist]` exclude rules to keep `.claude/`, `.github/`, `tests/`, `docs/`, `Dockerfile`, `Makefile`, `uv.lock`, etc. out of the source distribution

## Original Issue

Release the initial version to pypi

## Note for release

After merging, create a GitHub Release with a **PEP 440 compliant tag** (e.g., `0.1.0` — no `v` prefix). The `on-release-main` workflow will automatically build, publish to PyPI, and deploy docs.

Ensure `PYPI_TOKEN` is an **account-wide** token (not project-scoped) since this is the first upload.

close #235