### PR TITLE
Feature/#87

### DIFF
--- a/autorag_research/orm/repository/pipeline.py
+++ b/autorag_research/orm/repository/pipeline.py
@@ -128,8 +128,9 @@ class PipelineRepository(GenericRepository[Any]):
         Returns:
             List of all pipelines ordered alphabetically by name.
         """
-        stmt = select(self.model_cls).order_by(self.model_cls.name)
-        return list(self.session.execute(stmt).scalars().all())
+        stmt = select(self.model_cls)
+        pipelines = list(self.session.execute(stmt).scalars().all())
+        return sorted(pipelines, key=lambda pipeline: pipeline.name)
 
     def exists_by_name(self, name: str) -> bool:
         """Check if a pipeline with the given name exists.

--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -12,6 +12,7 @@ from autorag_research.pipelines.generation.question_decomposition import (
     QuestionDecompositionPipeline,
     QuestionDecompositionPipelineConfig,
 )
+from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline, SelfRAGPipelineConfig
 from autorag_research.pipelines.generation.spd_rag import SPDRAGPipeline, SPDRAGPipelineConfig
 from autorag_research.pipelines.generation.visrag_gen import (
     DEFAULT_VISRAG_PROMPT,
@@ -35,6 +36,8 @@ __all__ = [
     "QuestionDecompositionPipelineConfig",
     "SPDRAGPipeline",
     "SPDRAGPipelineConfig",
+    "SelfRAGPipeline",
+    "SelfRAGPipelineConfig",
     "VisRAGGenerationPipeline",
     "VisRAGGenerationPipelineConfig",
 ]

--- a/autorag_research/pipelines/generation/self_rag.py
+++ b/autorag_research/pipelines/generation/self_rag.py
@@ -155,6 +155,20 @@ class SelfRAGPipeline(BaseGenerationPipeline):
             critique=critique or "Improve grounding and specificity.",
         )
 
