### PR TITLE
Feature/#88

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Standalone retrieval pipelines. Use them on their own for retrieval-only evaluat
 | [Vector Search (DPR)](https://aclanthology.org/2020.emnlp-main.550.pdf)          | Dense vector similarity search (single-vector and multi-vector MaxSim) | EMNLP 20  |
 | [BM25](https://www.staff.city.ac.uk/~sbrp622/papers/foundations_bm25_review.pdf) | Sparse full-text retrieval                                             | -         |
 | [HyDE](https://arxiv.org/abs/2212.10496)                                         | Hypothetical Document Embeddings                                       | ACL 23    |
+| [Query Rewrite](https://aclanthology.org/2023.emnlp-main.322/)                   | Rewrite query text before delegating retrieval                         | EMNLP 23  |
 | [Hybrid RRF](https://cormack.uwaterloo.ca/cormacksigir09-rrf.pdf)                | Reciprocal Rank Fusion of two retrieval pipelines                      | -         |
 | [Hybrid CC](https://arxiv.org/pdf/2210.11934)                                    | Convex Combination fusion of two retrieval pipelines                   | -         |
 
@@ -185,7 +186,7 @@ metrics:
   generation: [rouge]
 ```
 
-Generation pipelines (and some retrieval pipelines like HyDE) require an LLM. The `llm` field in each pipeline config references a file in `configs/llm/` by name (without `.yaml`):
+Generation pipelines (and some retrieval pipelines like HyDE and Query Rewrite) require an LLM. The `llm` field in each pipeline config references a file in `configs/llm/` by name (without `.yaml`):
 
 ```yaml
 # configs/pipelines/generation/basic_rag.yaml

--- a/autorag_research/executor.py
+++ b/autorag_research/executor.py
@@ -23,11 +23,9 @@ from autorag_research.config import (
 from autorag_research.orm.service.generation_evaluation import GenerationEvaluationService
 from autorag_research.orm.service.retrieval_evaluation import RetrievalEvaluationService
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.loader import RetrievalPipelineLoader
 
 logger = logging.getLogger("AutoRAG-Research")
-
-
-PIPELINE_TYPES = ["pipelines", "retrieval"]
 
 
 @dataclass
@@ -169,6 +167,13 @@ class Executor:
 
         # Cache for dependency retrieval pipelines (loaded from YAML)
         self._dependency_pipelines: dict[str, BaseRetrievalPipeline] = {}
+        self._retrieval_pipeline_loader = RetrievalPipelineLoader(
+            session_factory=session_factory,
+            schema=schema,
+            config_dir=self._config_dir,
+            config_resolver=self._config_resolver,
+            dependency_pipelines=self._dependency_pipelines,
+        )
 
         logger.info(f"Executor initialized with {len(config.pipelines)} pipelines and {len(config.metrics)} metrics")
         logger.debug(f"Config directory: {self._config_dir}")
@@ -578,62 +583,4 @@ class Executor:
         Raises:
             ValueError: If retrieval wrapper configs reference each other cyclically.
         """
-        from hydra.utils import instantiate
-
-        current_name = getattr(config, "name", "")
-        name = getattr(config, "retrieval_pipeline_name", "")
-        inject_retrieval_pipeline = getattr(config, "inject_retrieval_pipeline", None)
-        existing_pipeline = getattr(config, "_retrieval_pipeline", None)
-
-        if not name or not callable(inject_retrieval_pipeline):
-            return
-
-        if existing_pipeline is not None:
-            logger.debug(f"Retrieval pipeline already injected for {config.name}")
-            return
-
-        current_identifiers = []
-        for identifier in (resolution_key, current_name):
-            if identifier and identifier not in current_identifiers:
-                current_identifiers.append(identifier)
-
-        current_stack = resolving_stack + tuple(
-            identifier for identifier in current_identifiers if identifier not in resolving_stack
-        )
-        if name in current_stack:
-            cycle_path = " -> ".join([*current_stack, name])
-            msg = f"Cyclic retrieval pipeline dependency detected: {cycle_path}"
-            raise ValueError(msg)
-
-        logger.info(f"Resolving retrieval pipeline dependency: {name}")
-
-        # Return cached pipeline if already loaded
-        if name in self._dependency_pipelines:
-            logger.debug(f"Using cached retrieval pipeline: {name}")
-            inject_retrieval_pipeline(self._dependency_pipelines[name])
-            return
-
-        # Load pipeline config from pipelines/retrieval/ directory
-        pipeline_cfg = self._config_resolver.resolve_config(PIPELINE_TYPES, name)
-        pipeline_config = instantiate(pipeline_cfg)
-        resolved_name = getattr(pipeline_config, "name", "")
-        if resolved_name and resolved_name in current_stack:
-            cycle_path = " -> ".join([*current_stack, name])
-            msg = f"Cyclic retrieval pipeline dependency detected: {cycle_path}"
-            raise ValueError(msg)
-
-        self._resolve_dependencies(pipeline_config, current_stack, name)
-
-        # Instantiate the retrieval pipeline
-        pipeline_class = pipeline_config.get_pipeline_class()
-        retrieval_pipeline = pipeline_class(
-            session_factory=self.session_factory,
-            name=pipeline_config.name,
-            schema=self._schema,
-            **pipeline_config.get_pipeline_kwargs(),
-        )
-
-        # Cache and inject
-        self._dependency_pipelines[name] = retrieval_pipeline
-        inject_retrieval_pipeline(retrieval_pipeline)
-        logger.info(f"Loaded and injected retrieval pipeline: {name}")
+        self._retrieval_pipeline_loader.resolve_dependencies(config, resolving_stack, resolution_key)

--- a/autorag_research/executor.py
+++ b/autorag_research/executor.py
@@ -553,7 +553,12 @@ class Executor:
                 error_message=error_msg,
             )
 
-    def _resolve_dependencies(self, config: BasePipelineConfig) -> None:
+    def _resolve_dependencies(
+        self,
+        config: BasePipelineConfig,
+        resolving_stack: tuple[str, ...] = (),
+        resolution_key: str | None = None,
+    ) -> None:
         """Resolve retrieval-pipeline dependencies for configs that declare them.
 
         Checks for `retrieval_pipeline_name` plus `inject_retrieval_pipeline()`,
@@ -564,9 +569,18 @@ class Executor:
 
         Args:
             config: Pipeline configuration that may depend on another retrieval pipeline.
+            resolving_stack: Pipeline names currently being resolved in the active
+                dependency chain. Used to detect cycles before recursing.
+            resolution_key: Config lookup name used to load `config`. When present,
+                it is tracked alongside `config.name` to catch cycles even when a
+                YAML config's lookup key and runtime pipeline name differ.
+
+        Raises:
+            ValueError: If retrieval wrapper configs reference each other cyclically.
         """
         from hydra.utils import instantiate
 
+        current_name = getattr(config, "name", "")
         name = getattr(config, "retrieval_pipeline_name", "")
         inject_retrieval_pipeline = getattr(config, "inject_retrieval_pipeline", None)
         existing_pipeline = getattr(config, "_retrieval_pipeline", None)
@@ -577,6 +591,19 @@ class Executor:
         if existing_pipeline is not None:
             logger.debug(f"Retrieval pipeline already injected for {config.name}")
             return
+
+        current_identifiers = []
+        for identifier in (resolution_key, current_name):
+            if identifier and identifier not in current_identifiers:
+                current_identifiers.append(identifier)
+
+        current_stack = resolving_stack + tuple(
+            identifier for identifier in current_identifiers if identifier not in resolving_stack
+        )
+        if name in current_stack:
+            cycle_path = " -> ".join([*current_stack, name])
+            msg = f"Cyclic retrieval pipeline dependency detected: {cycle_path}"
+            raise ValueError(msg)
 
         logger.info(f"Resolving retrieval pipeline dependency: {name}")
 
@@ -589,7 +616,13 @@ class Executor:
         # Load pipeline config from pipelines/retrieval/ directory
         pipeline_cfg = self._config_resolver.resolve_config(PIPELINE_TYPES, name)
         pipeline_config = instantiate(pipeline_cfg)
-        self._resolve_dependencies(pipeline_config)
+        resolved_name = getattr(pipeline_config, "name", "")
+        if resolved_name and resolved_name in current_stack:
+            cycle_path = " -> ".join([*current_stack, name])
+            msg = f"Cyclic retrieval pipeline dependency detected: {cycle_path}"
+            raise ValueError(msg)
+
+        self._resolve_dependencies(pipeline_config, current_stack, name)
 
         # Instantiate the retrieval pipeline
         pipeline_class = pipeline_config.get_pipeline_class()

--- a/autorag_research/executor.py
+++ b/autorag_research/executor.py
@@ -177,7 +177,7 @@ class Executor:
         """Run all configured pipelines and evaluate metrics.
 
         For each pipeline:
-        1. Resolve dependencies (generation only)
+        1. Resolve retrieval-pipeline dependencies when declared
         2. Run health check (if enabled)
         3. Run the pipeline with retry logic
         4. Verify completion
@@ -193,9 +193,8 @@ class Executor:
         for pipeline_config in self.config.pipelines:
             logger.info(f"=== Starting pipeline: {pipeline_config.name} ===")
 
-            # Step 0: Resolve dependencies for generation pipelines
-            if pipeline_config.pipeline_type == PipelineType.GENERATION:
-                self._resolve_dependencies(pipeline_config)
+            # Step 0: Resolve retrieval-pipeline dependencies when declared
+            self._resolve_dependencies(pipeline_config)
 
             # Step 1: Run health check (if enabled)
             if self.config.health_check_queries > 0:
@@ -555,34 +554,28 @@ class Executor:
             )
 
     def _resolve_dependencies(self, config: BasePipelineConfig) -> None:
-        """Resolve dependencies for a generation pipeline config.
+        """Resolve retrieval-pipeline dependencies for configs that declare them.
 
-        Checks for `retrieval_pipeline_name` attribute and loads/instantiates
-        the referenced retrieval pipeline, then injects it into the config.
+        Checks for `retrieval_pipeline_name` plus `inject_retrieval_pipeline()`,
+        loads/instantiates the referenced retrieval pipeline, then injects it.
 
         Uses Hydra's compose API when available to leverage configured search paths,
         with fallback to direct YAML loading from config_dir.
 
         Args:
-            config: Pipeline configuration (processes any BaseGenerationPipelineConfig
-                with a non-empty retrieval_pipeline_name).
+            config: Pipeline configuration that may depend on another retrieval pipeline.
         """
         from hydra.utils import instantiate
 
-        from autorag_research.config import BaseGenerationPipelineConfig
+        name = getattr(config, "retrieval_pipeline_name", "")
+        inject_retrieval_pipeline = getattr(config, "inject_retrieval_pipeline", None)
+        existing_pipeline = getattr(config, "_retrieval_pipeline", None)
 
-        # Only process generation pipeline configs
-        if not isinstance(config, BaseGenerationPipelineConfig):
+        if not name or not callable(inject_retrieval_pipeline):
             return
 
-        # Skip if retrieval pipeline already injected (programmatic usage)
-        if config._retrieval_pipeline is not None:
+        if existing_pipeline is not None:
             logger.debug(f"Retrieval pipeline already injected for {config.name}")
-            return
-
-        # Skip if no retrieval pipeline dependency
-        name: str = config.retrieval_pipeline_name
-        if not name:
             return
 
         logger.info(f"Resolving retrieval pipeline dependency: {name}")
@@ -590,12 +583,13 @@ class Executor:
         # Return cached pipeline if already loaded
         if name in self._dependency_pipelines:
             logger.debug(f"Using cached retrieval pipeline: {name}")
-            config.inject_retrieval_pipeline(self._dependency_pipelines[name])
+            inject_retrieval_pipeline(self._dependency_pipelines[name])
             return
 
         # Load pipeline config from pipelines/retrieval/ directory
         pipeline_cfg = self._config_resolver.resolve_config(PIPELINE_TYPES, name)
         pipeline_config = instantiate(pipeline_cfg)
+        self._resolve_dependencies(pipeline_config)
 
         # Instantiate the retrieval pipeline
         pipeline_class = pipeline_config.get_pipeline_class()
@@ -608,5 +602,5 @@ class Executor:
 
         # Cache and inject
         self._dependency_pipelines[name] = retrieval_pipeline
-        config.inject_retrieval_pipeline(retrieval_pipeline)
+        inject_retrieval_pipeline(retrieval_pipeline)
         logger.info(f"Loaded and injected retrieval pipeline: {name}")

--- a/autorag_research/pipelines/retrieval/__init__.py
+++ b/autorag_research/pipelines/retrieval/__init__.py
@@ -10,6 +10,10 @@ from autorag_research.pipelines.retrieval.hyde import (
     HyDEPipelineConfig,
     HyDERetrievalPipeline,
 )
+from autorag_research.pipelines.retrieval.query_rewrite import (
+    QueryRewritePipelineConfig,
+    QueryRewriteRetrievalPipeline,
+)
 from autorag_research.pipelines.retrieval.vector_search import (
     VectorSearchPipelineConfig,
     VectorSearchRetrievalPipeline,
@@ -25,6 +29,8 @@ __all__ = [
     "HybridCCRetrievalPipelineConfig",
     "HybridRRFRetrievalPipeline",
     "HybridRRFRetrievalPipelineConfig",
+    "QueryRewritePipelineConfig",
+    "QueryRewriteRetrievalPipeline",
     "VectorSearchPipelineConfig",
     "VectorSearchRetrievalPipeline",
 ]

--- a/autorag_research/pipelines/retrieval/hybrid.py
+++ b/autorag_research/pipelines/retrieval/hybrid.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.loader import RetrievalPipelineLoader
 from autorag_research.util import (
     normalize_dbsf,
     normalize_minmax,
@@ -344,22 +345,17 @@ class HybridRetrievalPipeline(BaseRetrievalPipeline, ABC):
         Returns:
             Instantiated retrieval pipeline.
         """
-        from hydra.utils import instantiate
-
         from autorag_research.cli.config_resolver import ConfigResolver
         from autorag_research.cli.utils import get_config_dir
 
         config_dir = config_dir or get_config_dir()
-        resolver = ConfigResolver(config_dir)
-        pipeline_cfg = resolver.resolve_config(["pipelines", "retrieval"], name)
-        pipeline_config: BaseRetrievalPipelineConfig = instantiate(pipeline_cfg)
-
-        pipeline_class = pipeline_config.get_pipeline_class()
-        return pipeline_class(
+        return RetrievalPipelineLoader(
             session_factory=session_factory,
-            name=pipeline_config.name,
             schema=schema,
-            **pipeline_config.get_pipeline_kwargs(),
+            config_dir=config_dir,
+            config_resolver=ConfigResolver(config_dir),
+        ).load_pipeline(
+            name,
         )
 
     @abstractmethod

--- a/autorag_research/pipelines/retrieval/loader.py
+++ b/autorag_research/pipelines/retrieval/loader.py
@@ -1,0 +1,116 @@
+"""Shared loader for retrieval pipelines and nested retrieval dependencies."""
+
+import inspect
+import logging
+from pathlib import Path
+from typing import Any
+
+from hydra.utils import instantiate
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.cli.config_resolver import ConfigResolver
+from autorag_research.cli.utils import get_config_dir
+from autorag_research.config import BasePipelineConfig, BaseRetrievalPipelineConfig
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+
+logger = logging.getLogger("AutoRAG-Research")
+
+PIPELINE_TYPES = ["pipelines", "retrieval"]
+
+
+class RetrievalPipelineLoader:
+    """Load retrieval pipelines and inject nested retrieval dependencies."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        schema: Any | None = None,
+        config_dir: Path | None = None,
+        config_resolver: ConfigResolver | None = None,
+        dependency_pipelines: dict[str, BaseRetrievalPipeline] | None = None,
+    ) -> None:
+        """Initialize the retrieval pipeline loader."""
+        self.session_factory = session_factory
+        self.schema = schema
+        self.config_dir = config_dir or get_config_dir()
+        self._config_resolver = config_resolver or ConfigResolver(self.config_dir)
+        self._dependency_pipelines = dependency_pipelines if dependency_pipelines is not None else {}
+
+    def resolve_dependencies(
+        self,
+        config: BasePipelineConfig,
+        resolving_stack: tuple[str, ...] = (),
+        resolution_key: str | None = None,
+    ) -> None:
+        """Resolve retrieval-pipeline dependencies for configs that declare them."""
+        dependency_name = getattr(config, "retrieval_pipeline_name", "")
+        inject_retrieval_pipeline = getattr(config, "inject_retrieval_pipeline", None)
+        existing_pipeline = getattr(config, "_retrieval_pipeline", None)
+
+        if not dependency_name or not callable(inject_retrieval_pipeline):
+            return
+
+        if existing_pipeline is not None:
+            logger.debug(f"Retrieval pipeline already injected for {config.name}")
+            return
+
+        current_stack = self._extend_resolution_stack(config, resolving_stack, resolution_key)
+        if dependency_name in current_stack:
+            cycle_path = " -> ".join([*current_stack, dependency_name])
+            msg = f"Cyclic retrieval pipeline dependency detected: {cycle_path}"
+            raise ValueError(msg)
+
+        inject_retrieval_pipeline(self.load_pipeline(dependency_name, current_stack))
+
+    def load_pipeline(
+        self,
+        name: str,
+        resolving_stack: tuple[str, ...] = (),
+    ) -> BaseRetrievalPipeline:
+        """Load a retrieval pipeline by config name and resolve nested wrappers."""
+        if name in self._dependency_pipelines:
+            logger.debug(f"Using cached retrieval pipeline: {name}")
+            return self._dependency_pipelines[name]
+
+        logger.info(f"Resolving retrieval pipeline dependency: {name}")
+        pipeline_cfg = self._config_resolver.resolve_config(PIPELINE_TYPES, name)
+        pipeline_config: BaseRetrievalPipelineConfig = instantiate(pipeline_cfg)
+        resolved_name = getattr(pipeline_config, "name", "")
+        if resolved_name and resolved_name in resolving_stack:
+            cycle_path = " -> ".join([*resolving_stack, name])
+            msg = f"Cyclic retrieval pipeline dependency detected: {cycle_path}"
+            raise ValueError(msg)
+
+        self.resolve_dependencies(pipeline_config, resolving_stack, name)
+        pipeline = self._instantiate_pipeline(pipeline_config)
+        self._dependency_pipelines[name] = pipeline
+        return pipeline
+
+    @staticmethod
+    def _extend_resolution_stack(
+        config: BasePipelineConfig,
+        resolving_stack: tuple[str, ...],
+        resolution_key: str | None,
+    ) -> tuple[str, ...]:
+        current_identifiers: list[str] = []
+        for identifier in (resolution_key, getattr(config, "name", "")):
+            if identifier and identifier not in current_identifiers:
+                current_identifiers.append(identifier)
+
+        return resolving_stack + tuple(
+            identifier for identifier in current_identifiers if identifier not in resolving_stack
+        )
+
+    def _instantiate_pipeline(self, pipeline_config: BaseRetrievalPipelineConfig) -> BaseRetrievalPipeline:
+        pipeline_class = pipeline_config.get_pipeline_class()
+        pipeline_kwargs = pipeline_config.get_pipeline_kwargs()
+
+        if self.config_dir is not None and "config_dir" in inspect.signature(pipeline_class.__init__).parameters:
+            pipeline_kwargs.setdefault("config_dir", self.config_dir)
+
+        return pipeline_class(
+            session_factory=self.session_factory,
+            name=pipeline_config.name,
+            schema=self.schema,
+            **pipeline_kwargs,
+        )

--- a/autorag_research/pipelines/retrieval/query_rewrite.py
+++ b/autorag_research/pipelines/retrieval/query_rewrite.py
@@ -1,0 +1,146 @@
+"""Query Rewrite retrieval pipeline for AutoRAG-Research.
+
+This pipeline implements an inference-time Rewrite-Retrieve flow inspired by
+"Query Rewriting in Retrieval-Augmented Large Language Models"
+(Ma et al., EMNLP 2023).
+
+Scope note:
+- This implementation covers the paper's practical query-rewrite-then-retrieve
+  inference pattern.
+- The paper's trainable/RL rewriter is intentionally out of scope for this MVP.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseRetrievalPipelineConfig
+from autorag_research.injection import health_check_llm
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+
+logger = logging.getLogger("AutoRAG-Research")
+
+DEFAULT_QUERY_REWRITE_PROMPT_TEMPLATE = """Rewrite the following question into a concise search query.
+Keep the original intent, add missing retrieval hints only when helpful, and return only the rewritten query.
+
+Question: {query}
+Rewritten query:"""
+
+
+@dataclass(kw_only=True)
+class QueryRewritePipelineConfig(BaseRetrievalPipelineConfig):
+    """Configuration for Query Rewrite retrieval pipeline."""
+
+    llm: str | BaseLanguageModel
+    retrieval_pipeline_name: str
+    prompt_template: str = field(default=DEFAULT_QUERY_REWRITE_PROMPT_TEMPLATE)
+    _retrieval_pipeline: BaseRetrievalPipeline | None = field(default=None, repr=False)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Auto-convert string LLM config names to model instances."""
+        if name == "llm" and isinstance(value, str):
+            from autorag_research.injection import load_llm
+
+            value = load_llm(value)
+            health_check_llm(value)
+        super().__setattr__(name, value)
+
+    def inject_retrieval_pipeline(self, pipeline: BaseRetrievalPipeline) -> None:
+        """Inject the wrapped retrieval pipeline instance."""
+        self._retrieval_pipeline = pipeline
+
+    def get_pipeline_class(self) -> type["QueryRewriteRetrievalPipeline"]:
+        """Return the QueryRewriteRetrievalPipeline class."""
+        return QueryRewriteRetrievalPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for QueryRewriteRetrievalPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "prompt_template": self.prompt_template,
+        }
+
+
+class QueryRewriteRetrievalPipeline(BaseRetrievalPipeline):
+    """Rewrite the query with an LLM, then delegate retrieval to another pipeline."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        prompt_template: str = DEFAULT_QUERY_REWRITE_PROMPT_TEMPLATE,
+        schema: Any | None = None,
+    ):
+        """Initialize query rewrite retrieval pipeline."""
+        if "{query}" not in prompt_template:
+            msg = "prompt_template must contain '{query}' placeholder"
+            raise ValueError(msg)
+
+        self.llm = llm
+        self._retrieval_pipeline = retrieval_pipeline
+        self.prompt_template = prompt_template
+
+        super().__init__(session_factory, name, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return query rewrite pipeline configuration for storage."""
+        model_name = getattr(self.llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self.llm).__name__
+
+        return {
+            "type": "query_rewrite",
+            "prompt_template": self.prompt_template,
+            "retrieval_pipeline_id": getattr(self._retrieval_pipeline, "pipeline_id", None),
+            "wrapped_pipeline_type": type(self._retrieval_pipeline).__name__,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_response_content(response: Any) -> str:
+        """Extract text content from an LLM response."""
+        if hasattr(response, "content"):
+            return str(response.content)
+        return str(response)
+
+    async def _rewrite_query(self, query_text: str) -> str:
+        """Rewrite the query text with the configured LLM prompt."""
+        prompt = self.prompt_template.format(query=query_text)
+        response = await self.llm.ainvoke(prompt)
+        rewritten_query = self._extract_response_content(response).strip()
+
+        if rewritten_query:
+            return rewritten_query
+
+        logger.warning("Query rewrite returned empty text; falling back to original query")
+        return query_text
+
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        """Fetch query text by ID, rewrite it, and retrieve with the wrapped pipeline."""
+        query_texts = self._service.fetch_query_texts([query_id])
+        if not query_texts:
+            return []
+
+        return await self._retrieve_by_text(query_texts[0], top_k)
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        """Rewrite raw query text, then retrieve with the wrapped pipeline."""
+        rewritten_query = await self._rewrite_query(query_text)
+        return await self._retrieval_pipeline.retrieve(rewritten_query, top_k)
+
+
+__all__ = [
+    "DEFAULT_QUERY_REWRITE_PROMPT_TEMPLATE",
+    "QueryRewritePipelineConfig",
+    "QueryRewriteRetrievalPipeline",
+]

--- a/configs/pipelines/retrieval/query_rewrite.yaml
+++ b/configs/pipelines/retrieval/query_rewrite.yaml
@@ -1,0 +1,28 @@
+# Query Rewrite Retrieval Pipeline Configuration
+#
+# Rewrites the input query with an LLM, then delegates retrieval to another
+# retrieval pipeline using the rewritten query text.
+#
+# Parameters:
+#   llm: LLM config name from configs/llm/ (e.g., "mock", "openai-gpt5-mini")
+#   retrieval_pipeline_name: Existing retrieval pipeline config name to wrap
+#   prompt_template: Template with {query} placeholder
+#   top_k: Number of results to retrieve (default: 10)
+#   batch_size: Number of queries to process per batch (default: 128)
+#
+_target_: autorag_research.pipelines.retrieval.query_rewrite.QueryRewritePipelineConfig
+description: "Rewrite query text with an LLM before delegating retrieval"
+name: query_rewrite
+llm: mock
+retrieval_pipeline_name: bm25
+prompt_template: |
+  Rewrite the following question into a concise search query.
+  Keep the original intent, add missing retrieval hints only when helpful, and return only the rewritten query.
+
+  Question: {query}
+  Rewritten query:
+top_k: 10
+batch_size: 128
+max_concurrency: 16
+max_retries: 3
+retry_delay: 1.0

--- a/docs/pipelines/retrieval/index.md
+++ b/docs/pipelines/retrieval/index.md
@@ -10,6 +10,7 @@ Algorithms that take a query and return relevant documents.
 | [Hybrid](hybrid.md) | RRF / Convex Combination | Text |
 | [Vector Search](vector-search.md) | Dense (vector similarity) | Text |
 | [HyDE](hyde.md) | Dense (hypothetical document embeddings) | Text |
+| [Query Rewrite](query-rewrite.md) | Rewrite query text before retrieval | Text |
 
 ## Base Class
 

--- a/docs/pipelines/retrieval/query-rewrite.md
+++ b/docs/pipelines/retrieval/query-rewrite.md
@@ -1,0 +1,125 @@
+# Query Rewrite
+
+Rewrite the query with an LLM, then retrieve with an existing retrieval pipeline.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Type | Retrieval |
+| Algorithm | Rewrite-Retrieve |
+| Modality | Text |
+| Paper | [Query Rewriting in Retrieval-Augmented Large Language Models](https://aclanthology.org/2023.emnlp-main.322/) |
+
+## How It Works
+
+1. Receives a query
+2. Uses an LLM to rewrite the query into a retrieval-optimized search query
+3. Passes the rewritten query to a configured retrieval pipeline
+4. Persists the wrapper pipeline's retrieval outputs as usual
+
+This is different from HyDE:
+
+- **Query Rewrite** changes the **query text** before retrieval.
+- **HyDE** generates a **hypothetical answer passage**, embeds it, and searches with that embedding.
+
+## Scope
+
+This implementation covers the paper's practical inference-time rewrite-retrieve flow only.
+The paper's trainable/RL rewriter is out of scope for this MVP.
+
+## Configuration
+
+```yaml
+_target_: autorag_research.pipelines.retrieval.query_rewrite.QueryRewritePipelineConfig
+name: query_rewrite_bm25
+llm: openai-gpt5-mini
+retrieval_pipeline_name: bm25
+prompt_template: |
+  Rewrite the following question into a concise search query.
+  Keep the original intent, add missing retrieval hints only when helpful, and return only the rewritten query.
+
+  Question: {query}
+  Rewritten query:
+top_k: 10
+batch_size: 128
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| name | str | required | Unique pipeline instance name |
+| llm | str | required | LLM config name (from `configs/llm/`) |
+| retrieval_pipeline_name | str | required | Existing retrieval pipeline config to wrap |
+| prompt_template | str | see below | Template with `{query}` placeholder |
+| top_k | int | 10 | Results per query |
+| batch_size | int | 128 | Queries per batch |
+
+**Default prompt template:**
+
+```text
+Rewrite the following question into a concise search query.
+Keep the original intent, add missing retrieval hints only when helpful, and return only the rewritten query.
+
+Question: {query}
+Rewritten query:
+```
+
+## Usage
+
+### Python API
+
+```python
+from langchain_openai import ChatOpenAI
+
+from autorag_research.orm.connection import DBConnection
+from autorag_research.pipelines.retrieval.bm25 import BM25RetrievalPipeline
+from autorag_research.pipelines.retrieval.query_rewrite import QueryRewriteRetrievalPipeline
+
+db = DBConnection.from_config()
+session_factory = db.get_session_factory()
+
+wrapped_retriever = BM25RetrievalPipeline(
+    session_factory=session_factory,
+    name="bm25",
+    tokenizer="bert",
+)
+
+pipeline = QueryRewriteRetrievalPipeline(
+    session_factory=session_factory,
+    name="query_rewrite_bm25",
+    llm=ChatOpenAI(model="gpt-5-mini"),
+    retrieval_pipeline=wrapped_retriever,
+)
+
+results = await pipeline.retrieve("Who wrote the original paper on transformers?", top_k=10)
+```
+
+### YAML / Executor
+
+Create or reuse a wrapped retrieval config such as `configs/pipelines/retrieval/bm25.yaml`, then point the query rewrite config at it:
+
+```yaml
+# configs/pipelines/retrieval/query_rewrite_bm25.yaml
+_target_: autorag_research.pipelines.retrieval.query_rewrite.QueryRewritePipelineConfig
+name: query_rewrite_bm25
+llm: openai-gpt5-mini
+retrieval_pipeline_name: bm25
+```
+
+The executor will resolve `retrieval_pipeline_name`, instantiate the wrapped retriever, and inject it automatically.
+
+## When to Use
+
+Good for:
+
+- conversational or underspecified queries
+- preserving an existing retriever while improving query phrasing
+- lightweight LLM-assisted retrieval baselines
+
+Consider other methods when:
+
+- you need the paper's trainable/RL rewriter
+- you prefer dense retrieval over rewritten text search
+- added LLM latency is unacceptable

--- a/tests/autorag_research/pipelines/retrieval/test_hybrid_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_hybrid_pipeline.py
@@ -581,6 +581,57 @@ class TestHybridRRFRetrievalPipeline:
             assert pipeline._retrieval_pipeline_1 == mock_pipeline_1
             assert pipeline._retrieval_pipeline_2 == mock_pipeline_2
 
+    def test_load_pipeline_resolves_nested_query_rewrite_dependencies(self, session_factory: sessionmaker[Session]):
+        """Test named loading resolves nested QueryRewrite retrieval dependencies."""
+        from pathlib import Path
+
+        from autorag_research.pipelines.retrieval.bm25 import BM25PipelineConfig
+        from autorag_research.pipelines.retrieval.query_rewrite import QueryRewritePipelineConfig
+        from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_llm
+
+        query_rewrite_config = QueryRewritePipelineConfig(
+            name="query_rewrite",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="bm25",
+        )
+        wrapped_config = BM25PipelineConfig(name="bm25", tokenizer="bert")
+
+        class DummyWrappedPipeline:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.pipeline_id = 321
+
+        class DummyQueryRewritePipeline:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.pipeline_id = 999
+
+        query_rewrite_config.get_pipeline_class = lambda: DummyQueryRewritePipeline
+        wrapped_config.get_pipeline_class = lambda: DummyWrappedPipeline
+
+        dependency_configs = {
+            "query_rewrite": query_rewrite_config,
+            "bm25": wrapped_config,
+        }
+
+        def resolve_config(_dirs: list[str | Path], name: str):
+            return dependency_configs[name]
+
+        with (
+            patch("autorag_research.cli.config_resolver.ConfigResolver.resolve_config", side_effect=resolve_config),
+            patch("autorag_research.pipelines.retrieval.loader.instantiate", side_effect=lambda cfg: cfg),
+        ):
+            pipeline = HybridRRFRetrievalPipeline._load_pipeline(
+                "query_rewrite",
+                session_factory,
+                None,
+                Path("configs"),
+            )
+
+        assert isinstance(pipeline, DummyQueryRewritePipeline)
+        assert isinstance(pipeline.kwargs["retrieval_pipeline"], DummyWrappedPipeline)
+        assert pipeline.kwargs["retrieval_pipeline"].kwargs["name"] == "bm25"
+
 
 class TestHybridCCRetrievalPipeline:
     """Tests for HybridCCRetrievalPipeline."""

--- a/tests/autorag_research/pipelines/retrieval/test_query_rewrite_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_query_rewrite_pipeline.py
@@ -1,0 +1,210 @@
+"""Tests for the Query Rewrite retrieval pipeline."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.orm.repository.chunk_retrieved_result import ChunkRetrievedResultRepository
+from autorag_research.pipelines.retrieval.query_rewrite import (
+    DEFAULT_QUERY_REWRITE_PROMPT_TEMPLATE,
+    QueryRewritePipelineConfig,
+    QueryRewriteRetrievalPipeline,
+)
+from tests.autorag_research.pipelines.pipeline_test_utils import (
+    PipelineTestConfig,
+    PipelineTestVerifier,
+    create_mock_retrieval_pipeline,
+)
+
+
+@pytest.fixture
+def cleanup_pipeline_results(session_factory: sessionmaker[Session]):
+    """Cleanup fixture that deletes retrieval pipeline results after test."""
+    created_pipeline_ids: list[int] = []
+
+    yield created_pipeline_ids
+
+    session = session_factory()
+    try:
+        result_repo = ChunkRetrievedResultRepository(session)
+        for pipeline_id in created_pipeline_ids:
+            result_repo.delete_by_pipeline(pipeline_id)
+        session.commit()
+    finally:
+        session.close()
+
+
+class TestQueryRewritePipelineConfig:
+    """Tests for QueryRewritePipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        llm = FakeListLLM(responses=["rewritten query"])
+        config = QueryRewritePipelineConfig(
+            name="query_rewrite",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+        )
+
+        assert config.get_pipeline_class() == QueryRewriteRetrievalPipeline
+
+    def test_default_prompt_template(self):
+        llm = FakeListLLM(responses=["rewritten query"])
+        config = QueryRewritePipelineConfig(
+            name="query_rewrite",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+        )
+
+        assert config.prompt_template == DEFAULT_QUERY_REWRITE_PROMPT_TEMPLATE
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        llm = FakeListLLM(responses=["rewritten query"])
+        config = QueryRewritePipelineConfig(
+            name="query_rewrite",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        llm = FakeListLLM(responses=["rewritten query"])
+        wrapped_retrieval = create_mock_retrieval_pipeline(pipeline_id=77)
+        config = QueryRewritePipelineConfig(
+            name="query_rewrite",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+            prompt_template="Rewrite: {query}",
+        )
+
+        config.inject_retrieval_pipeline(wrapped_retrieval)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is wrapped_retrieval
+        assert kwargs["prompt_template"] == "Rewrite: {query}"
+
+    @pytest.mark.api
+    def test_string_llm_conversion(self):
+        with patch("autorag_research.injection.load_llm") as mock_load:
+            mock_llm = MagicMock()
+            mock_load.return_value = mock_llm
+
+            config = QueryRewritePipelineConfig(
+                name="query_rewrite",
+                llm="mock",
+                retrieval_pipeline_name="bm25",
+            )
+
+            mock_load.assert_called_once_with("mock")
+            assert config.llm is mock_llm
+
+
+class TestQueryRewriteRetrievalPipeline:
+    """Tests for QueryRewriteRetrievalPipeline."""
+
+    def test_creation_rejects_missing_query_placeholder(self, session_factory):
+        with pytest.raises(ValueError, match="\\{query\\}"):
+            QueryRewriteRetrievalPipeline(
+                session_factory=session_factory,
+                name="query_rewrite_invalid_prompt",
+                llm=FakeListLLM(responses=["rewritten query"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                prompt_template="Rewrite without placeholder",
+            )
+
+    @pytest.mark.asyncio
+    async def test_rewrite_query_uses_prompt_template(self, session_factory, cleanup_pipeline_results: list[int]):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(return_value="rewritten query")
+
+        pipeline = QueryRewriteRetrievalPipeline(
+            session_factory=session_factory,
+            name="query_rewrite_template_usage",
+            llm=llm,
+            retrieval_pipeline=create_mock_retrieval_pipeline(),
+            prompt_template="Rewrite better: {query}",
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        rewritten = await pipeline._rewrite_query("original query")
+
+        assert rewritten == "rewritten query"
+        llm.ainvoke.assert_awaited_once_with("Rewrite better: original query")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_rewrites_then_delegates(self, session_factory, cleanup_pipeline_results: list[int]):
+        wrapped_retrieval = create_mock_retrieval_pipeline(default_results=[{"doc_id": 9, "score": 0.95}])
+        pipeline = QueryRewriteRetrievalPipeline(
+            session_factory=session_factory,
+            name="query_rewrite_by_text",
+            llm=FakeListLLM(responses=["rewritten query"]),
+            retrieval_pipeline=wrapped_retrieval,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_text("original query", top_k=4)
+
+        wrapped_retrieval.retrieve.assert_awaited_once_with("rewritten query", 4)
+        assert results == [{"doc_id": 9, "score": 0.95}]
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_id_fetches_query_text_then_rewrites(
+        self,
+        session_factory,
+        cleanup_pipeline_results: list[int],
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(default_results=[{"doc_id": 3, "score": 0.88}])
+        pipeline = QueryRewriteRetrievalPipeline(
+            session_factory=session_factory,
+            name="query_rewrite_by_id",
+            llm=FakeListLLM(responses=["rewritten seeded query"]),
+            retrieval_pipeline=wrapped_retrieval,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_id(1, top_k=2)
+
+        wrapped_retrieval.retrieve.assert_awaited_once_with("rewritten seeded query", 2)
+        assert results == [{"doc_id": 3, "score": 0.88}]
+
+    def test_run_full_pipeline(self, session_factory, cleanup_pipeline_results: list[int]):
+        from autorag_research.orm.repository.query import QueryRepository
+
+        session = session_factory()
+        try:
+            query_count = QueryRepository(session).count()
+        finally:
+            session.close()
+
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 1, "score": 0.91, "content": "Content 1"},
+                {"doc_id": 2, "score": 0.83, "content": "Content 2"},
+            ]
+        )
+        pipeline = QueryRewriteRetrievalPipeline(
+            session_factory=session_factory,
+            name="query_rewrite_full_run",
+            llm=FakeListLLM(responses=["rewritten query"] * max(query_count, 1)),
+            retrieval_pipeline=wrapped_retrieval,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        result = pipeline.run(top_k=2)
+
+        verifier = PipelineTestVerifier(
+            result,
+            pipeline.pipeline_id,
+            session_factory,
+            PipelineTestConfig(
+                pipeline_type="retrieval",
+                expected_total_queries=query_count,
+                expected_min_results=0,
+                check_persistence=True,
+            ),
+        )
+        verifier.verify_all()

--- a/tests/autorag_research/test_executor.py
+++ b/tests/autorag_research/test_executor.py
@@ -18,6 +18,7 @@ from autorag_research.config import (
 from autorag_research.evaluation.metrics.retrieval import NDCGConfig, RecallConfig
 from autorag_research.executor import Executor, ExecutorResult, MetricResult
 from autorag_research.pipelines.retrieval.bm25 import BM25PipelineConfig
+from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_llm
 
 
 class TestExecutorWithRealDB:
@@ -181,6 +182,91 @@ class TestExecutorWithRealDB:
         assert result.total_pipelines_succeeded == 0
         assert result.pipeline_results[0].success is False
         assert result.pipeline_results[0].retries_used == config.max_retries
+
+
+class TestDependencyResolution:
+    """Tests for recursive retrieval dependency resolution."""
+
+    def test_resolve_dependencies_injects_wrapped_retrieval_pipeline(self, session_factory):
+        from autorag_research.pipelines.retrieval.query_rewrite import QueryRewritePipelineConfig
+
+        config = ExecutorConfig(pipelines=[], metrics=[], health_check_queries=0)
+        executor = Executor(session_factory, config)
+
+        query_rewrite_config = QueryRewritePipelineConfig(
+            name="query_rewrite",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="bm25",
+        )
+        wrapped_config = BM25PipelineConfig(name="bm25", tokenizer="bert")
+
+        class DummyRetrievalPipeline:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.pipeline_id = 321
+
+        wrapped_config.get_pipeline_class = lambda: DummyRetrievalPipeline
+
+        with (
+            patch.object(executor._config_resolver, "resolve_config", return_value=wrapped_config),
+            patch("hydra.utils.instantiate", side_effect=lambda cfg: cfg),
+        ):
+            executor._resolve_dependencies(query_rewrite_config)
+
+        assert query_rewrite_config._retrieval_pipeline is not None
+        assert isinstance(query_rewrite_config._retrieval_pipeline, DummyRetrievalPipeline)
+        assert query_rewrite_config._retrieval_pipeline.kwargs["name"] == "bm25"
+
+    def test_run_resolves_top_level_query_rewrite_dependencies(self, session_factory):
+        from autorag_research.pipelines.retrieval.query_rewrite import QueryRewritePipelineConfig
+
+        query_rewrite_config = QueryRewritePipelineConfig(
+            name="query_rewrite",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="bm25",
+        )
+        config = ExecutorConfig(
+            pipelines=[query_rewrite_config],
+            metrics=[],
+            health_check_queries=0,
+        )
+        executor = Executor(session_factory, config)
+        wrapped_config = BM25PipelineConfig(name="bm25", tokenizer="bert")
+
+        class DummyWrappedPipeline:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.pipeline_id = 321
+
+        created_pipelines: list[Any] = []
+
+        class DummyQueryRewritePipeline:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.pipeline_id = 999
+                created_pipelines.append(self)
+
+            def run(self, **kwargs):
+                return {
+                    "pipeline_id": self.pipeline_id,
+                    "total_queries": 1,
+                    "failed_queries": [],
+                }
+
+        wrapped_config.get_pipeline_class = lambda: DummyWrappedPipeline
+        query_rewrite_config.get_pipeline_class = lambda: DummyQueryRewritePipeline
+        executor._verify_pipeline_completion = MagicMock(return_value=True)
+
+        with (
+            patch.object(executor._config_resolver, "resolve_config", return_value=wrapped_config),
+            patch("hydra.utils.instantiate", side_effect=lambda cfg: cfg),
+        ):
+            result = executor.run()
+
+        assert result.total_pipelines_run == 1
+        assert result.total_pipelines_succeeded == 1
+        assert len(created_pipelines) == 1
+        assert isinstance(created_pipelines[0].kwargs["retrieval_pipeline"], DummyWrappedPipeline)
 
 
 class TestMetricEvaluationRules:

--- a/tests/autorag_research/test_executor.py
+++ b/tests/autorag_research/test_executor.py
@@ -209,7 +209,7 @@ class TestDependencyResolution:
 
         with (
             patch.object(executor._config_resolver, "resolve_config", return_value=wrapped_config),
-            patch("hydra.utils.instantiate", side_effect=lambda cfg: cfg),
+            patch("autorag_research.pipelines.retrieval.loader.instantiate", side_effect=lambda cfg: cfg),
         ):
             executor._resolve_dependencies(query_rewrite_config)
 
@@ -259,7 +259,7 @@ class TestDependencyResolution:
 
         with (
             patch.object(executor._config_resolver, "resolve_config", return_value=wrapped_config),
-            patch("hydra.utils.instantiate", side_effect=lambda cfg: cfg),
+            patch("autorag_research.pipelines.retrieval.loader.instantiate", side_effect=lambda cfg: cfg),
         ):
             result = executor.run()
 
@@ -310,7 +310,7 @@ class TestDependencyResolution:
 
         with (
             patch.object(executor._config_resolver, "resolve_config", side_effect=resolve_config),
-            patch("hydra.utils.instantiate", side_effect=lambda cfg: cfg),
+            patch("autorag_research.pipelines.retrieval.loader.instantiate", side_effect=lambda cfg: cfg),
             pytest.raises(
                 ValueError,
                 match=r"Cyclic retrieval pipeline dependency detected: pipeline_a -> pipeline_b -> pipeline_a",
@@ -345,7 +345,7 @@ class TestDependencyResolution:
 
         with (
             patch.object(executor._config_resolver, "resolve_config", side_effect=resolve_config),
-            patch("hydra.utils.instantiate", side_effect=lambda cfg: cfg),
+            patch("autorag_research.pipelines.retrieval.loader.instantiate", side_effect=lambda cfg: cfg),
             pytest.raises(
                 ValueError,
                 match=r"Cyclic retrieval pipeline dependency detected: wrapped_a -> pipeline_b -> wrapped_b -> pipeline_a",

--- a/tests/autorag_research/test_executor.py
+++ b/tests/autorag_research/test_executor.py
@@ -268,6 +268,91 @@ class TestDependencyResolution:
         assert len(created_pipelines) == 1
         assert isinstance(created_pipelines[0].kwargs["retrieval_pipeline"], DummyWrappedPipeline)
 
+    def test_resolve_dependencies_rejects_self_referential_wrapper_cycle(self, session_factory):
+        from autorag_research.pipelines.retrieval.query_rewrite import QueryRewritePipelineConfig
+
+        config = ExecutorConfig(pipelines=[], metrics=[], health_check_queries=0)
+        executor = Executor(session_factory, config)
+
+        query_rewrite_config = QueryRewritePipelineConfig(
+            name="self_ref",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="self_ref",
+        )
+
+        with pytest.raises(ValueError, match=r"Cyclic retrieval pipeline dependency detected: self_ref -> self_ref"):
+            executor._resolve_dependencies(query_rewrite_config)
+
+    def test_resolve_dependencies_rejects_two_node_wrapper_cycle(self, session_factory):
+        from autorag_research.pipelines.retrieval.query_rewrite import QueryRewritePipelineConfig
+
+        config = ExecutorConfig(pipelines=[], metrics=[], health_check_queries=0)
+        executor = Executor(session_factory, config)
+
+        pipeline_a = QueryRewritePipelineConfig(
+            name="pipeline_a",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="pipeline_b",
+        )
+        pipeline_b = QueryRewritePipelineConfig(
+            name="pipeline_b",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="pipeline_a",
+        )
+
+        dependency_configs = {
+            "pipeline_a": pipeline_a,
+            "pipeline_b": pipeline_b,
+        }
+
+        def resolve_config(_config_type: list[str], name: str):
+            return dependency_configs[name]
+
+        with (
+            patch.object(executor._config_resolver, "resolve_config", side_effect=resolve_config),
+            patch("hydra.utils.instantiate", side_effect=lambda cfg: cfg),
+            pytest.raises(
+                ValueError,
+                match=r"Cyclic retrieval pipeline dependency detected: pipeline_a -> pipeline_b -> pipeline_a",
+            ),
+        ):
+            executor._resolve_dependencies(pipeline_a)
+
+    def test_resolve_dependencies_rejects_cycle_when_runtime_names_differ_from_lookup_names(self, session_factory):
+        from autorag_research.pipelines.retrieval.query_rewrite import QueryRewritePipelineConfig
+
+        config = ExecutorConfig(pipelines=[], metrics=[], health_check_queries=0)
+        executor = Executor(session_factory, config)
+
+        pipeline_a = QueryRewritePipelineConfig(
+            name="wrapped_a",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="pipeline_b",
+        )
+        pipeline_b = QueryRewritePipelineConfig(
+            name="wrapped_b",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="pipeline_a",
+        )
+
+        dependency_configs = {
+            "pipeline_a": pipeline_a,
+            "pipeline_b": pipeline_b,
+        }
+
+        def resolve_config(_config_type: list[str], name: str):
+            return dependency_configs[name]
+
+        with (
+            patch.object(executor._config_resolver, "resolve_config", side_effect=resolve_config),
+            patch("hydra.utils.instantiate", side_effect=lambda cfg: cfg),
+            pytest.raises(
+                ValueError,
+                match=r"Cyclic retrieval pipeline dependency detected: wrapped_a -> pipeline_b -> wrapped_b -> pipeline_a",
+            ),
+        ):
+            executor._resolve_dependencies(pipeline_a)
+
 
 class TestMetricEvaluationRules:
     """Test suite for metric evaluation rules."""


### PR DESCRIPTION
<!-- dani:stage=implementation;job=44f6a381674447b1aa583693a24302b8;issue=88 -->

## Summary
- add a Query Rewrite retrieval pipeline that rewrites query text with an LLM before delegating to another retrieval pipeline
- generalize executor dependency resolution so retrieval wrapper configs can run as top-level pipelines and nested dependencies
- add config/docs/README wiring plus regression tests for pipeline behavior and executor integration

## Verification
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_query_rewrite_pipeline.py tests/autorag_research/test_executor.py tests/autorag_research/cli/commands/test_e2e_pipeline.py tests/autorag_research/pipelines/generation/test_basic_rag_pipeline.py -q`
- `make clean-docker && make test`
- `make check`
- manual `Executor.run()` smoke for top-level `QueryRewritePipelineConfig` (success=true, total_queries=5)

Closes #88
