### PR TITLE
Feature/#303

### DIFF
--- a/autorag_research/orm/service/retrieval_pipeline.py
+++ b/autorag_research/orm/service/retrieval_pipeline.py
@@ -70,12 +70,14 @@ class RetrievalPipelineService(BasePipelineService):
             return {
                 "Pipeline": self._schema.Pipeline,
                 "ChunkRetrievedResult": self._schema.ChunkRetrievedResult,
+                "ImageChunkRetrievedResult": self._schema.ImageChunkRetrievedResult,
             }
-        from autorag_research.orm.schema import ChunkRetrievedResult, Pipeline
+        from autorag_research.orm.schema import ChunkRetrievedResult, ImageChunkRetrievedResult, Pipeline
 
         return {
             "Pipeline": Pipeline,
             "ChunkRetrievedResult": ChunkRetrievedResult,
+            "ImageChunkRetrievedResult": ImageChunkRetrievedResult,
         }
 
     def _create_uow(self) -> RetrievalUnitOfWork:
@@ -88,6 +90,7 @@ class RetrievalPipelineService(BasePipelineService):
         results: list[list[dict] | None],
         pipeline_id: int | str,
         failed_queries: list[int | str],
+        result_id_key: str,
     ) -> list[dict]:
         """Collect valid retrieval results and track failed queries.
 
@@ -109,15 +112,17 @@ class RetrievalPipelineService(BasePipelineService):
                 batch_results.append({
                     "query_id": query_id,
                     "pipeline_id": pipeline_id,
-                    "chunk_id": result["doc_id"],
+                    result_id_key: result["doc_id"],
                     "rel_score": result["score"],
                 })
         return batch_results
 
-    def run_pipeline(  # noqa: C901
+    def _run_pipeline(  # noqa: C901
         self,
         retrieval_func: RetrievalFunc,
         pipeline_id: int | str,
+        result_repo_name: Literal["chunk_results", "image_chunk_results"],
+        result_id_key: Literal["chunk_id", "image_chunk_id"],
         top_k: int = 10,
         batch_size: int = 128,
         max_concurrency: int = 16,
@@ -196,7 +201,8 @@ class RetrievalPipelineService(BasePipelineService):
                 query_ids = [q.id for q in queries]
 
                 # Skip queries that already have results (resume support)
-                existing_results = uow.chunk_results.get_by_query_and_pipeline(query_ids, pipeline_id)
+                result_repo = getattr(uow, result_repo_name)
+                existing_results = result_repo.get_by_query_and_pipeline(query_ids, pipeline_id)
                 completed_ids = {r.query_id for r in existing_results}
                 query_ids = [qid for qid in query_ids if qid not in completed_ids]
 
@@ -206,10 +212,16 @@ class RetrievalPipelineService(BasePipelineService):
 
                 results = asyncio.run(process_batch(query_ids))
 
-                batch_results = self._collect_retrieval_results(query_ids, results, pipeline_id, failed_queries)
+                batch_results = self._collect_retrieval_results(
+                    query_ids,
+                    results,
+                    pipeline_id,
+                    failed_queries,
+                    result_id_key,
+                )
 
                 if batch_results:
-                    uow.chunk_results.bulk_insert(batch_results)
+                    result_repo.bulk_insert(batch_results)
                     total_results += len(batch_results)
 
                 total_queries += len([r for r in results if r is not None])
@@ -227,6 +239,56 @@ class RetrievalPipelineService(BasePipelineService):
             "total_results": total_results,
             "failed_queries": failed_queries,
         }
+
+    def run_pipeline(
+        self,
+        retrieval_func: RetrievalFunc,
+        pipeline_id: int | str,
+        top_k: int = 10,
+        batch_size: int = 128,
+        max_concurrency: int = 16,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        query_limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Run retrieval pipeline and persist text chunk retrieval results."""
+        return self._run_pipeline(
+            retrieval_func=retrieval_func,
+            pipeline_id=pipeline_id,
+            result_repo_name="chunk_results",
+            result_id_key="chunk_id",
+            top_k=top_k,
+            batch_size=batch_size,
+            max_concurrency=max_concurrency,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+            query_limit=query_limit,
+        )
+
+    def run_image_pipeline(
+        self,
+        retrieval_func: RetrievalFunc,
+        pipeline_id: int | str,
+        top_k: int = 10,
+        batch_size: int = 128,
+        max_concurrency: int = 16,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        query_limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Run retrieval pipeline and persist image chunk retrieval results."""
+        return self._run_pipeline(
+            retrieval_func=retrieval_func,
+            pipeline_id=pipeline_id,
+            result_repo_name="image_chunk_results",
+            result_id_key="image_chunk_id",
+            top_k=top_k,
+            batch_size=batch_size,
+            max_concurrency=max_concurrency,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+            query_limit=query_limit,
+        )
 
     def delete_pipeline_results(self, pipeline_id: int | str) -> int:
         """Delete all retrieval results for a specific pipeline.

--- a/autorag_research/orm/service/retrieval_pipeline.py
+++ b/autorag_research/orm/service/retrieval_pipeline.py
@@ -301,6 +301,7 @@ class RetrievalPipelineService(BasePipelineService):
         """
         with self._create_uow() as uow:
             deleted_count = uow.chunk_results.delete_by_pipeline(pipeline_id)
+            deleted_count += uow.image_chunk_results.delete_by_pipeline(pipeline_id)
             uow.commit()
             return deleted_count
 

--- a/autorag_research/orm/uow/retrieval_uow.py
+++ b/autorag_research/orm/uow/retrieval_uow.py
@@ -4,7 +4,7 @@ Provides atomic transaction management for retrieval operations including:
 - Query fetching
 - Chunk/ImageChunk retrieval for content
 - Pipeline configuration
-- Result storage (ChunkRetrievedResult)
+- Result storage (ChunkRetrievedResult, ImageChunkRetrievedResult)
 """
 
 from typing import Any
@@ -14,6 +14,9 @@ from sqlalchemy.orm import sessionmaker
 from autorag_research.orm.repository.chunk import ChunkRepository
 from autorag_research.orm.repository.chunk_retrieved_result import ChunkRetrievedResultRepository
 from autorag_research.orm.repository.image_chunk import ImageChunkRepository
+from autorag_research.orm.repository.image_chunk_retrieved_result import (
+    ImageChunkRetrievedResultRepository,
+)
 from autorag_research.orm.repository.metric import MetricRepository
 from autorag_research.orm.repository.pipeline import PipelineRepository
 from autorag_research.orm.repository.query import QueryRepository
@@ -29,8 +32,7 @@ class RetrievalUnitOfWork(BaseUnitOfWork):
     - Pipeline: For configuration and tracking
     - Metric: For tracking evaluation metrics
     - ChunkRetrievedResult: For storing text retrieval results
-
-    Note: ImageChunkRetrievedResult can be added later for multi-modal retrieval.
+    - ImageChunkRetrievedResult: For storing image retrieval results
     """
 
     def __init__(self, session_factory: sessionmaker, schema: Any | None = None):
@@ -49,6 +51,7 @@ class RetrievalUnitOfWork(BaseUnitOfWork):
         self._pipeline_repo: PipelineRepository | None = None
         self._metric_repo: MetricRepository | None = None
         self._chunk_result_repo: ChunkRetrievedResultRepository | None = None
+        self._image_chunk_result_repo: ImageChunkRetrievedResultRepository | None = None
 
     def _get_schema_classes(self) -> dict[str, type]:
         """Get all model classes from schema.
@@ -64,12 +67,14 @@ class RetrievalUnitOfWork(BaseUnitOfWork):
                 "Pipeline": self._schema.Pipeline,
                 "Metric": self._schema.Metric,
                 "ChunkRetrievedResult": self._schema.ChunkRetrievedResult,
+                "ImageChunkRetrievedResult": self._schema.ImageChunkRetrievedResult,
             }
 
         from autorag_research.orm.schema import (
             Chunk,
             ChunkRetrievedResult,
             ImageChunk,
+            ImageChunkRetrievedResult,
             Metric,
             Pipeline,
             Query,
@@ -82,6 +87,7 @@ class RetrievalUnitOfWork(BaseUnitOfWork):
             "Pipeline": Pipeline,
             "Metric": Metric,
             "ChunkRetrievedResult": ChunkRetrievedResult,
+            "ImageChunkRetrievedResult": ImageChunkRetrievedResult,
         }
 
     def _reset_repositories(self) -> None:
