### PR TITLE
Sonnet will decide to approve or deny the permission.

### DIFF
--- a/.claude/hooks/permission-gates.py
+++ b/.claude/hooks/permission-gates.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+import json
+import re
+import shlex
+import sys
+
+WRITEY = [
+    "insert", "update", "delete", "truncate", "alter", "create",
+    "grant", "revoke", "vacuum", "analyze", "comment", "do", "call",
+    "copy", "refresh", "reindex", "cluster", "lock",
+    "set", "reset",
+    "begin", "commit", "rollback", "savepoint",
+    "prepare", "execute",
+]
+
+def emit(decision, reason):
+    sys.stdout.write(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason
+        }
+    }))
+
+def tokens(cmd):
+    try:
+        return shlex.split(cmd)
+    except Exception:
+        return cmd.split()
+
+def env_ref(cmd):
+    return bool(re.search(r'(^|[ \t"\'/])\.env(\.[^ \t"\'/]+)?($|[ \t"\'/])', cmd))
+
+def is_psql(ts):
+    i = 0
+    while i < len(ts) and re.match(r'^[A-Za-z_][A-Za-z0-9_]*=.*$', ts[i]):
+        i += 1
+    if i < len(ts) and (ts[i] == "psql" or ts[i].endswith("/psql") or ts[i].endswith("\\psql.exe")):
+        return i
+    return None
+
+def extract_sql(ts, psql_i):
+    i = psql_i + 1
+    while i < len(ts):
+        t = ts[i]
+        if t in ("-c", "--command"):
+            return ts[i+1] if i+1 < len(ts) else ""
+        if t.startswith("--command="):
+            return t.split("=", 1)[1]
+        if t in ("-f", "--file"):
+            return None
+        i += 1
+    return None
+
+def classify(sql):
+    s = sql.strip()
+    low = s.lower()
+
+    if re.search(r"\bdrop\b", low):
+        return "deny", "psql: DROP denied"
+
+    starts = bool(re.match(r"^(select|with)\b", low))
+    has_select = bool(re.search(r"\bselect\b", low))
+    has_into = bool(re.search(r"\binto\b", low))
+    has_writey = any(re.search(rf"\b{k}\b", low) for k in WRITEY)
+
+    if starts and has_select and (not has_into) and (not has_writey):
+        return "allow", "psql: read-only query auto-allowed"
+
+    return "ask", "psql: non-SELECT query requires confirmation"
+
+def main():
+    payload = json.load(sys.stdin)
+    if payload.get("tool_name") != "Bash":
+        return
+
+    cmd = payload.get("tool_input", {}).get("command", "")
+    if not isinstance(cmd, str) or not cmd.strip():
+        return
+
+    if env_ref(cmd):
+        emit("deny", "sensitive file access denied")
+        return
+
+    ts = tokens(cmd)
+    p = is_psql(ts)
+    if p is not None:
+        sql = extract_sql(ts, p)
+        if sql is None:
+            emit("ask", "psql: interactive/file execution requires confirmation")
+            return
+        decision, reason = classify(sql)
+        emit(decision, reason)
+        return
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/permission-reviewer.py
+++ b/.claude/hooks/permission-reviewer.py
@@ -1,3 +1,4 @@
+# ruff: noqa: S110, S603, S607, TRY300
 #!/usr/bin/env python3
 """
 PermissionRequest hook: Sonnet API to auto-judge gray-zone commands.
@@ -6,6 +7,7 @@ PermissionRequest hook: Sonnet API to auto-judge gray-zone commands.
 - Only deny genuine, irreversible risks
 Requires ANTHROPIC_API_KEY environment variable.
 """
+
 import json
 import os
 import subprocess
@@ -19,7 +21,9 @@ def load_api_key():
     try:
         result = subprocess.run(
             ["zsh", "-lc", "echo $ANTHROPIC_API_KEY"],
-            capture_output=True, text=True, timeout=3,
+            capture_output=True,
+            text=True,
+            timeout=3,
         )
         key = result.stdout.strip()
         if key:
