### PR TITLE
KeyError: 'total_results' in pipeline executor and missing 'error' attribute in PipelineResult

### DIFF
--- a/autorag_research/cli/commands/run.py
+++ b/autorag_research/cli/commands/run.py
@@ -167,8 +167,8 @@ def print_results(result) -> None:
     for pr in result.pipeline_results:
         status = "+" if pr.success else "x"
         typer.echo(f"  {status} {pr.pipeline_name}")
-        if pr.error:
-            typer.echo(f"      Error: {pr.error}")
+        if pr.error_message:
+            typer.echo(f"      Error: {pr.error_message}")
 
     typer.echo("\nMetric Results:")
     typer.echo("-" * 60)

--- a/autorag_research/executor.py
+++ b/autorag_research/executor.py
@@ -39,7 +39,6 @@ class PipelineResult:
         pipeline_name: The name of the pipeline.
         pipeline_type: The type of pipeline (RETRIEVAL or GENERATION).
         total_queries: Total number of queries processed.
-        total_results: Total number of results stored.
         retries_used: Number of retry attempts used.
         success: Whether the pipeline execution was successful.
         error_message: Error message if the pipeline failed.
@@ -49,7 +48,6 @@ class PipelineResult:
     pipeline_name: str
     pipeline_type: PipelineType
     total_queries: int
-    total_results: int
     retries_used: int
     success: bool
     error_message: str | None = None
@@ -257,8 +255,7 @@ class Executor:
                     logger.info(
                         f"Pipeline '{config.name}' completed successfully "
                         f"(pipeline_id={pipeline_id}, "
-                        f"queries={run_result['total_queries']}, "
-                        f"results={run_result['total_results']})"
+                        f"queries={run_result['total_queries']})"
                     )
 
                     return PipelineResult(
@@ -266,7 +263,6 @@ class Executor:
                         pipeline_name=config.name,
                         pipeline_type=config.pipeline_type,
                         total_queries=run_result["total_queries"],
-                        total_results=run_result["total_results"],
                         retries_used=attempt,
                         success=True,
                     )
@@ -285,7 +281,6 @@ class Executor:
             pipeline_name=config.name,
             pipeline_type=config.pipeline_type,
             total_queries=0,
-            total_results=0,
             retries_used=self.config.max_retries,
             success=False,
             error_message=error_msg,

--- a/tests/autorag_research/test_executor.py
+++ b/tests/autorag_research/test_executor.py
@@ -247,7 +247,6 @@ class TestMetricEvaluationRules:
         mock_pipeline.run.return_value = {
             "pipeline_id": 999,
             "total_queries": 10,
-            "total_results": 100,
         }
 
         config.pipelines[0].get_pipeline_class = lambda: lambda **kw: mock_pipeline
@@ -314,7 +313,6 @@ class TestMetricEvaluationRules:
         mock_pipeline.run.return_value = {
             "pipeline_id": 999,
             "total_queries": 10,
-            "total_results": 100,
         }
 
         config.pipelines[0].get_pipeline_class = lambda: lambda **kw: mock_pipeline


### PR DESCRIPTION
## Summary
- Removed dead `total_results` field from `PipelineResult` dataclass — it was never read downstream or persisted to DB, and generation pipelines don't return it (causing `KeyError` on generation pipeline runs like `basic_rag`)
- Fixed `pr.error` → `pr.error_message` in `print_results()` to match the actual dataclass field name (was causing `AttributeError`)
- Updated test mocks to remove `total_results` from mock return values

## Original Issue
```
Pipeline 'basic_rag' failed with error
KeyError: 'total_results'

Experiment failed
AttributeError: 'PipelineResult' object has no attribute 'error'
```

## Test plan
- [x] Verified `total_results` is not used anywhere downstream (not in `print_results`, not persisted to DB)
- [x] Executor unit tests pass (3/3 mocked tests pass; 2 DB-dependent tests skipped without Docker)
- [x] `make check` passes clean (ruff, ty, deptry)

close #274