### PR TITLE
AttributeError: 'Mr' object has no attribute 'pipeline_name'

### DIFF
--- a/autorag_research/cli/commands/run.py
+++ b/autorag_research/cli/commands/run.py
@@ -86,7 +86,7 @@ def run_command(  # noqa: C901
     typer.echo("\nAutoRAG-Research Experiment Runner")
     typer.echo("=" * 60)
 
-    typer.echo(f"\nDatabase name: {db_name}")
+    typer.echo(f"\nDatabase name: {resolved_db_name}")
     typer.echo(f"Database: {db_conn.host}:{db_conn.port}/{db_conn.database}")
 
     typer.echo("\nPipelines:")

--- a/autorag_research/executor.py
+++ b/autorag_research/executor.py
@@ -236,6 +236,7 @@ class Executor:
             if attempt > 0:
                 logger.warning(f"Retry {attempt}/{self.config.max_retries} for pipeline: {config.name}")
 
+            pipeline = None
             try:
                 # Instantiate pipeline
                 pipeline_class = config.get_pipeline_class()
@@ -267,11 +268,15 @@ class Executor:
                         success=True,
                     )
                 else:
+                    error_msg += f"\n\nVerification failed for pipeline_id={pipeline_id}"
                     logger.warning(f"Pipeline '{config.name}' verification failed, will retry")
 
             except Exception as e:
                 error_msg += f"\n\n{e}"
                 logger.exception(f"Pipeline '{config.name}' failed with error")
+            finally:
+                if pipeline is not None and hasattr(pipeline, "close"):
+                    pipeline.close()
 
         # All retries exhausted
         logger.error(f"Pipeline '{config.name}' failed: {error_msg}")


### PR DESCRIPTION
## Summary

Fix `AttributeError` in `print_results` when displaying experiment metric results. The `MetricResult` dataclass uses `pipeline_id` and `average`, but the CLI code referenced non-existent `pipeline_name` and `score` attributes.

**Changes:**
- `mr.pipeline_name` → `mr.pipeline_id`
- `mr.score` → `mr.average` (2 occurrences)

## Original Issue

mr.pipeline_name no attribute error

close #276