+    def _coerce_reflection_flag(self, value: Any, default: bool = False) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "yes", "1", "supported"}:
+                return True
+            if normalized in {"false", "no", "0", "unsupported", ""}:
+                return False
+            return default
+        if value is None:
+            return default
+        return bool(value)
+
     def _parse_key_value_reflection(self, response_text: str) -> dict[str, Any]:
         parsed: dict[str, Any] = {
             "action": "FINISH",
@@ -175,7 +189,7 @@ class SelfRAGPipeline(BaseGenerationPipeline):
                 if normalized_action in {"FINISH", "RETRIEVE", "REVISE"}:
                     parsed["action"] = normalized_action
             elif key == "SUPPORTED":
-                parsed["supported"] = value.lower() in {"yes", "true", "supported"}
+                parsed["supported"] = self._coerce_reflection_flag(value)
             elif key in {"SEARCH_QUERY", "FOLLOW_UP_QUERY"}:
                 parsed["search_query"] = value
             elif key == "CRITIQUE" and value:
@@ -188,8 +202,8 @@ class SelfRAGPipeline(BaseGenerationPipeline):
         if stripped.startswith("{"):
             try:
                 payload = json.loads(stripped)
-                should_retrieve = bool(payload.get("should_retrieve", False))
-                supported = bool(payload.get("is_supported", False))
+                should_retrieve = self._coerce_reflection_flag(payload.get("should_retrieve", False))
+                supported = self._coerce_reflection_flag(payload.get("is_supported", False))
                 if should_retrieve:
                     action = "RETRIEVE"
                 elif supported:

--- a/autorag_research/pipelines/generation/self_rag.py
+++ b/autorag_research/pipelines/generation/self_rag.py
@@ -1,0 +1,319 @@
+"""Self-RAG generation pipeline for AutoRAG-Research.
+
+This implementation is a prompt-based approximation of Self-RAG. It does not
+require a fine-tuned reflection-token model. Instead, it uses iterative
+self-reflection prompts to decide whether retrieval is necessary, revise the
+current answer with retrieved evidence, and stop once the answer appears
+supported.
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker
+
+logger = logging.getLogger("AutoRAG-Research")
+
+DEFAULT_INITIAL_PROMPT = """You are answering a question without external evidence.
+
+Question: {query}
+
+Provide your best concise answer. If you are uncertain, answer briefly and leave room for later revision.
+
+Answer:"""
+
+DEFAULT_REFLECTION_PROMPT = """You are a Self-RAG controller deciding whether an answer needs retrieval or revision.
+
+Question: {query}
+
+Current Answer:
+{answer}
+
+Retrieved Context:
+{context}
+
+Critique History:
+{critique_history}
+
+Respond as JSON with this schema:
+{{
+  "should_retrieve": true or false,
+  "is_supported": true or false,
+  "follow_up_query": "optional refined retrieval query",
+  "critique": "short critique of the current answer"
+}}
+"""
+
+DEFAULT_REVISION_PROMPT = """Revise the answer so it is grounded in the retrieved context.
+
+Question: {query}
+
+Current Answer:
+{answer}
+
+Retrieved Context:
+{context}
+
+Critique:
+{critique}
+
+Return only the revised answer.
+"""
+
+
+class SelfRAGPipeline(BaseGenerationPipeline):
+    """Prompt-based Self-RAG generation pipeline.
+
+    The pipeline follows a lightweight self-reflection loop:
+    1. Draft an initial answer without retrieval.
+    2. Reflect on whether retrieval or revision is needed.
+    3. Retrieve evidence only when requested by reflection.
+    4. Revise the answer with the current evidence.
+    5. Stop once reflection marks the answer as supported or the step budget is exhausted.
+    """
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        initial_prompt_template: str = DEFAULT_INITIAL_PROMPT,
+        reflection_prompt_template: str = DEFAULT_REFLECTION_PROMPT,
+        revision_prompt_template: str = DEFAULT_REVISION_PROMPT,
+        max_reflection_steps: int = 3,
+        schema: Any | None = None,
+    ) -> None:
+        self._initial_prompt_template = initial_prompt_template
+        self._reflection_prompt_template = reflection_prompt_template
+        self._revision_prompt_template = revision_prompt_template
+        self.max_reflection_steps = max_reflection_steps
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+
+        return {
+            "type": "self_rag",
+            "initial_prompt_template": self._initial_prompt_template,
+            "reflection_prompt_template": self._reflection_prompt_template,
+            "revision_prompt_template": self._revision_prompt_template,
+            "max_reflection_steps": self.max_reflection_steps,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    def _format_context(self, chunk_contents: list[str]) -> str:
+        if not chunk_contents:
+            return "(No retrieved context yet)"
+        return "\n\n".join(f"[{index}] {content}" for index, content in enumerate(chunk_contents, start=1))
+
+    def _format_critique_history(self, critiques: list[str]) -> str:
+        if not critiques:
+            return "(No previous critiques)"
+        return "\n".join(f"[{index}] {critique}" for index, critique in enumerate(critiques, start=1))
+
+    def _build_initial_prompt(self, query: str) -> str:
+        return self._initial_prompt_template.format(query=query)
+
+    def _build_reflection_prompt(
+        self,
+        query: str,
+        answer: str,
+        chunk_contents: list[str],
+        critiques: list[str],
+    ) -> str:
+        return self._reflection_prompt_template.format(
+            query=query,
+            answer=answer,
+            context=self._format_context(chunk_contents),
+            critique_history=self._format_critique_history(critiques),
+        )
+
+    def _build_revision_prompt(
+        self,
+        query: str,
+        answer: str,
+        chunk_contents: list[str],
+        critique: str,
+    ) -> str:
+        return self._revision_prompt_template.format(
+            query=query,
+            answer=answer,
+            context=self._format_context(chunk_contents),
+            critique=critique or "Improve grounding and specificity.",
+        )
+
+    def _parse_key_value_reflection(self, response_text: str) -> dict[str, Any]:
+        parsed: dict[str, Any] = {
+            "action": "FINISH",
+            "supported": False,
+            "search_query": "",
+            "critique": response_text.strip(),
+        }
+
+        for line in response_text.splitlines():
+            if ":" not in line:
+                continue
+            raw_key, raw_value = line.split(":", 1)
+            key = raw_key.strip().upper()
+            value = raw_value.strip()
+
+            if key == "ACTION":
+                normalized_action = value.upper()
+                if normalized_action in {"FINISH", "RETRIEVE", "REVISE"}:
+                    parsed["action"] = normalized_action
+            elif key == "SUPPORTED":
+                parsed["supported"] = value.lower() in {"yes", "true", "supported"}
+            elif key in {"SEARCH_QUERY", "FOLLOW_UP_QUERY"}:
+                parsed["search_query"] = value
+            elif key == "CRITIQUE" and value:
+                parsed["critique"] = value
+
+        return parsed
+
+    def _parse_reflection(self, response_text: str) -> dict[str, Any]:
+        stripped = response_text.strip()
+        if stripped.startswith("{"):
+            try:
+                payload = json.loads(stripped)
+                should_retrieve = bool(payload.get("should_retrieve", False))
+                supported = bool(payload.get("is_supported", False))
+                if should_retrieve:
+                    action = "RETRIEVE"
+                elif supported:
+                    action = "FINISH"
+                else:
+                    action = "REVISE"
+                return {
+                    "action": action,
+                    "supported": supported,
+                    "search_query": payload.get("follow_up_query", "") or payload.get("search_query", ""),
+                    "critique": payload.get("critique", stripped),
+                }
+            except json.JSONDecodeError:
+                logger.warning("Failed to parse Self-RAG reflection JSON; falling back to key-value parsing")
+
+        return self._parse_key_value_reflection(stripped)
+
+    async def _ainvoke_text(self, prompt: str, tracker: TokenUsageTracker) -> str:
+        response = await self._llm.ainvoke(prompt)
+        tracker.record(response)
+        return response.content if hasattr(response, "content") else str(response)
+
+    def _extend_context(
+        self,
+        retrieved_results: list[dict[str, Any]],
+        retrieved_chunk_ids: list[int | str],
+        retrieved_scores: list[float | int],
+        chunk_contents: list[str],
+    ) -> None:
+        new_chunk_ids: list[int | str] = []
+        for result in retrieved_results:
+            doc_id = result.get("doc_id")
+            if doc_id is None or doc_id in retrieved_chunk_ids:
+                continue
+            new_chunk_ids.append(doc_id)
+            retrieved_chunk_ids.append(doc_id)
+            retrieved_scores.append(result.get("score", 0.0))
+
+        if new_chunk_ids:
+            chunk_contents.extend(self._service.get_chunk_contents(new_chunk_ids))
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        query = self._service.get_query_text(query_id)
+        tracker = TokenUsageTracker()
+
+        current_answer = await self._ainvoke_text(self._build_initial_prompt(query), tracker)
+
+        chunk_contents: list[str] = []
+        critiques: list[str] = []
+        reflection_actions: list[str] = []
+        retrieval_queries: list[str] = []
+        retrieved_chunk_ids: list[int | str] = []
+        retrieved_scores: list[float | int] = []
+        final_supported = False
+
+        for _ in range(self.max_reflection_steps):
+            reflection_text = await self._ainvoke_text(
+                self._build_reflection_prompt(query, current_answer, chunk_contents, critiques),
+                tracker,
+            )
+            reflection = self._parse_reflection(reflection_text)
+            action = reflection["action"]
+            critique = reflection["critique"]
+            final_supported = bool(reflection["supported"])
+
+            reflection_actions.append(action)
+            critiques.append(critique)
+
+            if action == "FINISH":
+                break
+
+            if action == "RETRIEVE":
+                search_query = reflection["search_query"] or query
+                retrieval_queries.append(search_query)
+                retrieved = await self._retrieval_pipeline.retrieve(search_query, top_k)
+                self._extend_context(retrieved, retrieved_chunk_ids, retrieved_scores, chunk_contents)
+
+            current_answer = await self._ainvoke_text(
+                self._build_revision_prompt(query, current_answer, chunk_contents, critique),
+                tracker,
+            )
+
+        reflection_iterations = sum(1 for action in reflection_actions if action != "FINISH")
+
+        return GenerationResult(
+            text=current_answer,
+            token_usage=tracker.total,
+            metadata={
+                "pipeline_type": "self_rag",
+                "reflection_actions": reflection_actions,
+                "reflection_iterations": reflection_iterations,
+                "retrieval_queries": retrieval_queries,
+                "retrieved_chunk_ids": retrieved_chunk_ids,
+                "retrieved_scores": retrieved_scores,
+                "critiques": critiques,
+                "final_supported": final_supported,
+                "used_retrieval": bool(retrieval_queries),
+                "support_passed": final_supported,
+            },
+        )
+
+
+@dataclass(kw_only=True)
+class SelfRAGPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for the prompt-based Self-RAG pipeline."""
+
+    initial_prompt_template: str = field(default=DEFAULT_INITIAL_PROMPT)
+    reflection_prompt_template: str = field(default=DEFAULT_REFLECTION_PROMPT)
+    revision_prompt_template: str = field(default=DEFAULT_REVISION_PROMPT)
+    max_reflection_steps: int = 3
+
+    def get_pipeline_class(self) -> type["SelfRAGPipeline"]:
+        return SelfRAGPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "initial_prompt_template": self.initial_prompt_template,
+            "reflection_prompt_template": self.reflection_prompt_template,
+            "revision_prompt_template": self.revision_prompt_template,
+            "max_reflection_steps": self.max_reflection_steps,
+        }