@@ -92,6 +98,7 @@ class RetrievalUnitOfWork(BaseUnitOfWork):
         self._pipeline_repo = None
         self._metric_repo = None
         self._chunk_result_repo = None
+        self._image_chunk_result_repo = None
 
     @property
     def queries(self) -> QueryRepository:
@@ -187,4 +194,20 @@ class RetrievalUnitOfWork(BaseUnitOfWork):
             "_chunk_result_repo",
             ChunkRetrievedResultRepository,
             lambda: self._get_schema_classes()["ChunkRetrievedResult"],
+        )
+
+    @property
+    def image_chunk_results(self) -> ImageChunkRetrievedResultRepository:
+        """Get the ImageChunkRetrievedResult repository.
+
+        Returns:
+            ImageChunkRetrievedResultRepository instance.
+
+        Raises:
+            SessionNotSetError: If session is not initialized.
+        """
+        return self._get_repository(
+            "_image_chunk_result_repo",
+            ImageChunkRetrievedResultRepository,
+            lambda: self._get_schema_classes()["ImageChunkRetrievedResult"],
         )

--- a/autorag_research/pipelines/retrieval/__init__.py
+++ b/autorag_research/pipelines/retrieval/__init__.py
@@ -1,5 +1,9 @@
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
 from autorag_research.pipelines.retrieval.bm25 import BM25PipelineConfig, BM25RetrievalPipeline