@@ -61,22 +65,29 @@ def call_sonnet(request_info, api_key):
     payload = json.dumps({
         "model": "claude-sonnet-4-5-20250929",
         "max_tokens": 150,
-        "messages": [
-            {"role": "user", "content": "Review this request:\n\n" + request_info}
-        ],
+        "messages": [{"role": "user", "content": "Review this request:\n\n" + request_info}],
         "system": SYSTEM_PROMPT,
     })
     try:
         result = subprocess.run(
             [
-                "curl", "-s", "--max-time", "15",
+                "curl",
+                "-s",
+                "--max-time",
+                "15",
                 "https://api.anthropic.com/v1/messages",
-                "-H", "content-type: application/json",
-                "-H", "x-api-key: " + api_key,
-                "-H", "anthropic-version: 2023-06-01",
-                "-d", payload,
+                "-H",
+                "content-type: application/json",
+                "-H",
+                "x-api-key: " + api_key,
+                "-H",
+                "anthropic-version: 2023-06-01",
+                "-d",
+                payload,
             ],
-            capture_output=True, text=True, timeout=18,
+            capture_output=True,
+            text=True,
+            timeout=18,
         )
         resp = json.loads(result.stdout)
         text = resp["content"][0]["text"]

--- a/.claude/hooks/permission-reviewer.py
+++ b/.claude/hooks/permission-reviewer.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+PermissionRequest hook: Sonnet API to auto-judge gray-zone commands.
+- Only receives requests that didn't match allow/deny rules
+- Default stance: APPROVE (dev context, most operations are safe)
+- Only deny genuine, irreversible risks
+Requires ANTHROPIC_API_KEY environment variable.
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def load_api_key():
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if key:
+        return key
+    try:
+        result = subprocess.run(
+            ["zsh", "-lc", "echo $ANTHROPIC_API_KEY"],
+            capture_output=True, text=True, timeout=3,
+        )
+        key = result.stdout.strip()
+        if key:
+            return key
+    except Exception:
+        pass
+    return None
+
+
+SYSTEM_PROMPT = """\
+You are a permissive permission reviewer for a developer's coding agent.
+The request below already passed rule-based allow/deny filters without matching — \
+it's an edge case that needs your contextual judgment.
+
+Your default stance is to APPROVE. Developers move fast and most operations are \
+safe in a dev context. Only deny something if it poses a genuine, concrete risk — \
+not a theoretical one.
+
+Approve liberally:
+- Deleting files/dirs is almost always fine (build artifacts, caches, temp files, \
+even source files during refactoring)
+- Unfamiliar commands or scripts are fine if they look like normal dev work
+- Git operations, package management, builds, tests — just let them through
+- When in doubt, approve. The developer can always undo.
+
+Only deny when the risk is real and irreversible:
+- Destroying the home directory, root filesystem, or OS-level system files
+- Leaking credentials or secrets to external services
+- Publishing packages or deploying to production
+- Commands that clearly exfiltrate data to unknown destinations
+
+Respond ONLY with a JSON object: {"ok": true} to approve or {"ok": false, "reason": "..."} to deny.
+No other text.\
+"""
+
+
+def call_sonnet(request_info, api_key):
+    """Call Anthropic API via curl (no external dependencies)."""
+    payload = json.dumps({
+        "model": "claude-sonnet-4-5-20250929",
+        "max_tokens": 150,
+        "messages": [
+            {"role": "user", "content": "Review this request:\n\n" + request_info}
+        ],
+        "system": SYSTEM_PROMPT,
+    })
+    try:
+        result = subprocess.run(
+            [
+                "curl", "-s", "--max-time", "15",
+                "https://api.anthropic.com/v1/messages",
+                "-H", "content-type: application/json",
+                "-H", "x-api-key: " + api_key,
+                "-H", "anthropic-version: 2023-06-01",
+                "-d", payload,
+            ],
+            capture_output=True, text=True, timeout=18,
+        )
+        resp = json.loads(result.stdout)
+        text = resp["content"][0]["text"]
+        start = text.find("{")
+        end = text.rfind("}") + 1
+        if start >= 0 and end > start:
+            return json.loads(text[start:end])
+        return {"ok": True}
+    except Exception:
+        return {"ok": True}
+
+
+def emit(behavior, message=""):
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PermissionRequest",
+            "decision": {"behavior": behavior},
+        }
+    }
+    if behavior == "deny" and message:
+        output["hookSpecificOutput"]["decision"]["message"] = message
+    sys.stdout.write(json.dumps(output))
+
+
+def main():
+    payload = json.load(sys.stdin)
+    tool_name = payload.get("tool_name", "unknown")
+    tool_input = payload.get("tool_input", {})
+
+    if tool_name == "Bash":
+        request_info = "Tool: Bash\nCommand: " + tool_input.get("command", "")
+    elif tool_name in ("Edit", "Write"):
+        request_info = "Tool: " + tool_name + "\nFile: " + tool_input.get("file_path", "")
+    else:
+        request_info = "Tool: " + tool_name + "\nInput: " + json.dumps(tool_input, ensure_ascii=False)[:500]
+
+    api_key = load_api_key()
+    if not api_key:
+        emit("allow")
+        return
+
+    result = call_sonnet(request_info, api_key)
+
+    if result.get("ok", True):
+        emit("allow")
+    else:
+        emit("deny", result.get("reason", "Sonnet denied this request"))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/permission-reviewer.py
+++ b/.claude/hooks/permission-reviewer.py
@@ -117,6 +117,7 @@ def main():
     tool_name = payload.get("tool_name", "unknown")
     tool_input = payload.get("tool_input", {})
 