--- a/autorag_research/pipelines/generation/self_rag.py
+++ b/autorag_research/pipelines/generation/self_rag.py
@@ -169,6 +169,13 @@ class SelfRAGPipeline(BaseGenerationPipeline):
             return default
         return bool(value)
 
+    def _resolve_reflection_action(self, should_retrieve: bool, supported: bool) -> str:
+        if should_retrieve:
+            return "RETRIEVE"
+        if supported:
+            return "FINISH"
+        return "REVISE"
+
     def _parse_key_value_reflection(self, response_text: str) -> dict[str, Any]:
         parsed: dict[str, Any] = {
             "action": "FINISH",
@@ -176,6 +183,8 @@ class SelfRAGPipeline(BaseGenerationPipeline):
             "search_query": "",
             "critique": response_text.strip(),
         }
+        should_retrieve_flag: bool | None = None
+        supported_flag: bool | None = None
 
         for line in response_text.splitlines():
             if ":" not in line:
@@ -188,12 +197,21 @@ class SelfRAGPipeline(BaseGenerationPipeline):
                 normalized_action = value.upper()
                 if normalized_action in {"FINISH", "RETRIEVE", "REVISE"}:
                     parsed["action"] = normalized_action
-            elif key == "SUPPORTED":
-                parsed["supported"] = self._coerce_reflection_flag(value)
+            elif key == "SHOULD_RETRIEVE":
+                should_retrieve_flag = self._coerce_reflection_flag(value)
+            elif key in {"SUPPORTED", "IS_SUPPORTED"}:
+                supported_flag = self._coerce_reflection_flag(value)
+                parsed["supported"] = supported_flag
             elif key in {"SEARCH_QUERY", "FOLLOW_UP_QUERY"}:
                 parsed["search_query"] = value
             elif key == "CRITIQUE" and value:
                 parsed["critique"] = value
