### PR TITLE
Feature/#118

### DIFF
--- a/autorag_research/data/crag.py
+++ b/autorag_research/data/crag.py
@@ -136,7 +136,9 @@ class CRAGIngestor(TextEmbeddingDataIngestor):
         target_split = _resolve_subset(subset)
         if subset == "train":
             logger.warning(
-                "CRAG does not publish a train split in the supported source file; using the dev split instead."
+                "CRAG does not publish a train split in the supported source file; using the dev split instead. "
+                "Ingesting both subset='train' and subset='dev' will duplicate the same upstream examples under "
+                "different IDs."
             )
         if min_corpus_cnt is not None:
             logger.warning(

--- a/autorag_research/data/crag.py
+++ b/autorag_research/data/crag.py
@@ -1,0 +1,204 @@
+import logging
+import re
+from html import unescape
+from html.parser import HTMLParser
+from typing import Any, Literal
+
+from datasets import load_dataset
+from langchain_core.embeddings import Embeddings
+
+from autorag_research.data.base import TextEmbeddingDataIngestor
+from autorag_research.data.registry import register_ingestor
+from autorag_research.data.util import make_id
+from autorag_research.exceptions import ServiceNotSetError, UnsupportedDataSubsetError
+
+logger = logging.getLogger("AutoRAG-Research")
+
+CRAG_DATA_URL = "https://github.com/facebookresearch/CRAG/raw/refs/heads/main/data/crag_task_1_and_2_dev_v4.jsonl.bz2"
+CRAG_SUBSET_TO_SPLIT = {
+    "train": 0,
+    "dev": 0,
+    "test": 1,
+}
+DEFAULT_BATCH_SIZE = 100
+
+
+class _HTMLTextExtractor(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._parts: list[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style"} and self._skip_depth > 0:
+            self._skip_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth == 0 and data:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        return _normalize_text(" ".join(self._parts))
+
+
+def _normalize_text(value: str | None) -> str:
+    if not value:
+        return ""
+    return re.sub(r"\s+", " ", unescape(value)).strip()
+
+
+def _resolve_subset(subset: str) -> int:
+    if subset not in CRAG_SUBSET_TO_SPLIT:
+        raise UnsupportedDataSubsetError([subset])
+    return CRAG_SUBSET_TO_SPLIT[subset]
+
+
+def _make_query_id(subset: str, interaction_id: str) -> str:
+    return make_id("crag", subset, interaction_id)
+
+
+def _make_chunk_id(subset: str, interaction_id: str, result_index: int) -> str:
+    return make_id("crag", subset, interaction_id, result_index)
+
+
+def _extract_page_text(page_result: str | None) -> str:
+    if not page_result:
+        return ""
+
+    parser = _HTMLTextExtractor()
+    parser.feed(page_result)
+    parser.close()
+    extracted = parser.get_text()
+    if extracted:
+        return extracted
+
+    stripped = re.sub(r"<[^>]+>", " ", page_result)
+    return _normalize_text(stripped)
+
+
+def _build_generation_gt(answer: str | None, alt_ans: list[str] | None) -> list[str] | None:
+    deduped_answers: list[str] = []
+    seen: set[str] = set()
+
+    for candidate in [answer, *(alt_ans or [])]:
+        normalized = _normalize_text(candidate)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped_answers.append(normalized)
+
+    return deduped_answers or None
+
+
+def _format_search_result_contents(search_result: dict[str, Any]) -> str:
+    title = _normalize_text(search_result.get("page_name"))
+    url = _normalize_text(search_result.get("page_url"))
+    snippet = _normalize_text(search_result.get("page_snippet"))
+    last_modified = _normalize_text(search_result.get("page_last_modified"))
+    page_text = _extract_page_text(search_result.get("page_result"))
+    content = page_text or snippet
+
+    sections = [
+        ("Title", title),
+        ("URL", url),
+        ("Snippet", snippet),
+        ("Last Modified", last_modified),
+        ("Content", content),
+    ]
+    return "\n".join(f"{label}: {value}" for label, value in sections if value)
+
+
+@register_ingestor(
+    name="crag",
+    description="CRAG benchmark for generation-oriented RAG evaluation using search-result pages",
+)
+class CRAGIngestor(TextEmbeddingDataIngestor):
+    def __init__(self, embedding_model: Embeddings, batch_size: int = DEFAULT_BATCH_SIZE):
+        super().__init__(embedding_model)
+        self.batch_size = batch_size
+
+    def detect_primary_key_type(self) -> Literal["bigint", "string"]:
+        return "string"
+
+    def ingest(
+        self,
+        subset: Literal["train", "dev", "test"] = "test",
+        query_limit: int | None = None,
+        min_corpus_cnt: int | None = None,
+    ) -> None:
+        if self.service is None:
+            raise ServiceNotSetError
+
+        target_split = _resolve_subset(subset)
+        if subset == "train":
+            logger.warning(
+                "CRAG does not publish a train split in the supported source file; using the dev split instead."
+            )
+        if min_corpus_cnt is not None:
+            logger.warning(
+                "min_corpus_cnt is ineffective for CRAG. Each query ships with its own search results rather than a shared corpus."
+            )
+
+        dataset = load_dataset("json", data_files=CRAG_DATA_URL, split="train", streaming=True)
+
+        batch: list[dict[str, Any]] = []
+        total_processed = 0
+
+        for example in dataset:
+            example_dict: dict[str, Any] = example
+            if example_dict.get("split") != target_split:
+                continue
+
+            batch.append(example_dict)
+
+            if len(batch) >= self.batch_size:
+                self._process_batch(subset, batch)
+                total_processed += len(batch)
+                batch = []
+                logger.info(f"[crag:{subset}] Processed {total_processed} examples...")
+
+            if query_limit is not None and total_processed + len(batch) >= query_limit:
+                remaining = query_limit - total_processed
+                batch = batch[:remaining]
+                break
+
+        if batch:
+            self._process_batch(subset, batch)
+            total_processed += len(batch)
+
+        logger.info(f"[crag:{subset}] Total examples processed: {total_processed}")
+        self.service.clean()
+        logger.info("CRAG ingestion complete.")
+
+    def _process_batch(self, subset: str, examples: list[dict[str, Any]]) -> None:
+        if self.service is None:
+            raise ServiceNotSetError
+
+        queries: list[dict[str, str | list[str] | None]] = []
+        chunks: list[dict[str, str | int | bool | None]] = []
+
+        for example in examples:
+            interaction_id = str(example["interaction_id"])
+            queries.append({
+                "id": _make_query_id(subset, interaction_id),
+                "contents": example["query"],
+                "generation_gt": _build_generation_gt(example.get("answer"), example.get("alt_ans")),
+            })
+
+            for result_index, search_result in enumerate(example.get("search_results", [])):
+                chunk_contents = _format_search_result_contents(search_result)
+                if not chunk_contents:
+                    continue
+                chunks.append({
+                    "id": _make_chunk_id(subset, interaction_id, result_index),
+                    "contents": chunk_contents,
+                })
+
+        if chunks:
+            self.service.add_chunks(chunks)
+        if queries:
+            self.service.add_queries(queries)

--- a/docs/datasets/index.md
+++ b/docs/datasets/index.md
@@ -9,6 +9,7 @@ Available benchmarks for RAG evaluation.
 | BEIR | Text | 300-15k | 3k-5M | No | Retrieval |
 | MTEB | Text | varies | varies | No | Retrieval |
 | RAGBench | Text | varies | varies | Yes | RAG |
+| CRAG | Text | varies | varies | Yes | RAG / Generation |
 | MrTyDi | Text | varies | varies | No | Multilingual |
 | BRIGHT | Text | varies | varies | No | Retrieval |
 | Open-RAGBench | Multimodal | varies | varies | Yes | RAG |

--- a/docs/datasets/text/crag.md
+++ b/docs/datasets/text/crag.md
@@ -1,0 +1,47 @@
+# CRAG
+
+Comprehensive RAG Benchmark support for generation-oriented evaluation with provided web search results.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Modality | Text |
+| Generation GT | Yes |
+| Retrieval GT | No |
+| Source | facebookresearch/CRAG Task 1/2 dev file |
+
+## Description
+
+CRAG (Comprehensive RAG Benchmark) pairs factual questions with gold answers and per-query web search results.
+This ingestor currently supports the Task 1/2 development dataset and stores:
+
+- queries as `Query.contents`
+- `answer` + `alt_ans` as `generation_gt`
+- each `search_results[*]` entry as a text chunk built from title, URL, snippet, last-modified time, and extracted HTML text
+
+## Scope Notes
+
+- `subset=dev` maps to CRAG `split=0`
+- `subset=test` maps to CRAG `split=1`
+- `subset=train` currently aliases the public dev split because the supported source file does not publish a separate train split
+- retrieval relevance labels are **not** created because CRAG search results are candidate context, not authoritative qrels
+- `min_corpus_cnt` is ignored because CRAG examples already carry their own per-query search results
+
+## Ingest from Source
+
+```bash
+autorag-research ingest --name=crag --embedding-model=openai-small
+```
+
+Optional split selection:
+
+```bash
+autorag-research ingest --name=crag --subset=dev --embedding-model=openai-small
+```
+
+## Best For
+
+- generation-focused RAG evaluation
+- answer-grounded benchmarking with realistic web context
+- experiments that need per-query search results without assuming retrieval qrels

--- a/docs/datasets/text/crag.md
+++ b/docs/datasets/text/crag.md
@@ -25,6 +25,7 @@ This ingestor currently supports the Task 1/2 development dataset and stores:
 - `subset=dev` maps to CRAG `split=0`
 - `subset=test` maps to CRAG `split=1`
 - `subset=train` currently aliases the public dev split because the supported source file does not publish a separate train split
+- ingesting both `subset=train` and `subset=dev` into the same database duplicates the same upstream examples under different IDs
 - retrieval relevance labels are **not** created because CRAG search results are candidate context, not authoritative qrels
 - `min_corpus_cnt` is ignored because CRAG examples already carry their own per-query search results
 

--- a/docs/datasets/text/index.md
+++ b/docs/datasets/text/index.md
@@ -9,5 +9,6 @@ Text-based benchmarks for retrieval and RAG evaluation.
 | [BEIR](beir.md) | Heterogeneous information retrieval | No |
 | [MTEB](mteb.md) | Massive Text Embedding Benchmark | No |
 | [RAGBench](ragbench.md) | RAG evaluation benchmark | Yes |
+| [CRAG](crag.md) | Comprehensive RAG Benchmark with search-result context | Yes |
 | [MrTyDi](mrtydi.md) | Multilingual retrieval | No |
 | [BRIGHT](bright.md) | Reasoning-intensive retrieval | No |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
           - datasets/text/beir.md
           - datasets/text/mteb.md
           - datasets/text/ragbench.md
+          - datasets/text/crag.md
           - datasets/text/mrtydi.md
           - datasets/text/bright.md
       - Multimodal:

--- a/tests/autorag_research/data/test_crag.py
+++ b/tests/autorag_research/data/test_crag.py
@@ -152,6 +152,23 @@ class TestIngestUnit:
         service.add_retrieval_gt.assert_not_called()
         service.clean.assert_called_once_with()
 
+    @patch("autorag_research.data.crag.load_dataset")
+    def test_ingest_warns_that_train_alias_duplicates_dev_examples(
+        self,
+        mock_load_dataset,
+        mock_embedding_model,
+        caplog,
+    ):
+        mock_load_dataset.return_value = []
+        service = MagicMock()
+        ingestor = CRAGIngestor(mock_embedding_model, batch_size=10)
+        ingestor.set_service(service)
+
+        with caplog.at_level("WARNING", logger="AutoRAG-Research"):
+            ingestor.ingest(subset="train")
+
+        assert "Ingesting both subset='train' and subset='dev' will duplicate the same upstream examples" in caplog.text
+
 
 CRAG_INTEGRATION_CONFIG = IngestorTestConfig(
     expected_query_count=2,

--- a/tests/autorag_research/data/test_crag.py
+++ b/tests/autorag_research/data/test_crag.py
@@ -1,0 +1,187 @@
+"""Tests for CRAGIngestor."""
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.embeddings.fake import FakeEmbeddings
+
+from autorag_research.data.crag import (
+    CRAGIngestor,
+    _build_generation_gt,
+    _format_search_result_contents,
+    _make_chunk_id,
+    _make_query_id,
+    _resolve_subset,
+)
+from autorag_research.data.registry import get_ingestor
+from autorag_research.orm.service.text_ingestion import TextDataIngestionService
+from tests.autorag_research.data.ingestor_test_utils import (
+    IngestorTestConfig,
+    create_test_database,
+)
+
+EMBEDDING_DIM = 768
+
+SAMPLE_EXAMPLES = [
+    {
+        "interaction_id": "dev-1",
+        "query": "Who won the championship?",
+        "answer": "The Tigers",
+        "alt_ans": ["Tigers", "The Tigers"],
+        "split": 0,
+        "search_results": [
+            {
+                "page_name": "Championship recap",
+                "page_url": "https://example.com/recap",
+                "page_snippet": "The Tigers won the final.",
+                "page_result": "<html><body><h1>Recap</h1><p>The Tigers won the final.</p></body></html>",
+                "page_last_modified": "Mon, 11 Mar 2024 06:06:35 GMT",
+            },
+            {
+                "page_name": "Box score",
+                "page_url": "https://example.com/box",
+                "page_snippet": "Box score summary",
+                "page_result": "",
+                "page_last_modified": "",
+            },
+        ],
+    },
+    {
+        "interaction_id": "test-1",
+        "query": "Who directed the movie?",
+        "answer": "Jane Doe",
+        "alt_ans": [],
+        "split": 1,
+        "search_results": [
+            {
+                "page_name": "Movie profile",
+                "page_url": "https://example.com/movie",
+                "page_snippet": "Jane Doe directed the movie.",
+                "page_result": "<html><body><p>Jane Doe directed the movie.</p></body></html>",
+                "page_last_modified": "Tue, 12 Mar 2024 06:06:35 GMT",
+            }
+        ],
+    },
+]
+
+
+@pytest.fixture
+def mock_embedding_model():
+    return FakeEmbeddings(size=EMBEDDING_DIM)
+
+
+class TestResolveSubset:
+    def test_resolve_supported_subsets(self):
+        assert _resolve_subset("train") == 0
+        assert _resolve_subset("dev") == 0
+        assert _resolve_subset("test") == 1
+
+
+class TestBuildGenerationGt:
+    def test_build_generation_gt_merges_primary_and_alternates_without_duplicates(self):
+        assert _build_generation_gt("The Tigers", ["Tigers", "The Tigers", "  "]) == ["The Tigers", "Tigers"]
+
+    def test_build_generation_gt_returns_none_when_all_answers_empty(self):
+        assert _build_generation_gt("", [" ", ""]) is None
+
+
+class TestChunkFormatting:
+    def test_format_search_result_contents_includes_metadata_and_html_text(self):
+        result = _format_search_result_contents(SAMPLE_EXAMPLES[0]["search_results"][0])
+        assert "Title: Championship recap" in result
+        assert "URL: https://example.com/recap" in result
+        assert "Snippet: The Tigers won the final." in result
+        assert "Last Modified: Mon, 11 Mar 2024 06:06:35 GMT" in result
+        assert "Recap" in result
+        assert "The Tigers won the final." in result
+        assert "<html>" not in result
+
+    def test_format_search_result_contents_falls_back_to_snippet_without_html(self):
+        result = _format_search_result_contents(SAMPLE_EXAMPLES[0]["search_results"][1])
+        assert "Snippet: Box score summary" in result
+        assert "Content:" in result
+        assert "Box score summary" in result
+
+
+class TestIdsAndRegistry:
+    def test_make_query_id(self):
+        assert _make_query_id("dev", "abc-123") == "crag_dev_abc-123"
+
+    def test_make_chunk_id(self):
+        assert _make_chunk_id("dev", "abc-123", 4) == "crag_dev_abc-123_4"
+
+    def test_registry_metadata_exposes_crag_ingestor(self):
+        import autorag_research.data.crag as crag_module
+
+        importlib.reload(crag_module)
+
+        meta = get_ingestor("crag")
+        assert meta is not None
+        assert meta.name == "crag"
+        assert meta.hf_repo is None
+
+
+class TestIngestUnit:
+    @patch("autorag_research.data.crag.load_dataset")
+    def test_ingest_filters_to_requested_split_and_skips_retrieval_gt(self, mock_load_dataset, mock_embedding_model):
+        mock_load_dataset.return_value = SAMPLE_EXAMPLES
+        service = MagicMock()
+        ingestor = CRAGIngestor(mock_embedding_model, batch_size=10)
+        ingestor.set_service(service)
+
+        ingestor.ingest(subset="dev", query_limit=1)
+
+        service.add_queries.assert_called_once_with([
+            {
+                "id": "crag_dev_dev-1",
+                "contents": "Who won the championship?",
+                "generation_gt": ["The Tigers", "Tigers"],
+            }
+        ])
+        service.add_chunks.assert_called_once_with([
+            {
+                "id": "crag_dev_dev-1_0",
+                "contents": _format_search_result_contents(SAMPLE_EXAMPLES[0]["search_results"][0]),
+            },
+            {
+                "id": "crag_dev_dev-1_1",
+                "contents": _format_search_result_contents(SAMPLE_EXAMPLES[0]["search_results"][1]),
+            },
+        ])
+        service.add_retrieval_gt.assert_not_called()
+        service.clean.assert_called_once_with()
+
+
+CRAG_INTEGRATION_CONFIG = IngestorTestConfig(
+    expected_query_count=2,
+    expected_chunk_count=10,
+    check_retrieval_relations=False,
+    check_generation_gt=True,
+    generation_gt_required_for_all=True,
+    primary_key_type="string",
+    db_name="crag_integration_test",
+)
+
+
+@pytest.mark.data
+class TestCRAGIngestorIntegration:
+    def test_ingest_dev_subset(self, mock_embedding_model):
+        with create_test_database(CRAG_INTEGRATION_CONFIG) as db:
+            service = TextDataIngestionService(db.session_factory, schema=db.schema)
+            ingestor = CRAGIngestor(mock_embedding_model, batch_size=2)
+            ingestor.set_service(service)
+
+            ingestor.ingest(subset="dev", query_limit=2)
+
+            stats = service.get_statistics()
+            assert stats["queries"]["total"] == 2
+            assert stats["chunks"]["total"] == 10
+
+            with service._create_uow() as uow:
+                queries = uow.queries.get_all(limit=None)
+                chunks = uow.chunks.get_all(limit=10)
+
+            assert all(query.generation_gt for query in queries)
+            assert any(chunk.contents.startswith("Title:") for chunk in chunks)
+            assert any("Content:" in chunk.contents for chunk in chunks)


### PR DESCRIPTION
## Summary
- add a built-in `crag` ingestor for the CRAG Task 1/2 public source file
- ingest CRAG answers into `generation_gt` and convert `search_results` entries into text chunks without fabricating retrieval qrels
- document CRAG dataset support and its split/ground-truth behavior

## Testing
- uv run pytest -q tests/autorag_research/data/test_crag.py
- uv run pytest -q tests/autorag_research/data/test_registry.py tests/autorag_research/data/test_crag.py
- make check
- uv run mkdocs build --strict

<!-- dani:stage=implementation;job=66a38176b09041fcab987d5d4a1d8334;issue=118 -->