+    # matcher가 Bash|Edit|Write만 통과시키므로 여기엔 해당 도구만 옴
     if tool_name == "Bash":
         request_info = "Tool: Bash\nCommand: " + tool_input.get("command", "")
     elif tool_name in ("Edit", "Write"):

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/bin/python3 /Users/jeffrey/.claude/hooks/permission-gates.py"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/permission-gates.py"
           }
         ]
       }
@@ -42,9 +42,8 @@
       {
         "hooks": [
           {
-            "type": "prompt",
-            "model": "sonnet",
-            "prompt": "You are a permissive permission reviewer for a developer's coding agent. The request below already passed rule-based allow/deny filters without matching \u2014 it's an edge case that needs your contextual judgment.\n\nRequest: $ARGUMENTS\n\nYour default stance is to APPROVE. Developers move fast and most operations are safe in a dev context. Only deny something if it poses a genuine, concrete risk \u2014 not a theoretical one.\n\nApprove liberally:\n- Deleting files/dirs is almost always fine (build artifacts, caches, temp files, even source files during refactoring)\n- Unfamiliar commands or scripts are fine if they look like normal dev work\n- Git operations, package management, builds, tests \u2014 just let them through\n- When in doubt, approve. The developer can always undo.\n\nOnly deny when the risk is real and irreversible:\n- Destroying the home directory, root filesystem, or OS-level system files\n- Leaking credentials or secrets to external services\n- Publishing packages or deploying to production\n- Commands that clearly exfiltrate data to unknown destinations\n\nErr on the side of approval. Respond with JSON only.",
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/permission-reviewer.py",
             "timeout": 20
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
     ],
     "PermissionRequest": [
       {
-        "matcher": "Bash|Read|Edit|Write|NotebookEdit|WebFetch|Skill",
+        "matcher": "Bash|Read|Edit|Write|NotebookEdit|WebFetch|WebSearch|Search|Skill",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
     ],
     "PermissionRequest": [
       {
-        "matcher": "Bash|Read|Edit|Write",
+        "matcher": "Bash|Read|Edit|Write|NotebookEdit|WebFetch|Skill",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
     ],
     "PermissionRequest": [
       {
-        "matcher": "Bash|Edit|Write",
+        "matcher": "Bash|Read|Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,7 @@
     ],
     "PermissionRequest": [
       {
+        "matcher": "Bash|Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,29 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 /Users/jeffrey/.claude/hooks/permission-gates.py"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "model": "sonnet",
+            "prompt": "You are a permissive permission reviewer for a developer's coding agent. The request below already passed rule-based allow/deny filters without matching \u2014 it's an edge case that needs your contextual judgment.\n\nRequest: $ARGUMENTS\n\nYour default stance is to APPROVE. Developers move fast and most operations are safe in a dev context. Only deny something if it poses a genuine, concrete risk \u2014 not a theoretical one.\n\nApprove liberally:\n- Deleting files/dirs is almost always fine (build artifacts, caches, temp files, even source files during refactoring)\n- Unfamiliar commands or scripts are fine if they look like normal dev work\n- Git operations, package management, builds, tests \u2014 just let them through\n- When in doubt, approve. The developer can always undo.\n\nOnly deny when the risk is real and irreversible:\n- Destroying the home directory, root filesystem, or OS-level system files\n- Leaking credentials or secrets to external services\n- Publishing packages or deploying to production\n- Commands that clearly exfiltrate data to unknown destinations\n\nErr on the side of approval. Respond with JSON only.",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",


### PR DESCRIPTION
Global hooks were silently overridden when project-level hooks existed. Added both hooks to project settings to ensure psql/sensitive-file gating and Sonnet-based auto-approval work correctly.

close #289