+from autorag_research.pipelines.retrieval.heaven import (
+    HEAVENPipelineConfig,
+    HEAVENRetrievalPipeline,
+)
 from autorag_research.pipelines.retrieval.hybrid import (
     HybridCCRetrievalPipeline,
     HybridCCRetrievalPipelineConfig,
@@ -19,6 +23,8 @@ __all__ = [
     "BM25PipelineConfig",
     "BM25RetrievalPipeline",
     "BaseRetrievalPipeline",
+    "HEAVENPipelineConfig",
+    "HEAVENRetrievalPipeline",
     "HyDEPipelineConfig",
     "HyDERetrievalPipeline",
     "HybridCCRetrievalPipeline",

--- a/autorag_research/pipelines/retrieval/heaven.py
+++ b/autorag_research/pipelines/retrieval/heaven.py
@@ -1,0 +1,355 @@
+"""HEAVEN retrieval pipeline for visually rich retrieval workloads.
+
+This staged AutoRAG adaptation keeps the paper's two-step structure while
+mapping it onto the repository's existing multimodal primitives:
+
+1. Stage 1: single-vector candidate generation over ImageChunk embeddings
+2. Stage 2: multi-vector reranking over the stage-1 candidate set
+   with a linguistically guided query-vector budget
+
+The paper's VS-Page preprocessing is intentionally treated as an offline
+indexing concern. In this repository, `ImageChunk` is the retrieval unit.
+"""
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import nltk
+from langchain_core.embeddings import Embeddings
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseRetrievalPipelineConfig
+from autorag_research.embeddings.base import MultiVectorBaseEmbedding
+from autorag_research.exceptions import EmbeddingError
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+
+_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9']+")
+
+
+def _estimate_key_vector_count(query_text: str, total_query_vectors: int, default_keep_ratio: float) -> int:
+    """Estimate how many query vectors to keep for key-token scoring.
+
+    The paper filters query tokens by linguistic importance. AutoRAG does not
+    persist token-to-vector alignments, so this approximation derives a vector
+    budget from noun density in the raw query text.
+    """
+    if total_query_vectors <= 0:
+        return 0
+
+    tokens = _TOKEN_PATTERN.findall(query_text.lower())
+    ratio = default_keep_ratio
+    if tokens:
+        try:
+            tagged_tokens = nltk.pos_tag(tokens)
+        except LookupError:
+            nltk.download("averaged_perceptron_tagger_eng", quiet=True)
+            tagged_tokens = nltk.pos_tag(tokens)
+        noun_count = sum(1 for _, tag in tagged_tokens if tag.startswith("NN"))
+        if noun_count > 0:
+            ratio = noun_count / len(tokens)
+
+    keep_count = math.ceil(total_query_vectors * ratio)
+    return max(1, min(total_query_vectors, keep_count))
+
+
+def _split_query_vectors(
+    query_vectors: list[list[float]],
+    key_vector_count: int,
+) -> tuple[list[list[float]], list[list[float]]]:
+    """Split query vectors into key and non-key groups."""
+    key_vector_count = max(0, min(len(query_vectors), key_vector_count))
+    return query_vectors[:key_vector_count], query_vectors[key_vector_count:]
+
+
+def _refine_candidate_ids(
+    stage1_results: list[dict[str, Any]],
+    key_scores: dict[int | str, float],
+    refine_count: int,
+) -> list[int | str]:
+    """Select the candidate IDs that advance to the non-key reranking stage."""
+    if refine_count <= 0:
+        return []
+
+    stage1_order = {result["doc_id"]: index for index, result in enumerate(stage1_results)}
+    ranked = sorted(
+        key_scores.items(),
+        key=lambda item: (-item[1], stage1_order.get(item[0], math.inf)),
+    )
+    return [doc_id for doc_id, _ in ranked[:refine_count]]
+
+
+def _combine_heaven_scores(
+    stage1_results: list[dict[str, Any]],
+    key_scores: dict[int | str, float],
+    non_key_scores: dict[int | str, float],
+    refine_count: int,
+    stage1_weight: float,
+    top_k: int,
+) -> list[dict[str, Any]]:
+    """Combine stage-1, key-token, and non-key-token scores."""
+    refined_ids = set(_refine_candidate_ids(stage1_results, key_scores, refine_count))
+    combined_results: list[dict[str, Any]] = []
+
+    for result in stage1_results:
+        doc_id = result["doc_id"]
+        stage1_score = float(result["score"])
+        key_score = key_scores.get(doc_id, 0.0)
+        non_key_score = non_key_scores.get(doc_id, 0.0) if doc_id in refined_ids else 0.0
+        final_score = stage1_weight * stage1_score + (1 - stage1_weight) * (key_score + non_key_score)
+        combined_results.append({"doc_id": doc_id, "score": final_score})
+
+    combined_results.sort(key=lambda item: item["score"], reverse=True)
+    return combined_results[:top_k]
+
+
+@dataclass(kw_only=True)
+class HEAVENPipelineConfig(BaseRetrievalPipelineConfig):
+    """Configuration for the HEAVEN retrieval pipeline."""
+
+    stage1_candidate_count: int = 200
+    stage2_refine_ratio: float = 0.25
+    stage1_weight: float = 0.3
+    default_key_token_ratio: float = 0.5
+    single_vector_embedding_model: Embeddings | str | None = field(default=None)
+    multi_vector_embedding_model: MultiVectorBaseEmbedding | str | None = field(default=None)
+
+    def get_pipeline_class(self) -> type["HEAVENRetrievalPipeline"]:
+        """Return the HEAVENRetrievalPipeline class."""
+        return HEAVENRetrievalPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for HEAVENRetrievalPipeline constructor."""
+        return {
+            "stage1_candidate_count": self.stage1_candidate_count,
+            "stage2_refine_ratio": self.stage2_refine_ratio,
+            "stage1_weight": self.stage1_weight,
+            "default_key_token_ratio": self.default_key_token_ratio,
+            "single_vector_embedding_model": self.single_vector_embedding_model,
+            "multi_vector_embedding_model": self.multi_vector_embedding_model,
+        }
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Load embedding configs passed by name."""
+        if name in {"single_vector_embedding_model", "multi_vector_embedding_model"} and isinstance(value, str):
+            from autorag_research.injection import load_embedding_model
+
+            value = load_embedding_model(value)
+        super().__setattr__(name, value)
+
+
+class HEAVENRetrievalPipeline(BaseRetrievalPipeline):
+    """Two-stage HEAVEN retrieval pipeline over ImageChunk records."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        stage1_candidate_count: int = 200,
+        stage2_refine_ratio: float = 0.25,
+        stage1_weight: float = 0.3,
+        default_key_token_ratio: float = 0.5,
+        single_vector_embedding_model: Embeddings | None = None,
+        multi_vector_embedding_model: MultiVectorBaseEmbedding | None = None,
+        schema: Any | None = None,
+    ):
+        if stage1_candidate_count <= 0:
+            msg = "stage1_candidate_count must be positive"
+            raise ValueError(msg)
+        if not 0 < stage2_refine_ratio <= 1:
+            msg = "stage2_refine_ratio must be in (0, 1]"
+            raise ValueError(msg)
+        if not 0 <= stage1_weight <= 1:
+            msg = "stage1_weight must be in [0, 1]"
+            raise ValueError(msg)
+        if not 0 < default_key_token_ratio <= 1:
+            msg = "default_key_token_ratio must be in (0, 1]"
+            raise ValueError(msg)
+
+        self.stage1_candidate_count = stage1_candidate_count
+        self.stage2_refine_ratio = stage2_refine_ratio
+        self.stage1_weight = stage1_weight
+        self.default_key_token_ratio = default_key_token_ratio
+        self._single_vector_embedding_model = single_vector_embedding_model
+        self._multi_vector_embedding_model = multi_vector_embedding_model
+
+        super().__init__(session_factory, name, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return HEAVEN pipeline configuration."""
+        return {
+            "type": "heaven",
+            "retrieval_unit": "image_chunk",
+            "stage1_candidate_count": self.stage1_candidate_count,
+            "stage2_refine_ratio": self.stage2_refine_ratio,
+            "stage1_weight": self.stage1_weight,
+            "default_key_token_ratio": self.default_key_token_ratio,
+        }
+
+    def _fetch_stored_query(self, query_id: int | str) -> tuple[str, list[float], list[list[float]]]:
+        """Fetch stored query text and embeddings from the database."""
+        with self._service._create_uow() as uow:
+            query = uow.queries.get_by_id(query_id)
+            if query is None:
+                raise ValueError(f"Query {query_id} not found")  # noqa: TRY003
+            if query.embedding is None:
+                raise ValueError(f"Query {query_id} has no single-vector embedding")  # noqa: TRY003
+            if query.embeddings is None:
+                raise ValueError(f"Query {query_id} has no multi-vector embeddings")  # noqa: TRY003
+            return (
+                query.contents,
+                list(query.embedding),
+                [list(vector) for vector in query.embeddings],
+            )
+
+    def _run_stage1_search_from_embedding(
+        self,
+        query_embedding: list[float],
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Run stage-1 single-vector search over ImageChunk embeddings."""
+        with self._service._create_uow() as uow:
+            results = uow.image_chunks.vector_search_with_scores(query_vector=query_embedding, limit=limit)
+            return [
+                {
+                    "doc_id": image_chunk.id,
+                    "score": 1 - distance,
+                    "content": image_chunk.contents,
+                }
+                for image_chunk, distance in results
+            ]
+
+    def _fetch_candidate_multi_embeddings(
+        self,
+        candidate_ids: list[int | str],
+    ) -> dict[int | str, list[list[float]]]:
+        """Fetch multi-vector embeddings for the candidate image chunks."""
+        if not candidate_ids:
+            return {}
+
+        with self._service._create_uow() as uow:
+            image_chunks = uow.image_chunks.get_by_ids(candidate_ids)
+
+        image_chunk_map = {image_chunk.id: image_chunk for image_chunk in image_chunks}
+        candidate_embeddings: dict[int | str, list[list[float]]] = {}
+        for candidate_id in candidate_ids:
+            image_chunk = image_chunk_map.get(candidate_id)
+            if image_chunk is None or image_chunk.embeddings is None:
+                continue
+            candidate_embeddings[candidate_id] = [list(vector) for vector in image_chunk.embeddings]
+        return candidate_embeddings
+
+    @staticmethod
+    def _score_candidates(
+        query_vectors: list[list[float]],
+        candidate_embeddings: dict[int | str, list[list[float]]],
+    ) -> dict[int | str, float]:
+        """Score candidates with MaxSim-style late interaction."""
+        if not query_vectors:
+            return dict.fromkeys(candidate_embeddings, 0.0)
+
+        scores: dict[int | str, float] = {}
+        for candidate_id, doc_vectors in candidate_embeddings.items():
+            if not doc_vectors:
+                scores[candidate_id] = 0.0
+                continue
+
+            total_score = 0.0
+            for query_vector in query_vectors:
+                total_score += max(
+                    sum(query_dim * doc_dim for query_dim, doc_dim in zip(query_vector, doc_vector, strict=True))
+                    for doc_vector in doc_vectors
+                )
+            scores[candidate_id] = total_score / len(query_vectors)
+        return scores
+
+    def _run_heaven_search(
+        self,
+        query_text: str,
+        single_vector_query: list[float],
+        multi_vector_query: list[list[float]],
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        """Execute the full two-stage HEAVEN retrieval flow."""
+        candidate_limit = max(top_k, self.stage1_candidate_count)
+        stage1_results = self._run_stage1_search_from_embedding(single_vector_query, candidate_limit)
+        if not stage1_results:
+            return []
+
+        candidate_ids = [result["doc_id"] for result in stage1_results]
+        candidate_embeddings = self._fetch_candidate_multi_embeddings(candidate_ids)
+        if not candidate_embeddings or not multi_vector_query:
+            return stage1_results[:top_k]
+
+        key_vector_count = _estimate_key_vector_count(
+            query_text=query_text,
+            total_query_vectors=len(multi_vector_query),
+            default_keep_ratio=self.default_key_token_ratio,
+        )
+        key_vectors, non_key_vectors = _split_query_vectors(multi_vector_query, key_vector_count)
+        key_scores = self._score_candidates(key_vectors, candidate_embeddings)
+
+        refine_count = min(
+            len(candidate_ids),
+            max(top_k, math.ceil(len(candidate_ids) * self.stage2_refine_ratio)),
+        )
+        refined_ids = _refine_candidate_ids(stage1_results, key_scores, refine_count)
+        refined_embeddings = {
+            candidate_id: candidate_embeddings[candidate_id]
+            for candidate_id in refined_ids
+            if candidate_id in candidate_embeddings
+        }
+        non_key_scores = self._score_candidates(non_key_vectors, refined_embeddings) if non_key_vectors else {}
+
+        return _combine_heaven_scores(
+            stage1_results=stage1_results,
+            key_scores=key_scores,
+            non_key_scores=non_key_scores,
+            refine_count=refine_count,
+            stage1_weight=self.stage1_weight,
+            top_k=top_k,
+        )
+
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        """Retrieve image chunks for a stored query."""
+        query_text, single_vector_query, multi_vector_query = self._fetch_stored_query(query_id)
+        return self._run_heaven_search(query_text, single_vector_query, multi_vector_query, top_k)
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        """Retrieve image chunks for an ad-hoc query."""
+        if self._single_vector_embedding_model is None or self._multi_vector_embedding_model is None:
+            raise EmbeddingError
+
+        single_vector_query = await self._single_vector_embedding_model.aembed_query(query_text)
+        multi_vector_query = await self._multi_vector_embedding_model.aembed_query(query_text)
+        return self._run_heaven_search(query_text, single_vector_query, multi_vector_query, top_k)
+
+    def run(
+        self,
+        top_k: int = 10,
+        batch_size: int = 128,
+        max_concurrency: int = 16,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        query_limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Run HEAVEN over stored queries and persist image retrieval results."""
+        return self._service.run_image_pipeline(
+            retrieval_func=self._retrieve_by_id,
+            pipeline_id=self.pipeline_id,
+            top_k=top_k,
+            batch_size=batch_size,
+            max_concurrency=max_concurrency,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+            query_limit=query_limit,
+        )
+
+
+__all__ = [
+    "HEAVENPipelineConfig",
+    "HEAVENRetrievalPipeline",
+    "_combine_heaven_scores",
+    "_estimate_key_vector_count",
+]

--- a/configs/pipelines/retrieval/heaven.yaml
+++ b/configs/pipelines/retrieval/heaven.yaml
@@ -1,0 +1,29 @@
+# HEAVEN Retrieval Pipeline Configuration
+#
+# Retrieval-only adaptation of the HEAVEN paper for AutoRAG's multimodal stack.
+# Uses ImageChunk as the retrieval unit:
+#   1. Stage 1 single-vector candidate generation
+#   2. Stage 2 multi-vector reranking with query-token filtering
+#
+# Parameters:
+#   stage1_candidate_count: Number of image chunks to keep from stage 1
+#   stage2_refine_ratio: Fraction of stage-1 candidates to send to the non-key rerank pass
+#   stage1_weight: Weight for the stage-1 score in final fusion
+#   default_key_token_ratio: Fallback key-token budget when POS tagging finds no nouns
+#   single_vector_embedding_model: Optional embedding config for ad-hoc retrieve()
+#   multi_vector_embedding_model: Optional multi-vector embedding config for ad-hoc retrieve()
+#
+_target_: autorag_research.pipelines.retrieval.heaven.HEAVENPipelineConfig
+description: "Two-stage HEAVEN image retrieval over ImageChunk candidates"
+name: heaven
+stage1_candidate_count: 200
+stage2_refine_ratio: 0.25
+stage1_weight: 0.3
+default_key_token_ratio: 0.5
+single_vector_embedding_model: null
+multi_vector_embedding_model: null
+top_k: 10
+batch_size: 128
+max_concurrency: 16
+max_retries: 3
+retry_delay: 1.0

--- a/tests/autorag_research/orm/service/test_retrieval_pipeline.py
+++ b/tests/autorag_research/orm/service/test_retrieval_pipeline.py
@@ -82,6 +82,36 @@ class TestRetrievalPipelineService:
             results_after = uow.chunk_results.get_by_pipeline(pipeline_id)
             assert len(results_after) == 0
 
+    def test_delete_pipeline_results_deletes_image_chunk_results(self, service, mock_retrieval_func, session_factory):
+        # Count actual queries in database
+        with session_factory() as session:
+            query_repo = QueryRepository(session)
+            query_count = query_repo.count()
+
+        pipeline_id, _ = service.get_or_create_pipeline(
+            name="test_delete_image_pipeline_results",
+            config={"type": "heaven", "retrieval_unit": "image_chunk"},
+        )
+
+        service.run_image_pipeline(
+            retrieval_func=mock_retrieval_func,
+            pipeline_id=pipeline_id,
+            top_k=2,
+        )
+
+        with service._create_uow() as uow:
+            results_before = uow.image_chunk_results.get_by_pipeline(pipeline_id)
+            assert len(results_before) > 0
+
+        deleted_count = service.delete_pipeline_results(pipeline_id)
+
+        expected_results = query_count * 2
+        assert deleted_count == expected_results
+
+        with service._create_uow() as uow:
+            results_after = uow.image_chunk_results.get_by_pipeline(pipeline_id)
+            assert len(results_after) == 0
+
 
 class TestVectorSearchByEmbedding:
     """Tests for RetrievalPipelineService.vector_search_by_embedding method."""

--- a/tests/autorag_research/pipelines/retrieval/test_heaven_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_heaven_pipeline.py
@@ -1,0 +1,189 @@
+"""Tests for the HEAVEN retrieval pipeline."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.orm.repository.image_chunk_retrieved_result import ImageChunkRetrievedResultRepository
+from autorag_research.orm.repository.query import QueryRepository
+from autorag_research.pipelines.retrieval.heaven import (
+    HEAVENPipelineConfig,
+    HEAVENRetrievalPipeline,
+    _combine_heaven_scores,
+    _estimate_key_vector_count,
+)
+
+
+class TestHEAVENHelpers:
+    """Unit tests for HEAVEN helper functions."""
+
+    def test_estimate_key_vector_count_uses_nouns_and_preserves_one(self):
+        """Noun-heavy queries should keep a proportional vector budget with a floor of one."""
+        with patch(
+            "autorag_research.pipelines.retrieval.heaven.nltk.pos_tag",
+            side_effect=[
+                [("invoice", "NN"), ("status", "NN"), ("for", "IN"), ("order", "NN")],
+                [("quickly", "RB"), ("please", "UH")],
+            ],
+        ):
+            assert (
+                _estimate_key_vector_count("invoice status for order", total_query_vectors=8, default_keep_ratio=0.25)
+                == 6
+            )
+            assert _estimate_key_vector_count("quickly please", total_query_vectors=3, default_keep_ratio=0.2) == 1
+
+    def test_combine_heaven_scores_applies_stage2_refinement(self):
+        """Only refined candidates should receive the non-key stage contribution."""
+        stage1_results = [
+            {"doc_id": 1, "score": 0.9},
+            {"doc_id": 2, "score": 0.8},
+            {"doc_id": 3, "score": 0.7},
+        ]
+        key_scores = {1: 0.95, 2: 0.7, 3: 0.2}
+        non_key_scores = {1: 0.05, 2: 0.9}
+
+        combined = _combine_heaven_scores(
+            stage1_results=stage1_results,
+            key_scores=key_scores,
+            non_key_scores=non_key_scores,
+            refine_count=2,
+            stage1_weight=0.25,
+            top_k=3,
+        )
+
+        assert [result["doc_id"] for result in combined] == [2, 1, 3]
+        assert combined[2]["score"] < combined[1]["score"]
+
+
+class TestHEAVENPipeline:
+    """Tests for HEAVENRetrievalPipeline."""
+
+    @pytest.fixture
+    def cleanup_pipeline_results(self, session_factory: sessionmaker[Session]):
+        """Cleanup fixture that deletes image chunk pipeline results after test."""
+        created_pipeline_ids: list[int] = []
+
+        yield created_pipeline_ids
+
+        session = session_factory()
+        try:
+            result_repo = ImageChunkRetrievedResultRepository(session)
+            for pipeline_id in created_pipeline_ids:
+                result_repo.delete_by_pipeline(pipeline_id)
+            session.commit()
+        finally:
+            session.close()
+
+    def test_pipeline_config_getters(self):
+        """Config should resolve to the HEAVEN pipeline and preserve stage parameters."""
+        config = HEAVENPipelineConfig(
+            name="heaven_cfg",
+            stage1_candidate_count=64,
+            stage2_refine_ratio=0.5,
+            stage1_weight=0.4,
+            default_key_token_ratio=0.3,
+        )
+
+        assert config.get_pipeline_class() is HEAVENRetrievalPipeline
+        assert config.get_pipeline_kwargs() == {
+            "stage1_candidate_count": 64,
+            "stage2_refine_ratio": 0.5,
+            "stage1_weight": 0.4,
+            "default_key_token_ratio": 0.3,
+            "single_vector_embedding_model": None,
+            "multi_vector_embedding_model": None,
+        }
+
+    def test_retrieve_by_id_uses_stage1_candidates_then_refines_with_stage2(
+        self,
+        session_factory: sessionmaker[Session],
+        cleanup_pipeline_results: list[int],
+    ):
+        """HEAVEN should rerank stage1 image candidates with stage2 scores."""
+        pipeline = HEAVENRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_heaven_retrieve",
+            stage1_candidate_count=3,
+            stage2_refine_ratio=0.5,
+            stage1_weight=0.25,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        with (
+            patch.object(
+                pipeline,
+                "_fetch_stored_query",
+                return_value=(
+                    "invoice status for order",
+                    [1.0, 0.0],
+                    [[1.0, 0.0], [0.9, 0.1], [0.2, 0.8], [0.1, 0.9]],
+                ),
+            ),
+            patch.object(
+                pipeline,
+                "_run_stage1_search_from_embedding",
+                return_value=[
+                    {"doc_id": 1, "score": 0.9},
+                    {"doc_id": 2, "score": 0.8},
+                    {"doc_id": 3, "score": 0.7},
+                ],
+            ),
+            patch.object(
+                pipeline,
+                "_fetch_candidate_multi_embeddings",
+                return_value={1: [[1.0, 0.0]], 2: [[0.8, 0.2]], 3: [[0.1, 0.9]]},
+            ),
+            patch("autorag_research.pipelines.retrieval.heaven._estimate_key_vector_count", return_value=2),
+            patch.object(
+                pipeline,
+                "_score_candidates",
+                side_effect=[
+                    {1: 1.0, 2: 0.7, 3: 0.2},
+                    {1: 0.2, 2: 0.9},
+                ],
+            ) as mock_score,
+        ):
+            results = asyncio.run(pipeline._retrieve_by_id(query_id=1, top_k=2))
+
+        assert [result["doc_id"] for result in results] == [2, 1]
+        assert list(mock_score.call_args_list[1].args[1].keys()) == [1, 2]
+
+    def test_run_persists_image_chunk_results(
+        self,
+        session_factory: sessionmaker[Session],
+        cleanup_pipeline_results: list[int],
+    ):
+        """Batch runs should persist ImageChunkRetrievedResult rows instead of text chunk results."""
+        session = session_factory()
+        try:
+            query_count = QueryRepository(session).count()
+        finally:
+            session.close()
+
+        pipeline = HEAVENRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_heaven_run",
+            stage1_candidate_count=4,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        mock_results = [
+            {"doc_id": 1, "score": 0.95},
+            {"doc_id": 2, "score": 0.75},
+        ]
+
+        with patch.object(pipeline, "_retrieve_by_id", new=AsyncMock(return_value=mock_results)):
+            result = pipeline.run(top_k=2)
+
+        session = session_factory()
+        try:
+            stored = ImageChunkRetrievedResultRepository(session).get_by_pipeline(pipeline.pipeline_id)
+        finally:
+            session.close()
+
+        assert result["pipeline_id"] == pipeline.pipeline_id
+        assert result["total_queries"] == query_count
+        assert result["total_results"] == query_count * len(mock_results)
+        assert len(stored) == query_count * len(mock_results)

--- a/tests/autorag_research/pipelines/retrieval/test_heaven_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_heaven_pipeline.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.orm.repository.image_chunk_retrieved_result import ImageChunkRetrievedResultRepository
 from autorag_research.orm.repository.query import QueryRepository
+from autorag_research.orm.service.retrieval_pipeline import RetrievalPipelineService
 from autorag_research.pipelines.retrieval.heaven import (
     HEAVENPipelineConfig,
     HEAVENRetrievalPipeline,
@@ -62,19 +63,14 @@ class TestHEAVENPipeline:
 
     @pytest.fixture
     def cleanup_pipeline_results(self, session_factory: sessionmaker[Session]):
-        """Cleanup fixture that deletes image chunk pipeline results after test."""
+        """Cleanup fixture that deletes HEAVEN pipeline results through the service API."""
         created_pipeline_ids: list[int] = []
 
         yield created_pipeline_ids
 
-        session = session_factory()
-        try:
-            result_repo = ImageChunkRetrievedResultRepository(session)
-            for pipeline_id in created_pipeline_ids:
-                result_repo.delete_by_pipeline(pipeline_id)
-            session.commit()
-        finally:
-            session.close()
+        service = RetrievalPipelineService(session_factory)
+        for pipeline_id in created_pipeline_ids:
+            service.delete_pipeline_results(pipeline_id)
 
     def test_pipeline_config_getters(self):
         """Config should resolve to the HEAVEN pipeline and preserve stage parameters."""


### PR DESCRIPTION
## Summary
- add a retrieval-only HEAVEN pipeline over `ImageChunk` candidates
- persist image retrieval outputs through `ImageChunkRetrievedResult`
- cover config wiring, stage fusion, orchestration, and persistence with tests

## Verification
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_heaven_pipeline.py -q`
- `uv run pytest tests/autorag_research/pipelines/retrieval -q`
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_vector_search_pipeline.py tests/autorag_research/pipelines/retrieval/test_hybrid_pipeline.py tests/autorag_research/orm/service/test_retrieval_pipeline.py tests/autorag_research/orm/uow/test_retrieval_uow.py -q`
- `make check`

<!-- dani:stage=implementation;job=6b03232a498c4bca9ea752fccaec8463;issue=303 -->
