### PR TITLE
feat: add Question Decomposition for RAG pipeline

### DIFF
--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -8,6 +8,10 @@ from autorag_research.pipelines.generation.et2rag import (
 )
 from autorag_research.pipelines.generation.ircot import IRCoTGenerationPipeline, IRCoTGenerationPipelineConfig
 from autorag_research.pipelines.generation.main_rag import MAINRAGPipeline
+from autorag_research.pipelines.generation.question_decomposition import (
+    QuestionDecompositionPipeline,
+    QuestionDecompositionPipelineConfig,
+)
 from autorag_research.pipelines.generation.spd_rag import SPDRAGPipeline, SPDRAGPipelineConfig
 from autorag_research.pipelines.generation.visrag_gen import (
     DEFAULT_VISRAG_PROMPT,
@@ -27,6 +31,8 @@ __all__ = [
     "IRCoTGenerationPipelineConfig",
     "MAINRAGPipeline",
     "OrganizationStrategy",
+    "QuestionDecompositionPipeline",
+    "QuestionDecompositionPipelineConfig",
     "SPDRAGPipeline",
     "SPDRAGPipelineConfig",
     "VisRAGGenerationPipeline",

--- a/autorag_research/pipelines/generation/question_decomposition.py
+++ b/autorag_research/pipelines/generation/question_decomposition.py
@@ -1,0 +1,276 @@
+"""Question Decomposition generation pipeline for AutoRAG-Research.
+
+Implements a decomposition-first RAG strategy:
+1. Decompose the original query into sub-questions
+2. Retrieve for the original query and each sub-question
+3. Merge and deduplicate retrieved documents by doc_id using the highest score
+4. Keep the final top-k documents
+5. Generate the answer from the merged context
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker
+
+logger = logging.getLogger("AutoRAG-Research")
+
+DEFAULT_DECOMPOSITION_PROMPT = """You are decomposing a question for retrieval-augmented generation.
+
+Question: {query}
+
+Write up to {max_subquestions} short, standalone sub-questions that would help retrieve evidence.
+Return one sub-question per line and no other text.
+If decomposition is unnecessary, repeat the original question once.
+
+Sub-questions:"""
+
+DEFAULT_QA_PROMPT = """Answer the following question using the provided paragraphs.
+
+Question: {query}
+
+Paragraphs:
+{paragraphs}
+
+Provide a concise, direct answer to the question based on the information in the paragraphs.
+
+Answer:"""
+
+_SUBQUESTION_PREFIX_RE = re.compile(
+    r"^\s*(?:sub-?question\s*\d*\s*:|question\s*\d*\s*:|[-*•]|\d+[.)]|[A-Za-z][.)])\s*",
+    re.IGNORECASE,
+)
+
+
+class QuestionDecompositionPipeline(BaseGenerationPipeline):
+    """Generation pipeline that retrieves over decomposed sub-questions."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: "BaseLanguageModel",
+        retrieval_pipeline: "BaseRetrievalPipeline",
+        decomposition_prompt_template: str = DEFAULT_DECOMPOSITION_PROMPT,
+        qa_prompt_template: str = DEFAULT_QA_PROMPT,
+        max_subquestions: int = 3,
+        schema: Any | None = None,
+    ):
+        """Initialize Question Decomposition pipeline.
+
+        Args:
+            session_factory: SQLAlchemy sessionmaker for database connections.
+            name: Name for this pipeline.
+            llm: LangChain BaseLanguageModel instance for decomposition and generation.
+            retrieval_pipeline: Retrieval pipeline for fetching relevant context.
+            decomposition_prompt_template: Template for decomposition prompt.
+                Must contain {query}; may optionally contain {max_subquestions}.
+            qa_prompt_template: Template for the final QA prompt.
+                Must contain {query} and {paragraphs}.
+            max_subquestions: Maximum number of unique sub-questions to retrieve for.
+            schema: Schema namespace from create_schema(). If None, uses default schema.
+        """
+        # IMPORTANT: Store parameters BEFORE calling super().__init__
+        # because _get_pipeline_config() is called during base init
+        self._decomposition_prompt_template = decomposition_prompt_template
+        self._qa_prompt_template = qa_prompt_template
+        self.max_subquestions = max_subquestions
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return Question Decomposition pipeline configuration for storage."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+
+        return {
+            "type": "question_decomposition",
+            "decomposition_prompt_template": self._decomposition_prompt_template,
+            "qa_prompt_template": self._qa_prompt_template,
+            "max_subquestions": self.max_subquestions,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract text content from a LangChain response or raw string."""
+        return response.content if hasattr(response, "content") else str(response)
+
+    @staticmethod
+    def _normalize_question(question: str) -> str:
+        """Normalize question text for duplicate detection."""
+        return " ".join(question.lower().split())
+
+    @staticmethod
+    def _normalize_score(score: Any) -> float:
+        """Normalize retrieval score values for ranking."""
+        if isinstance(score, (int, float)):
+            return float(score)
+        return 0.0
+
+    def _build_decomposition_prompt(self, query: str) -> str:
+        """Build the decomposition prompt."""
+        return self._decomposition_prompt_template.format(
+            query=query,
+            max_subquestions=self.max_subquestions,
+        )
+
+    def _build_qa_prompt(self, query: str, paragraphs: list[str]) -> str:
+        """Build prompt for final answer generation."""
+        if paragraphs:
+            numbered_paragraphs = "\n\n".join([f"[{i + 1}] {p}" for i, p in enumerate(paragraphs)])
+        else:
+            numbered_paragraphs = "(No paragraphs available)"
+
+        return self._qa_prompt_template.format(
+            query=query,
+            paragraphs=numbered_paragraphs,
+        )
+
+    def _parse_subquestions(self, decomposition_text: str) -> list[str]:
+        """Parse sub-questions from the decomposition model output."""
+        text = decomposition_text.strip()
+        if not text:
+            return []
+
+        candidates = [line.strip() for line in text.splitlines() if line.strip()]
+
+        if len(candidates) == 1:
+            inline_numbered = re.split(r"\s+(?=(?:\d+[.)]|[-*•])\s*)", candidates[0])
+            if len(inline_numbered) > 1:
+                candidates = [item.strip() for item in inline_numbered if item.strip()]
+            elif candidates[0].count("?") > 1:
+                candidates = [item.strip() for item in re.split(r"(?<=\?)\s+", candidates[0]) if item.strip()]
+
+        subquestions: list[str] = []
+        for candidate in candidates:
+            cleaned = _SUBQUESTION_PREFIX_RE.sub("", candidate).strip()
+            cleaned = cleaned.rstrip(" ;")
+            if cleaned:
+                subquestions.append(cleaned)
+
+        return subquestions
+
+    def _deduplicate_subquestions(self, query: str, subquestions: list[str]) -> list[str]:
+        """Drop duplicate sub-questions and the original query."""
+        seen = {self._normalize_question(query)}
+        unique_subquestions: list[str] = []
+
+        for subquestion in subquestions:
+            normalized = self._normalize_question(subquestion)
+            if not normalized or normalized in seen:
+                continue
+
+            seen.add(normalized)
+            unique_subquestions.append(subquestion)
+
+            if len(unique_subquestions) >= self.max_subquestions:
+                break
+
+        return unique_subquestions
+
+    def _merge_results(self, result_sets: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+        """Merge retrieved results by doc_id, keeping the highest score."""
+        merged: dict[int | str, dict[str, Any]] = {}
+
+        for result_set in result_sets:
+            for result in result_set:
+                doc_id = result.get("doc_id")
+                if doc_id is None:
+                    continue
+
+                score = self._normalize_score(result.get("score"))
+                existing = merged.get(doc_id)
+                if existing is None or score > self._normalize_score(existing.get("score")):
+                    merged[doc_id] = {
+                        "doc_id": doc_id,
+                        "score": score,
+                    }
+
+        return sorted(
+            merged.values(),
+            key=lambda item: (-self._normalize_score(item.get("score")), str(item.get("doc_id"))),
+        )
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate an answer using question decomposition."""
+        query_text = self._service.get_query_text(query_id)
+        tracker = TokenUsageTracker()
+
+        logger.debug(f"Question Decomposition: decomposing query ID {query_id}")
+        decomposition_prompt = self._build_decomposition_prompt(query_text)
+        decomposition_response = await self._llm.ainvoke(decomposition_prompt)
+        decomposition_text = self._extract_text(decomposition_response)
+        tracker.record(decomposition_response)
+
+        subquestions = self._deduplicate_subquestions(
+            query_text,
+            self._parse_subquestions(decomposition_text),
+        )
+
+        result_sets: list[list[dict[str, Any]]] = [
+            await self._retrieval_pipeline._retrieve_by_id(query_id, top_k),
+        ]
+
+        for subquestion in subquestions:
+            result_sets.append(await self._retrieval_pipeline.retrieve(subquestion, top_k))
+
+        merged_results = self._merge_results(result_sets)
+        final_results = merged_results[:top_k]
+        chunk_ids = [result["doc_id"] for result in final_results]
+        paragraphs = self._service.get_chunk_contents(chunk_ids) if chunk_ids else []
+
+        qa_prompt = self._build_qa_prompt(query_text, paragraphs)
+        qa_response = await self._llm.ainvoke(qa_prompt)
+        answer_text = self._extract_text(qa_response)
+        tracker.record(qa_response)
+
+        return GenerationResult(
+            text=answer_text,
+            token_usage=tracker.total,
+            metadata={
+                "raw_decomposition": decomposition_text,
+                "sub_questions": subquestions,
+                "retrieval_queries": [query_text, *subquestions],
+                "retrieved_chunk_ids": chunk_ids,
+                "retrieved_scores": [result["score"] for result in final_results],
+            },
+        )
+
+
+@dataclass(kw_only=True)
+class QuestionDecompositionPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for Question Decomposition generation pipeline."""
+
+    decomposition_prompt_template: str = field(default=DEFAULT_DECOMPOSITION_PROMPT)
+    qa_prompt_template: str = field(default=DEFAULT_QA_PROMPT)
+    max_subquestions: int = 3
+
+    def get_pipeline_class(self) -> type["QuestionDecompositionPipeline"]:
+        """Return the QuestionDecompositionPipeline class."""
+        return QuestionDecompositionPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for QuestionDecompositionPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "decomposition_prompt_template": self.decomposition_prompt_template,
+            "qa_prompt_template": self.qa_prompt_template,
+            "max_subquestions": self.max_subquestions,
+        }

--- a/configs/pipelines/generation/question_decomposition.yaml
+++ b/configs/pipelines/generation/question_decomposition.yaml
@@ -1,0 +1,43 @@
+# Question Decomposition Generation Pipeline Configuration
+#
+# Decomposes a complex question into sub-questions, retrieves for the original
+# question and each sub-question, merges and deduplicates the results by doc_id,
+# then answers using the final top-k paragraphs.
+#
+# Reference: ACL 2025 SRW - Question Decomposition for RAG
+#
+# Parameters:
+#   retrieval_pipeline_name: Name of retrieval pipeline to use
+#   llm: LLM model identifier (default: gpt-4o-mini)
+#   max_subquestions: Maximum number of unique sub-questions to retrieve for
+#   top_k: Retrieved documents per query and final merged top-k budget
+#
+_target_: autorag_research.pipelines.generation.question_decomposition.QuestionDecompositionPipelineConfig
+description: "Question Decomposition for RAG"
+name: question_decomposition
+retrieval_pipeline_name: bm25
+llm: gpt-4o-mini
+max_subquestions: 3
+top_k: 5
+batch_size: 10
+decomposition_prompt_template: |
+  You are decomposing a question for retrieval-augmented generation.
+
+  Question: {query}
+
+  Write up to {max_subquestions} short, standalone sub-questions that would help retrieve evidence.
+  Return one sub-question per line and no other text.
+  If decomposition is unnecessary, repeat the original question once.
+
+  Sub-questions:
+qa_prompt_template: |
+  Answer the following question using the provided paragraphs.
+
+  Question: {query}
+
+  Paragraphs:
+  {paragraphs}
+
+  Provide a concise, direct answer to the question based on the information in the paragraphs.
+
+  Answer:

--- a/tests/autorag_research/pipelines/generation/test_question_decomposition_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_question_decomposition_pipeline.py
@@ -1,0 +1,458 @@
+"""Tests for the Question Decomposition generation pipeline.
+
+Test Categories:
+1. Unit Tests - Helper methods for parsing, prompt building, and merging
+2. Pipeline Initialization Tests - Constructor and config
+3. Core Algorithm Tests - Decomposition, retrieval merging, token aggregation
+4. Integration Tests - End-to-end with PipelineTestVerifier
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from tests.autorag_research.pipelines.pipeline_test_utils import (
+    PipelineTestConfig,
+    PipelineTestVerifier,
+    cleanup_pipeline_results_factory,
+    create_mock_llm,
+    create_mock_retrieval_pipeline,
+)
+
+
+@pytest.fixture
+def cleanup(session_factory):
+    """Cleanup fixture for pipeline results."""
+    yield from cleanup_pipeline_results_factory(session_factory)
+
+
+@pytest.fixture
+def mock_retrieval():
+    """Create a mock retrieval pipeline."""
+    return create_mock_retrieval_pipeline()
+
+
+@pytest.fixture
+def question_decomposition_pipeline(session_factory, cleanup):
+    """Create a Question Decomposition pipeline with default settings."""
+    from autorag_research.pipelines.generation.question_decomposition import (
+        QuestionDecompositionPipeline,
+    )
+
+    pipeline = QuestionDecompositionPipeline(
+        session_factory=session_factory,
+        name="test_question_decomposition_fixture",
+        llm=create_mock_llm(),
+        retrieval_pipeline=create_mock_retrieval_pipeline(),
+    )
+    cleanup.append(pipeline.pipeline_id)
+    return pipeline
+
+
+class TestParseSubQuestions:
+    """Unit tests for _parse_subquestions helper method."""
+
+    @pytest.fixture
+    def pipeline_class(self):
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        return QuestionDecompositionPipeline
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("1. What is A?\n2. What is B?", ["What is A?", "What is B?"]),
+            ("- Find the author\n- Find the date", ["Find the author", "Find the date"]),
+            ("What is A? What is B?", ["What is A?", "What is B?"]),
+            ("Single sub-question", ["Single sub-question"]),
+            ("", []),
+        ],
+        ids=["numbered", "bullet", "inline_questions", "single", "empty"],
+    )
+    def test_parse_subquestions(self, pipeline_class, text, expected):
+        """Test sub-question parsing with different output formats."""
+        result = pipeline_class._parse_subquestions(None, text)
+        assert result == expected
+
+
+class TestPromptBuilders:
+    """Unit tests for prompt building methods."""
+
+    def test_build_decomposition_prompt(self, question_decomposition_pipeline):
+        """Test decomposition prompt contains query and configured limit."""
+        prompt = question_decomposition_pipeline._build_decomposition_prompt("What is A?")
+        assert "What is A?" in prompt
+        assert str(question_decomposition_pipeline.max_subquestions) in prompt
+
+    def test_build_qa_prompt(self, question_decomposition_pipeline):
+        """Test QA prompt is built correctly."""
+        prompt = question_decomposition_pipeline._build_qa_prompt("Question?", ["Doc 1", "Doc 2"])
+        assert "Question?" in prompt
+        assert "[1]" in prompt and "[2]" in prompt
+        assert "Doc 1" in prompt and "Doc 2" in prompt
+
+
+class TestMergeResults:
+    """Unit tests for retrieval merge behavior."""
+
+    def test_merge_results_keeps_highest_score(self, question_decomposition_pipeline):
+        """Test duplicate doc_ids keep the highest observed score."""
+        merged = question_decomposition_pipeline._merge_results([
+            [{"doc_id": 1, "score": 0.4}, {"doc_id": 2, "score": 0.7}],
+            [{"doc_id": 1, "score": 0.9}, {"doc_id": 3, "score": 0.6}],
+        ])
+
+        assert merged == [
+            {"doc_id": 1, "score": 0.9},
+            {"doc_id": 2, "score": 0.7},
+            {"doc_id": 3, "score": 0.6},
+        ]
+
+
+class TestQuestionDecompositionPipelineInitialization:
+    """Tests for Question Decomposition pipeline initialization and config."""
+
+    def test_initialization_stores_config(self, session_factory, mock_retrieval, cleanup):
+        """Test pipeline stores custom parameters correctly."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_init",
+            llm=create_mock_llm(),
+            retrieval_pipeline=mock_retrieval,
+            decomposition_prompt_template="DECOMP: {query} ({max_subquestions})",
+            qa_prompt_template="QA: {query}\n{paragraphs}",
+            max_subquestions=5,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        assert pipeline.pipeline_id > 0
+        assert pipeline.max_subquestions == 5
+        assert pipeline._decomposition_prompt_template == "DECOMP: {query} ({max_subquestions})"
+        assert pipeline._qa_prompt_template == "QA: {query}\n{paragraphs}"
+
+    def test_initialization_default_values(self, session_factory, mock_retrieval, cleanup):
+        """Test pipeline uses correct default values."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_defaults",
+            llm=create_mock_llm(),
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        assert pipeline.max_subquestions == 3
+
+    def test_get_pipeline_config(self, session_factory, mock_retrieval, cleanup):
+        """Test _get_pipeline_config returns correct configuration."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_config",
+            llm=create_mock_llm(),
+            retrieval_pipeline=mock_retrieval,
+            max_subquestions=4,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        config = pipeline._get_pipeline_config()
+        assert config["type"] == "question_decomposition"
+        assert config["max_subquestions"] == 4
+        assert config["retrieval_pipeline_id"] == mock_retrieval.pipeline_id
+        assert "decomposition_prompt_template" in config
+        assert "qa_prompt_template" in config
+
+
+class TestQuestionDecompositionAlgorithm:
+    """Tests for Question Decomposition core algorithm behavior."""
+
+    @pytest.mark.asyncio
+    async def test_retrieves_original_and_subquestions(self, session_factory, cleanup):
+        """Test retrieval runs for the original query and each unique sub-question."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        captured_prompts = []
+
+        async def mock_ainvoke(prompt):
+            captured_prompts.append(prompt)
+            response = MagicMock()
+            response.content = (
+                "1. Who is Doc One about?\n2. When was Doc One written?"
+                if len(captured_prompts) == 1
+                else "Final answer."
+            )
+            response.usage_metadata = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+            return response
+
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        mock_retrieval = MagicMock()
+        mock_retrieval.pipeline_id = 1
+        mock_retrieval._retrieve_by_id = AsyncMock(
+            return_value=[{"doc_id": 1, "score": 0.7}, {"doc_id": 2, "score": 0.6}]
+        )
+        mock_retrieval.retrieve = AsyncMock(
+            side_effect=[
+                [{"doc_id": 3, "score": 0.95}],
+                [{"doc_id": 4, "score": 0.8}],
+            ]
+        )
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_retrievals",
+            llm=mock_llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(1, top_k=2)
+
+        mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 2)
+        assert mock_retrieval.retrieve.await_count == 2
+        assert result.metadata is not None
+        assert result.metadata["sub_questions"] == [
+            "Who is Doc One about?",
+            "When was Doc One written?",
+        ]
+        assert result.metadata["retrieved_chunk_ids"] == [3, 4]
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_docs_by_highest_score_and_applies_top_k(self, session_factory, cleanup):
+        """Test merged retrieval keeps max score per doc and trims to final top-k."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        call_count = [0]
+
+        async def mock_ainvoke(prompt):
+            response = MagicMock()
+            response.content = (
+                "1. Who wrote Doc One?\n2. What is the publication date?" if call_count[0] == 0 else "Final answer."
+            )
+            response.usage_metadata = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+            call_count[0] += 1
+            return response
+
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        mock_retrieval = MagicMock()
+        mock_retrieval.pipeline_id = 1
+        mock_retrieval._retrieve_by_id = AsyncMock(
+            return_value=[{"doc_id": 1, "score": 0.4}, {"doc_id": 2, "score": 0.9}]
+        )
+        mock_retrieval.retrieve = AsyncMock(
+            side_effect=[
+                [{"doc_id": 1, "score": 0.95}, {"doc_id": 3, "score": 0.5}],
+                [{"doc_id": 2, "score": 0.85}, {"doc_id": 4, "score": 0.8}],
+            ]
+        )
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_dedup",
+            llm=mock_llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(1, top_k=3)
+
+        assert result.metadata is not None
+        assert result.metadata["retrieved_chunk_ids"] == [1, 2, 4]
+        assert result.metadata["retrieved_scores"] == [0.95, 0.9, 0.8]
+
+    @pytest.mark.asyncio
+    async def test_aggregates_token_usage(self, session_factory, cleanup):
+        """Test token usage is aggregated across decomposition and answer generation."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        call_count = [0]
+
+        async def mock_ainvoke(prompt):
+            call_count[0] += 1
+            response = MagicMock()
+            response.content = "1. Sub-question?" if call_count[0] == 1 else "Final answer."
+            response.usage_metadata = {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+            return response
+
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_tokens",
+            llm=mock_llm,
+            retrieval_pipeline=create_mock_retrieval_pipeline(),
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(1, top_k=3)
+
+        assert result.token_usage is not None
+        assert result.token_usage["total_tokens"] == 300
+        assert result.token_usage["prompt_tokens"] == 200
+        assert result.token_usage["completion_tokens"] == 100
+
+    @pytest.mark.asyncio
+    async def test_custom_prompt_templates(self, session_factory, cleanup):
+        """Test custom prompt templates are used for both LLM calls."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        captured_prompts = []
+
+        async def mock_ainvoke(prompt):
+            captured_prompts.append(prompt)
+            response = MagicMock()
+            response.content = "1. Sub-question?" if len(captured_prompts) == 1 else "Final answer."
+            response.usage_metadata = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+            return response
+
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_templates",
+            llm=mock_llm,
+            retrieval_pipeline=create_mock_retrieval_pipeline(),
+            decomposition_prompt_template="CUSTOM_DECOMP: {query} ({max_subquestions})",
+            qa_prompt_template="CUSTOM_QA: {query}\n{paragraphs}",
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        await pipeline._generate(2, top_k=2)
+
+        assert "CUSTOM_DECOMP:" in captured_prompts[0]
+        assert "CUSTOM_QA:" in captured_prompts[1]
+
+    @pytest.mark.asyncio
+    async def test_filters_duplicate_subquestions_and_original_query(self, session_factory, cleanup):
+        """Test sub-question list excludes duplicates and the original query."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        mock_llm = MagicMock()
+        responses = [
+            "What is Doc One about?\nWhat is Doc One about?\nWho wrote Doc One?\nWho wrote Doc One?",
+            "Final answer.",
+        ]
+        call_count = [0]
+
+        async def mock_ainvoke(prompt):
+            response = MagicMock()
+            response.content = responses[min(call_count[0], len(responses) - 1)]
+            response.usage_metadata = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+            call_count[0] += 1
+            return response
+
+        mock_llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        mock_retrieval = create_mock_retrieval_pipeline()
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_dedup_subquestions",
+            llm=mock_llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(1, top_k=3)
+
+        assert result.metadata is not None
+        assert result.metadata["sub_questions"] == ["Who wrote Doc One?"]
+        assert mock_retrieval.retrieve.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_retrieval(self, session_factory, cleanup):
+        """Test Question Decomposition handles empty retrieval results gracefully."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        mock_llm = MagicMock()
+        call_count = [0]
+
+        async def mock_ainvoke(prompt):
+            response = MagicMock()
+            response.content = "1. Missing evidence?" if call_count[0] == 0 else "Final answer."
+            response.usage_metadata = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+            call_count[0] += 1
+            return response
+
+        mock_llm.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_empty",
+            llm=mock_llm,
+            retrieval_pipeline=create_mock_retrieval_pipeline(default_results=[]),
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(1, top_k=5)
+
+        assert result.text is not None
+        assert result.metadata is not None
+        assert result.metadata["retrieved_chunk_ids"] == []
+
+
+class TestQuestionDecompositionPipelineIntegration:
+    """Integration tests for the Question Decomposition pipeline."""
+
+    def test_full_flow(self, session_factory, cleanup):
+        """Test end-to-end Question Decomposition flow with PipelineTestVerifier."""
+        from autorag_research.pipelines.generation.question_decomposition import (
+            QuestionDecompositionPipeline,
+        )
+
+        responses = []
+        for _ in range(10):
+            responses.extend([
+                "1. What evidence is relevant?\n2. What supporting detail is needed?",
+                "Final answer.",
+            ])
+
+        pipeline = QuestionDecompositionPipeline(
+            session_factory=session_factory,
+            name="test_question_decomposition_full_flow",
+            llm=FakeListLLM(responses=responses),
+            retrieval_pipeline=create_mock_retrieval_pipeline(),
+            max_subquestions=2,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = pipeline.run(top_k=3, batch_size=10)
+
+        config = PipelineTestConfig(
+            pipeline_type="generation",
+            expected_total_queries=5,
+            check_token_usage=False,
+            check_execution_time=True,
+            check_persistence=True,
+        )
+        verifier = PipelineTestVerifier(result, pipeline.pipeline_id, session_factory, config)
+        verifier.verify_all()


### PR DESCRIPTION
## Summary
- Implements question decomposition pipeline from Ammann et al. (ACL 2025 SRW)
- Decomposes complex queries into sub-questions, retrieves for each, merges/deduplicates, generates answer

Closes #189