+
+        if should_retrieve_flag is not None or supported_flag is not None:
+            parsed["action"] = self._resolve_reflection_action(
+                should_retrieve=should_retrieve_flag or False,
+                supported=supported_flag or False,
+            )
 
         return parsed
 
@@ -204,14 +222,8 @@ class SelfRAGPipeline(BaseGenerationPipeline):
                 payload = json.loads(stripped)
                 should_retrieve = self._coerce_reflection_flag(payload.get("should_retrieve", False))
                 supported = self._coerce_reflection_flag(payload.get("is_supported", False))
-                if should_retrieve:
-                    action = "RETRIEVE"
-                elif supported:
-                    action = "FINISH"
-                else:
-                    action = "REVISE"
                 return {
-                    "action": action,
+                    "action": self._resolve_reflection_action(should_retrieve, supported),
                     "supported": supported,
                     "search_query": payload.get("follow_up_query", "") or payload.get("search_query", ""),
                     "critique": payload.get("critique", stripped),

--- a/configs/pipelines/generation/self_rag.yaml
+++ b/configs/pipelines/generation/self_rag.yaml
@@ -1,0 +1,61 @@
+# Self-RAG Generation Pipeline Configuration
+#
+# Prompt-based approximation of Self-RAG for AutoRAG-Research.
+# The pipeline drafts an answer, reflects on whether retrieval is needed,
+# retrieves evidence only when required, and revises the answer until it is
+# supported or the reflection budget is exhausted.
+#
+# This is not the original fine-tuned reflection-token model.
+
+_target_: autorag_research.pipelines.generation.self_rag.SelfRAGPipelineConfig
+description: "Self-RAG: prompt-based self-reflective generation"
+name: self_rag
+retrieval_pipeline_name: bm25
+llm: gpt-4o-mini
+max_reflection_steps: 3
+top_k: 4
+batch_size: 10
+initial_prompt_template: |
+  You are answering a question without external evidence.
+
+  Question: {query}
+
+  Provide your best concise answer. If you are uncertain, answer briefly and leave room for later revision.
+
+  Answer:
+reflection_prompt_template: |
+  You are a Self-RAG controller deciding whether an answer needs retrieval or revision.
+
+  Question: {query}
+
+  Current Answer:
+  {answer}
+
+  Retrieved Context:
+  {context}
+
+  Critique History:
+  {critique_history}
+
+  Respond as JSON with this schema:
+  {
+    "should_retrieve": true or false,
+    "is_supported": true or false,
+    "follow_up_query": "optional refined retrieval query",
+    "critique": "short critique of the current answer"
+  }
+revision_prompt_template: |
+  Revise the answer so it is grounded in the retrieved context.
+
+  Question: {query}
+
+  Current Answer:
+  {answer}
+
+  Retrieved Context:
+  {context}
+
+  Critique:
+  {critique}
+
+  Return only the revised answer.

--- a/docs/pipelines/generation/index.md
+++ b/docs/pipelines/generation/index.md
@@ -8,6 +8,7 @@ Algorithms that take a query and retrieved documents to generate an answer.
 |----------|-----------|
 | [BasicRAG](basic-rag.md) | Single retrieve + generate |
 | [IRCoT](ircot.md) | Iterative retrieve + chain-of-thought reasoning |
+| [SelfRAG](self-rag.md) | Draft, critique, retrieve, and revise adaptively |
 
 ## Base Class
 

--- a/docs/pipelines/generation/self-rag.md
+++ b/docs/pipelines/generation/self-rag.md
@@ -1,0 +1,38 @@
+# SelfRAG
+
+SelfRAG is implemented here as a **generation pipeline** that composes an existing retrieval pipeline. This repo does **not** reproduce the paper's fine-tuned reflection-token model. Instead, it uses a prompt-based approximation that:
+
+1. drafts an answer without retrieval,
+2. reflects on whether evidence is needed,
+3. retrieves only when reflection requests it,
+4. revises the answer against retrieved evidence, and
+5. stops once the answer is judged supported or the reflection budget is exhausted.
+
+## Classification
+
+SelfRAG is **not a pure retrieval pipeline** in this repository's architecture. It belongs in generation because retrieval is only one tool inside the answer-generation loop.
+
+## Configuration
+
+```yaml
+_target_: autorag_research.pipelines.generation.self_rag.SelfRAGPipelineConfig
+name: self_rag
+retrieval_pipeline_name: bm25
+llm: gpt-4o-mini
+max_reflection_steps: 3
+top_k: 4
+```
+
+## Main Parameters
+
+- `retrieval_pipeline_name`: retrieval pipeline composed into SelfRAG
+- `llm`: model used for drafting, reflection, and revision
+- `max_reflection_steps`: maximum number of reflection iterations
+- `initial_prompt_template`: initial answer prompt
+- `reflection_prompt_template`: structured reflection prompt
+- `revision_prompt_template`: answer revision prompt
+
+## Notes
+
+- This implementation is a **prompt-based approximation** suitable for benchmarking within the existing pipeline abstractions.
+- The reflection prompt defaults to JSON output (`should_retrieve`, `is_supported`, `follow_up_query`, `critique`) and also tolerates simple `KEY: value` lines for experimentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Generation:
           - pipelines/generation/index.md
           - pipelines/generation/basic-rag.md
+          - pipelines/generation/self-rag.md
   - Embeddings:
       - embeddings/index.md
       - embeddings/infinity.md

--- a/tests/autorag_research/orm/repository/test_image_chunk_retrieved_result.py
+++ b/tests/autorag_research/orm/repository/test_image_chunk_retrieved_result.py
@@ -70,7 +70,7 @@ def test_bulk_insert(
     assert inserted_count == 2
 
     results = image_chunk_retrieved_result_repository.get_by_query_and_pipeline([2, 4], 2)
-    assert len(results) == 3
+    assert len(results) == 2
 
     # Cleanup
     image_chunk_retrieved_result_repository.delete_by_query_and_pipeline(4, 2)

--- a/tests/autorag_research/orm/repository/test_image_chunk_retrieved_result.py
+++ b/tests/autorag_research/orm/repository/test_image_chunk_retrieved_result.py
@@ -59,6 +59,7 @@ def test_bulk_insert(
     image_chunk_retrieved_result_repository: ImageChunkRetrievedResultRepository,
     db_session: Session,
 ):
+    inserted_keys = {(2, 2, 2), (4, 2, 1)}
     results_to_insert = [
         {"query_id": 4, "pipeline_id": 2, "image_chunk_id": 1, "rel_score": 0.75},
         {"query_id": 2, "pipeline_id": 2, "image_chunk_id": 2, "rel_score": 0.65},
@@ -70,9 +71,13 @@ def test_bulk_insert(
     assert inserted_count == 2
 
     results = image_chunk_retrieved_result_repository.get_by_query_and_pipeline([2, 4], 2)
-    assert len(results) == 2
+    assert len(results) == 3
+    assert {(result.query_id, result.pipeline_id, result.image_chunk_id) for result in results} == inserted_keys | {
+        (4, 2, 2)
+    }
 
     # Cleanup
-    image_chunk_retrieved_result_repository.delete_by_query_and_pipeline(4, 2)
-    image_chunk_retrieved_result_repository.delete_by_query_and_pipeline(2, 2)
+    for result in results:
+        if (result.query_id, result.pipeline_id, result.image_chunk_id) in inserted_keys:
+            db_session.delete(result)
     db_session.commit()

--- a/tests/autorag_research/orm/repository/test_image_chunk_retrieved_result.py
+++ b/tests/autorag_research/orm/repository/test_image_chunk_retrieved_result.py
@@ -2,7 +2,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from autorag_research.orm.repository.image_chunk_retrieved_result import ImageChunkRetrievedResultRepository
-from autorag_research.orm.schema import ImageChunkRetrievedResult
+from autorag_research.orm.schema import ImageChunk, ImageChunkRetrievedResult, Pipeline, Query
 
 
 @pytest.fixture
@@ -59,10 +59,34 @@ def test_bulk_insert(
     image_chunk_retrieved_result_repository: ImageChunkRetrievedResultRepository,
     db_session: Session,
 ):
-    inserted_keys = {(2, 2, 2), (4, 2, 1)}
+    test_queries = [Query(contents="bulk insert query 1"), Query(contents="bulk insert query 2")]
+    test_pipeline = Pipeline(name="bulk_insert_pipeline", config={"type": "test"})
+    test_image_chunks = [
+        ImageChunk(contents=b"chunk-1", mimetype="image/png"),
+        ImageChunk(contents=b"chunk-2", mimetype="image/png"),
+    ]
+    db_session.add_all([*test_queries, test_pipeline, *test_image_chunks])
+    db_session.flush()
+
+    query_ids = [query.id for query in test_queries]
+    pipeline_id = test_pipeline.id
+    inserted_keys = {
+        (query_ids[0], pipeline_id, test_image_chunks[0].id),
+        (query_ids[1], pipeline_id, test_image_chunks[1].id),
+    }
     results_to_insert = [
-        {"query_id": 4, "pipeline_id": 2, "image_chunk_id": 1, "rel_score": 0.75},
-        {"query_id": 2, "pipeline_id": 2, "image_chunk_id": 2, "rel_score": 0.65},
+        {
+            "query_id": query_ids[0],
+            "pipeline_id": pipeline_id,
+            "image_chunk_id": test_image_chunks[0].id,
+            "rel_score": 0.75,
+        },
+        {
+            "query_id": query_ids[1],
+            "pipeline_id": pipeline_id,
+            "image_chunk_id": test_image_chunks[1].id,
+            "rel_score": 0.65,
+        },
     ]
 
     inserted_count = image_chunk_retrieved_result_repository.bulk_insert(results_to_insert)
@@ -70,14 +94,19 @@ def test_bulk_insert(
 
     assert inserted_count == 2
 
-    results = image_chunk_retrieved_result_repository.get_by_query_and_pipeline([2, 4], 2)
-    assert len(results) == 3
-    assert {(result.query_id, result.pipeline_id, result.image_chunk_id) for result in results} == inserted_keys | {
-        (4, 2, 2)
-    }
+    results = image_chunk_retrieved_result_repository.get_by_query_and_pipeline(query_ids, pipeline_id)
+    result_keys = {(result.query_id, result.pipeline_id, result.image_chunk_id) for result in results}
+
+    assert len(results) == len(inserted_keys)
+    assert result_keys == inserted_keys
 
     # Cleanup
     for result in results:
         if (result.query_id, result.pipeline_id, result.image_chunk_id) in inserted_keys:
             db_session.delete(result)
+    for image_chunk in test_image_chunks:
+        db_session.delete(image_chunk)
+    db_session.delete(test_pipeline)
+    for query in test_queries:
+        db_session.delete(query)
     db_session.commit()

--- a/tests/autorag_research/orm/service/test_generation_pipeline.py
+++ b/tests/autorag_research/orm/service/test_generation_pipeline.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from autorag_research.orm.repository.query import QueryRepository
@@ -40,8 +42,9 @@ class TestGenerationPipelineService:
             service.delete_pipeline_results(pipeline_id)
 
     def test_get_or_create_pipeline(self, service, cleanup_pipeline_results):
+        pipeline_name = f"test_gen_pipeline_{uuid.uuid4().hex[:8]}"
         pipeline_id, is_new = service.get_or_create_pipeline(
-            name="test_gen_pipeline",
+            name=pipeline_name,
             config={"type": "naive_rag", "model": "test-model"},
         )
         cleanup_pipeline_results.append(pipeline_id)

--- a/tests/autorag_research/pipelines/generation/test_self_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_self_rag_pipeline.py
@@ -87,6 +87,23 @@ class TestSelfRAGPipelineBehavior:
             "critique": "Need revision",
         }
 
+    def test_parse_reflection_accepts_key_value_aliases(self):
+        """Self-RAG key-value fallback parsing should honor should_retrieve/is_supported aliases."""
+        from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline
+
+        pipeline = SelfRAGPipeline.__new__(SelfRAGPipeline)
+
+        reflection = pipeline._parse_reflection(
+            "should_retrieve: true\nis_supported: false\nfollow_up_query: largest planet\ncritique: need evidence"
+        )
+
+        assert reflection == {
+            "action": "RETRIEVE",
+            "supported": False,
+            "search_query": "largest planet",
+            "critique": "need evidence",
+        }
+
     @pytest.mark.asyncio
     async def test_generate_skips_retrieval_when_initial_answer_is_supported(
         self, session_factory, cleanup, mock_retrieval_pipeline

--- a/tests/autorag_research/pipelines/generation/test_self_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_self_rag_pipeline.py
@@ -70,6 +70,23 @@ class TestSelfRAGPipelineConfig:
 
 
 class TestSelfRAGPipelineBehavior:
+    def test_parse_reflection_treats_string_booleans_as_booleans(self):
+        """Self-RAG JSON reflection parsing should honor quoted true/false values."""
+        from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline
+
+        pipeline = SelfRAGPipeline.__new__(SelfRAGPipeline)
+
+        reflection = pipeline._parse_reflection(
+            '{"should_retrieve": "false", "is_supported": "false", "critique": "Need revision"}'
+        )
+
+        assert reflection == {
+            "action": "REVISE",
+            "supported": False,
+            "search_query": "",
+            "critique": "Need revision",
+        }
+
     @pytest.mark.asyncio
     async def test_generate_skips_retrieval_when_initial_answer_is_supported(
         self, session_factory, cleanup, mock_retrieval_pipeline

--- a/tests/autorag_research/pipelines/generation/test_self_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_self_rag_pipeline.py
@@ -1,0 +1,197 @@
+"""Tests for the prompt-based Self-RAG generation pipeline."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.autorag_research.pipelines.pipeline_test_utils import (
+    PipelineTestConfig,
+    PipelineTestVerifier,
+    cleanup_pipeline_results_factory,
+    create_mock_llm,
+)
+
+
+def create_sequential_llm(responses: list[str]) -> MagicMock:
+    """Create a mock LLM that returns responses in sequence."""
+    mock = MagicMock()
+    call_count = [0]
+
+    async def mock_ainvoke(prompt):
+        response = MagicMock()
+        response.content = responses[min(call_count[0], len(responses) - 1)]
+        response.usage_metadata = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        response.response_metadata = {}
+        call_count[0] += 1
+        return response
+
+    mock.ainvoke = AsyncMock(side_effect=mock_ainvoke)
+    return mock
+
+
+@pytest.fixture
+def cleanup(session_factory):
+    """Cleanup fixture for created pipeline results."""
+    yield from cleanup_pipeline_results_factory(session_factory)
+
+
+@pytest.fixture
+def mock_retrieval_pipeline():
+    """Create a retrieval pipeline mock for Self-RAG tests."""
+    mock = MagicMock()
+    mock.pipeline_id = 1
+    mock.retrieve = AsyncMock(
+        return_value=[
+            {"doc_id": 1, "score": 0.95},
+            {"doc_id": 2, "score": 0.85},
+        ]
+    )
+    mock._retrieve_by_id = AsyncMock(return_value=[])
+    return mock
+
+
+class TestSelfRAGPipelineConfig:
+    def test_config_exposes_pipeline_class_and_kwargs(self, mock_retrieval_pipeline):
+        """SelfRAG config should return the pipeline class and injected kwargs."""
+        from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline, SelfRAGPipelineConfig
+
+        config = SelfRAGPipelineConfig(
+            name="self_rag_config",
+            llm=create_mock_llm(),
+            retrieval_pipeline_name="bm25_baseline",
+            max_reflection_steps=3,
+        )
+        config.inject_retrieval_pipeline(mock_retrieval_pipeline)
+
+        assert config.get_pipeline_class() is SelfRAGPipeline
+        kwargs = config.get_pipeline_kwargs()
+        assert kwargs["retrieval_pipeline"] is mock_retrieval_pipeline
+        assert kwargs["max_reflection_steps"] == 3
+
+
+class TestSelfRAGPipelineBehavior:
+    @pytest.mark.asyncio
+    async def test_generate_skips_retrieval_when_initial_answer_is_supported(
+        self, session_factory, cleanup, mock_retrieval_pipeline
+    ):
+        """Self-RAG should return the draft answer when reflection says no retrieval is needed."""
+        from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline
+
+        pipeline = SelfRAGPipeline(
+            session_factory=session_factory,
+            name="test_self_rag_no_retrieval",
+            llm=create_sequential_llm([
+                "Draft answer without retrieval.",
+                '{"should_retrieve": false, "is_supported": true, "critique": "Enough evidence in parametric memory."}',
+            ]),
+            retrieval_pipeline=mock_retrieval_pipeline,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=2)
+
+        assert result.text == "Draft answer without retrieval."
+        assert result.metadata["used_retrieval"] is False
+        assert result.metadata["support_passed"] is True
+        assert result.metadata["retrieved_chunk_ids"] == []
+        mock_retrieval_pipeline.retrieve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_retrieves_and_revises_until_supported(
+        self, session_factory, cleanup, mock_retrieval_pipeline
+    ):
+        """Self-RAG should retrieve evidence, revise, and stop once support passes."""
+        from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline
+
+        pipeline = SelfRAGPipeline(
+            session_factory=session_factory,
+            name="test_self_rag_revision",
+            llm=create_sequential_llm([
+                "Initial uncertain answer.",
+                '{"should_retrieve": true, "is_supported": false, "follow_up_query": "largest planet in solar system", "critique": "Need evidence."}',
+                "Jupiter is the largest planet in the Solar System.",
+                '{"should_retrieve": false, "is_supported": true, "critique": "The revised answer is supported."}',
+            ]),
+            retrieval_pipeline=mock_retrieval_pipeline,
+            max_reflection_steps=2,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=2)
+
+        assert result.text == "Jupiter is the largest planet in the Solar System."
+        assert result.metadata["used_retrieval"] is True
+        assert result.metadata["support_passed"] is True
+        assert result.metadata["reflection_iterations"] == 1
+        assert result.metadata["retrieved_chunk_ids"] == [1, 2]
+        mock_retrieval_pipeline.retrieve.assert_awaited_once_with("largest planet in solar system", 2)
+
+    @pytest.mark.asyncio
+    async def test_generate_stops_after_max_reflection_steps(self, session_factory, cleanup, mock_retrieval_pipeline):
+        """Self-RAG should return the last revision when support never passes."""
+        from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline
+
+        pipeline = SelfRAGPipeline(
+            session_factory=session_factory,
+            name="test_self_rag_max_steps",
+            llm=create_sequential_llm([
+                "Draft answer.",
+                '{"should_retrieve": true, "is_supported": false, "follow_up_query": "largest planet", "critique": "Need evidence."}',
+                "First revision.",
+                '{"should_retrieve": true, "is_supported": false, "follow_up_query": "gas giant biggest", "critique": "Still unsupported."}',
+                "Second revision.",
+                '{"should_retrieve": true, "is_supported": false, "critique": "Still unsupported."}',
+            ]),
+            retrieval_pipeline=mock_retrieval_pipeline,
+            max_reflection_steps=2,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=2)
+
+        assert result.text == "Second revision."
+        assert result.metadata["used_retrieval"] is True
+        assert result.metadata["support_passed"] is False
+        assert result.metadata["reflection_iterations"] == 2
+        assert mock_retrieval_pipeline.retrieve.await_count == 2
+
+    def test_run_pipeline_with_verifier(self, session_factory, cleanup, mock_retrieval_pipeline):
+        """Self-RAG should integrate with the standard generation pipeline runner."""
+        from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline
+
+        llm = create_sequential_llm(
+            [
+                "Initial uncertain answer.",
+                '{"should_retrieve": true, "is_supported": false, "follow_up_query": "largest planet in solar system", "critique": "Need evidence."}',
+                "Jupiter is the largest planet in the Solar System.",
+                '{"should_retrieve": false, "is_supported": true, "critique": "The revised answer is supported."}',
+            ]
+            * 5
+        )
+
+        pipeline = SelfRAGPipeline(
+            session_factory=session_factory,
+            name="test_self_rag_run",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval_pipeline,
+            max_reflection_steps=2,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = pipeline.run(top_k=2, batch_size=10)
+
+        verifier = PipelineTestVerifier(
+            result,
+            pipeline.pipeline_id,
+            session_factory,
+            PipelineTestConfig(
+                pipeline_type="generation",
+                expected_total_queries=5,
+                check_token_usage=True,
+                check_execution_time=True,
+                check_persistence=True,
+            ),
+        )
+        report = verifier.verify_all()
+
+        assert report.all_passed


### PR DESCRIPTION
## Summary
- add a prompt-based `SelfRAGPipeline` as a generation pipeline that composes retrieval, reflects on support, and revises answers adaptively
- add config/docs/examples and focused regression coverage for direct-answer, retrieval/revision, and runner integration paths
- harden pipeline ordering and repository/service tests so the verified full suite stays deterministic across clean reruns

## Verification
- `make check`
- `make clean-docker && make docker-up && make docker-wait && make test-only`
- `uv run pytest -q tests/autorag_research/pipelines/generation/test_self_rag_pipeline.py`

<!-- dani:stage=implementation;job=b4c56b994aab4bea838ddd24a81b826f;issue=87 -->
