### PR TITLE
Feature/#178

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Standalone retrieval pipelines. Use them on their own for retrieval-only evaluat
 | [BM25](https://www.staff.city.ac.uk/~sbrp622/papers/foundations_bm25_review.pdf) | Sparse full-text retrieval                                             | -         |
 | [HyDE](https://arxiv.org/abs/2212.10496)                                         | Hypothetical Document Embeddings                                       | ACL 23    |
 | [Query Rewrite](https://aclanthology.org/2023.emnlp-main.322/)                   | Rewrite query text before delegating retrieval                         | EMNLP 23  |
+| [RETRO*](https://openreview.net/pdf?id=0WGl8PNMSA)                               | Rubric-based LLM reranking over retrieved candidates                   | ICLR 26   |
 | [Hybrid RRF](https://cormack.uwaterloo.ca/cormacksigir09-rrf.pdf)                | Reciprocal Rank Fusion of two retrieval pipelines                      | -         |
 | [Hybrid CC](https://arxiv.org/pdf/2210.11934)                                    | Convex Combination fusion of two retrieval pipelines                   | -         |
 
@@ -186,7 +187,7 @@ metrics:
   generation: [rouge]
 ```
 
-Generation pipelines (and some retrieval pipelines like HyDE and Query Rewrite) require an LLM. The `llm` field in each pipeline config references a file in `configs/llm/` by name (without `.yaml`):
+Generation pipelines (and some retrieval pipelines like HyDE, Query Rewrite, and RETRO*) require an LLM. The `llm` field in each pipeline config references a file in `configs/llm/` by name (without `.yaml`):
 
 ```yaml
 # configs/pipelines/generation/basic_rag.yaml

--- a/autorag_research/orm/repository/pipeline.py
+++ b/autorag_research/orm/repository/pipeline.py
@@ -128,8 +128,9 @@ class PipelineRepository(GenericRepository[Any]):
         Returns:
             List of all pipelines ordered alphabetically by name.
         """
-        stmt = select(self.model_cls).order_by(self.model_cls.name)
-        return list(self.session.execute(stmt).scalars().all())
+        stmt = select(self.model_cls)
+        pipelines = list(self.session.execute(stmt).scalars().all())
+        return sorted(pipelines, key=lambda pipeline: pipeline.name)
 
     def exists_by_name(self, name: str) -> bool:
         """Check if a pipeline with the given name exists.

--- a/autorag_research/pipelines/retrieval/__init__.py
+++ b/autorag_research/pipelines/retrieval/__init__.py
@@ -18,6 +18,10 @@ from autorag_research.pipelines.retrieval.query_rewrite import (
     QueryRewritePipelineConfig,
     QueryRewriteRetrievalPipeline,
 )
+from autorag_research.pipelines.retrieval.retro_star import (
+    RetroStarPipelineConfig,
+    RetroStarRetrievalPipeline,
+)
 from autorag_research.pipelines.retrieval.vector_search import (
     VectorSearchPipelineConfig,
     VectorSearchRetrievalPipeline,
@@ -37,6 +41,8 @@ __all__ = [
     "HybridRRFRetrievalPipelineConfig",
     "QueryRewritePipelineConfig",
     "QueryRewriteRetrievalPipeline",
+    "RetroStarPipelineConfig",
+    "RetroStarRetrievalPipeline",
     "VectorSearchPipelineConfig",
     "VectorSearchRetrievalPipeline",
 ]

--- a/autorag_research/pipelines/retrieval/retro_star.py
+++ b/autorag_research/pipelines/retrieval/retro_star.py
@@ -65,12 +65,17 @@ _SCORE_PATTERN = re.compile(r"<score>\s*(-?\d{1,3})\s*</score>", re.IGNORECASE |
 
 def _parse_retro_score(response_text: str) -> int:
     """Parse the final RETRO* relevance score from LLM output."""
-    match = _SCORE_PATTERN.search(response_text)
-    if match is None:
+    matches = list(_SCORE_PATTERN.finditer(response_text))
+    if not matches:
         msg = "RETRO* response must contain a final integer score inside <score> tags"
         raise ValueError(msg)
 
-    return max(0, min(100, int(match.group(1))))
+    score = int(matches[-1].group(1))
+    if not 0 <= score <= 100:
+        msg = "RETRO* score must be an integer between 0 and 100"
+        raise ValueError(msg)
+
+    return score
 
 
 def _integrate_retro_scores(scores: list[int | float], weights: list[float] | None = None) -> float:

--- a/autorag_research/pipelines/retrieval/retro_star.py
+++ b/autorag_research/pipelines/retrieval/retro_star.py
@@ -1,0 +1,346 @@
+"""RETRO* retrieval pipeline for AutoRAG-Research.
+
+This pipeline implements a phase-1 inference-time RETRO*-style reranking flow
+inspired by "Retro*: Optimizing LLMs for Reasoning-Intensive Document Retrieval"
+(ICLR 2026).
+
+Scope note:
+- This implementation wraps an existing retrieval pipeline and reranks its
+  candidates with rubric-guided LLM scoring.
+- The paper's training recipe (SFT + RL) is intentionally out of scope here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseRetrievalPipelineConfig
+from autorag_research.injection import health_check_llm
+from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import run_with_concurrency_limit, truncate_texts
+
+DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION = (
+    "A document is relevant when it helps answer the query, including evidence that is indirect "
+    "but still necessary for the required reasoning."
+)
+
+DEFAULT_RETRO_STAR_PROMPT_TEMPLATE = """You are performing reasoning-intensive document retrieval.
+
+Relevance definition:
+{relevance_definition}
+
+Given the query ({query_type}) and the candidate document ({document_type}), do three things:
+1. Analyze what information the query is really asking for.
+2. Analyze how well the document supports that need, including indirect reasoning value.
+3. Assign one integer relevance score from 0 to 100.
+
+Use this score guide:
+- 80-100: highly relevant and directly useful
+- 60-79: relevant, with most important information present
+- 40-59: moderately relevant, partially useful
+- 20-39: slightly relevant, limited value
+- 0-19: irrelevant
+
+End your response with the final score only inside <score> tags, for example <score>87</score>.
+
+Query ({query_type}):
+[Begin Query]
+{query}
+[End Query]
+
+Document ({document_type}):
+[Begin Document]
+{doc}
+[End Document]"""
+
+_SCORE_PATTERN = re.compile(r"<score>\s*(-?\d{1,3})\s*</score>", re.IGNORECASE | re.DOTALL)
+
+
+def _parse_retro_score(response_text: str) -> int:
+    """Parse the final RETRO* relevance score from LLM output."""
+    match = _SCORE_PATTERN.search(response_text)
+    if match is None:
+        msg = "RETRO* response must contain a final integer score inside <score> tags"
+        raise ValueError(msg)
+
+    return max(0, min(100, int(match.group(1))))
+
+
+def _integrate_retro_scores(scores: list[int | float], weights: list[float] | None = None) -> float:
+    """Integrate multiple sampled RETRO* scores into one final score."""
+    if not scores:
+        msg = "scores must not be empty"
+        raise ValueError(msg)
+
+    if weights is None:
+        return float(sum(scores) / len(scores))
+
+    if len(weights) != len(scores):
+        msg = "weights must have the same length as scores"
+        raise ValueError(msg)
+
+    total_weight = sum(weights)
+    if total_weight <= 0:
+        msg = "weights must sum to a positive value"
+        raise ValueError(msg)
+
+    weighted_sum = sum(score * weight for score, weight in zip(scores, weights, strict=True))
+    return float(weighted_sum / total_weight)
+
+
+@dataclass(kw_only=True)
+class RetroStarPipelineConfig(BaseRetrievalPipelineConfig):
+    """Configuration for the RETRO* retrieval pipeline."""
+
+    llm: str | BaseLanguageModel
+    retrieval_pipeline_name: str
+    candidate_top_k: int = 100
+    prompt_template: str = field(default=DEFAULT_RETRO_STAR_PROMPT_TEMPLATE)
+    relevance_definition: str = field(default=DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION)
+    query_type: str = "query"
+    document_type: str = "document"
+    num_samples: int = 1
+    sample_weights: list[float] | None = None
+    max_document_tokens: int = 768
+    max_query_tokens: int = 256
+    max_rerank_concurrency: int = 4
+    _retrieval_pipeline: BaseRetrievalPipeline | None = field(default=None, repr=False)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Auto-convert string LLM config names to model instances."""
+        if name == "llm" and isinstance(value, str):
+            from autorag_research.injection import load_llm
+
+            value = load_llm(value)
+            health_check_llm(value)
+        super().__setattr__(name, value)
+
+    def inject_retrieval_pipeline(self, pipeline: BaseRetrievalPipeline) -> None:
+        """Inject the wrapped retrieval pipeline instance."""
+        self._retrieval_pipeline = pipeline
+
+    def get_pipeline_class(self) -> type[RetroStarRetrievalPipeline]:
+        """Return the RetroStarRetrievalPipeline class."""
+        return RetroStarRetrievalPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for RetroStarRetrievalPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "candidate_top_k": self.candidate_top_k,
+            "prompt_template": self.prompt_template,
+            "relevance_definition": self.relevance_definition,
+            "query_type": self.query_type,
+            "document_type": self.document_type,
+            "num_samples": self.num_samples,
+            "sample_weights": self.sample_weights,
+            "max_document_tokens": self.max_document_tokens,
+            "max_query_tokens": self.max_query_tokens,
+            "max_rerank_concurrency": self.max_rerank_concurrency,
+        }
+
+
+class RetroStarRetrievalPipeline(BaseRetrievalPipeline):
+    """RETRO*-style rubric-based reranking over wrapped retrieval candidates."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        candidate_top_k: int = 100,
+        prompt_template: str = DEFAULT_RETRO_STAR_PROMPT_TEMPLATE,
+        relevance_definition: str = DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION,
+        query_type: str = "query",
+        document_type: str = "document",
+        num_samples: int = 1,
+        sample_weights: list[float] | None = None,
+        max_document_tokens: int = 768,
+        max_query_tokens: int = 256,
+        max_rerank_concurrency: int = 4,
+        schema: Any | None = None,
+    ):
+        """Initialize a RETRO* retrieval pipeline wrapper."""
+        if "{query}" not in prompt_template or "{doc}" not in prompt_template:
+            msg = "prompt_template must contain both '{query}' and '{doc}' placeholders"
+            raise ValueError(msg)
+        if candidate_top_k < 1:
+            msg = "candidate_top_k must be >= 1"
+            raise ValueError(msg)
+        if num_samples < 1:
+            msg = "num_samples must be >= 1"
+            raise ValueError(msg)
+        if max_document_tokens < 1 or max_query_tokens < 1:
+            msg = "max_document_tokens and max_query_tokens must be >= 1"
+            raise ValueError(msg)
+        if max_rerank_concurrency < 1:
+            msg = "max_rerank_concurrency must be >= 1"
+            raise ValueError(msg)
+        if sample_weights is not None and len(sample_weights) != num_samples:
+            msg = "sample_weights must match num_samples when provided"
+            raise ValueError(msg)
+
+        self.llm = llm
+        self._retrieval_pipeline = retrieval_pipeline
+        self.candidate_top_k = candidate_top_k
+        self.prompt_template = prompt_template
+        self.relevance_definition = relevance_definition
+        self.query_type = query_type
+        self.document_type = document_type
+        self.num_samples = num_samples
+        self.sample_weights = sample_weights
+        self.max_document_tokens = max_document_tokens
+        self.max_query_tokens = max_query_tokens
+        self.max_rerank_concurrency = max_rerank_concurrency
+
+        super().__init__(session_factory, name, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return RETRO* pipeline configuration for storage."""
+        model_name = getattr(self.llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self.llm).__name__
+
+        return {
+            "type": "retro_star",
+            "candidate_top_k": self.candidate_top_k,
+            "prompt_template": self.prompt_template,
+            "relevance_definition": self.relevance_definition,
+            "query_type": self.query_type,
+            "document_type": self.document_type,
+            "num_samples": self.num_samples,
+            "sample_weights": self.sample_weights,
+            "max_document_tokens": self.max_document_tokens,
+            "max_query_tokens": self.max_query_tokens,
+            "max_rerank_concurrency": self.max_rerank_concurrency,
+            "retrieval_pipeline_id": getattr(self._retrieval_pipeline, "pipeline_id", None),
+            "wrapped_pipeline_type": type(self._retrieval_pipeline).__name__,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_response_content(response: Any) -> str:
+        """Extract text content from an LLM response."""
+        if hasattr(response, "content"):
+            return str(response.content)
+        return str(response)
+
+    def _build_prompt(self, query_text: str, document_text: str) -> str:
+        """Build the RETRO* scoring prompt for one query-document pair."""
+        truncated_query = truncate_texts([query_text], self.max_query_tokens)[0]
+        truncated_document = truncate_texts([document_text], self.max_document_tokens)[0]
+        return self.prompt_template.format(
+            relevance_definition=self.relevance_definition,
+            query_type=self.query_type,
+            document_type=self.document_type,
+            query=truncated_query,
+            doc=truncated_document,
+        )
+
+    async def _score_document(self, query_text: str, document_text: str) -> float:
+        """Score a single candidate document with RETRO* prompting."""
+        prompt = self._build_prompt(query_text, document_text)
+        sampled_scores: list[float] = []
+        for _ in range(self.num_samples):
+            response = await self.llm.ainvoke(prompt)
+            sampled_scores.append(float(_parse_retro_score(self._extract_response_content(response))))
+
+        return _integrate_retro_scores(sampled_scores, self.sample_weights)
+
+    def _ensure_candidate_contents(self, candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Backfill missing candidate contents from the chunk table."""
+        missing_ids = [candidate["doc_id"] for candidate in candidates if not candidate.get("content")]
+        if not missing_ids:
+            return candidates
+
+        with RetrievalUnitOfWork(self.session_factory, self._schema) as uow:
+            chunks = uow.chunks.get_by_ids(missing_ids)
+
+        contents_by_id = {chunk.id: chunk.contents for chunk in chunks}
+        enriched_candidates: list[dict[str, Any]] = []
+        for candidate in candidates:
+            enriched_candidate = dict(candidate)
+            if not enriched_candidate.get("content"):
+                enriched_candidate["content"] = contents_by_id.get(candidate["doc_id"], "")
+            enriched_candidates.append(enriched_candidate)
+
+        return enriched_candidates
+
+    async def _score_candidate(self, query_text: str, candidate: dict[str, Any]) -> dict[str, Any]:
+        """Compute a RETRO* score for one wrapped retrieval candidate."""
+        retro_score = await self._score_document(query_text, candidate.get("content", ""))
+        return {
+            "doc_id": candidate["doc_id"],
+            "score": retro_score,
+            "content": candidate.get("content", ""),
+            "_wrapped_score": float(candidate.get("score", 0.0)),
+        }
+
+    async def _rerank_candidates(
+        self,
+        query_text: str,
+        candidates: list[dict[str, Any]],
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        """Rerank candidates with RETRO* scoring."""
+        scored_candidates = await run_with_concurrency_limit(
+            items=candidates,
+            async_func=lambda candidate: self._score_candidate(query_text, candidate),
+            max_concurrency=self.max_rerank_concurrency,
+            error_message="RETRO* candidate scoring failed",
+        )
+
+        valid_candidates = [candidate for candidate in scored_candidates if candidate is not None]
+        valid_candidates.sort(
+            key=lambda candidate: (candidate["score"], candidate["_wrapped_score"]),
+            reverse=True,
+        )
+
+        return [
+            {
+                "doc_id": candidate["doc_id"],
+                "score": candidate["score"],
+                "content": candidate["content"],
+            }
+            for candidate in valid_candidates[:top_k]
+        ]
+
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        """Fetch query text by ID, then rerank candidates with RETRO* scoring."""
+        query_texts = self._service.fetch_query_texts([query_id])
+        if not query_texts:
+            return []
+
+        return await self._retrieve_by_text(query_texts[0], top_k)
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        """Retrieve candidates from the wrapped pipeline, then rerank them."""
+        candidate_top_k = max(top_k, self.candidate_top_k)
+        candidates = await self._retrieval_pipeline.retrieve(query_text, candidate_top_k)
+        if not candidates:
+            return []
+
+        enriched_candidates = self._ensure_candidate_contents(candidates)
+        return await self._rerank_candidates(query_text, enriched_candidates, top_k)
+
+
+__all__ = [
+    "DEFAULT_RETRO_STAR_PROMPT_TEMPLATE",
+    "DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION",
+    "RetroStarPipelineConfig",
+    "RetroStarRetrievalPipeline",
+    "_integrate_retro_scores",
+    "_parse_retro_score",
+]

--- a/autorag_research/pipelines/retrieval/retro_star.py
+++ b/autorag_research/pipelines/retrieval/retro_star.py
@@ -12,6 +12,7 @@ Scope note:
 
 from __future__ import annotations
 
+import asyncio
 import re
 from dataclasses import dataclass, field
 from typing import Any
@@ -23,7 +24,7 @@ from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.injection import health_check_llm
 from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
-from autorag_research.util import run_with_concurrency_limit, truncate_texts
+from autorag_research.util import truncate_texts
 
 DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION = (
     "A document is relevant when it helps answer the query, including evidence that is indirect "
@@ -81,9 +82,7 @@ def _integrate_retro_scores(scores: list[int | float], weights: list[float] | No
     if weights is None:
         return float(sum(scores) / len(scores))
 
-    if len(weights) != len(scores):
-        msg = "weights must have the same length as scores"
-        raise ValueError(msg)
+    _validate_sample_weights(weights, len(scores))
 
     total_weight = sum(weights)
     if total_weight <= 0:
@@ -92,6 +91,22 @@ def _integrate_retro_scores(scores: list[int | float], weights: list[float] | No
 
     weighted_sum = sum(score * weight for score, weight in zip(scores, weights, strict=True))
     return float(weighted_sum / total_weight)
+
+
+def _validate_sample_weights(
+    weights: list[float],
+    expected_length: int,
+    *,
+    length_error_message: str = "weights must have the same length as scores",
+    negative_error_message: str = "weights must not contain negative values",
+) -> None:
+    """Validate optional RETRO* sample weights before integration."""
+    if len(weights) != expected_length:
+        msg = length_error_message
+        raise ValueError(msg)
+    if any(weight < 0 for weight in weights):
+        msg = negative_error_message
+        raise ValueError(msg)
 
 
 @dataclass(kw_only=True)
@@ -188,9 +203,13 @@ class RetroStarRetrievalPipeline(BaseRetrievalPipeline):
         if max_rerank_concurrency < 1:
             msg = "max_rerank_concurrency must be >= 1"
             raise ValueError(msg)
-        if sample_weights is not None and len(sample_weights) != num_samples:
-            msg = "sample_weights must match num_samples when provided"
-            raise ValueError(msg)
+        if sample_weights is not None:
+            _validate_sample_weights(
+                sample_weights,
+                num_samples,
+                length_error_message="sample_weights must match num_samples when provided",
+                negative_error_message="sample_weights must not contain negative values",
+            )
 
         self.llm = llm
         self._retrieval_pipeline = retrieval_pipeline
@@ -295,15 +314,14 @@ class RetroStarRetrievalPipeline(BaseRetrievalPipeline):
         top_k: int,
     ) -> list[dict[str, Any]]:
         """Rerank candidates with RETRO* scoring."""
-        scored_candidates = await run_with_concurrency_limit(
-            items=candidates,
-            async_func=lambda candidate: self._score_candidate(query_text, candidate),
-            max_concurrency=self.max_rerank_concurrency,
-            error_message="RETRO* candidate scoring failed",
-        )
+        semaphore = asyncio.Semaphore(self.max_rerank_concurrency)
 
-        valid_candidates = [candidate for candidate in scored_candidates if candidate is not None]
-        valid_candidates.sort(
+        async def score_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+            async with semaphore:
+                return await self._score_candidate(query_text, candidate)
+
+        scored_candidates = await asyncio.gather(*(score_candidate(candidate) for candidate in candidates))
+        scored_candidates.sort(
             key=lambda candidate: (candidate["score"], candidate["_wrapped_score"]),
             reverse=True,
         )
@@ -314,7 +332,7 @@ class RetroStarRetrievalPipeline(BaseRetrievalPipeline):
                 "score": candidate["score"],
                 "content": candidate["content"],
             }
-            for candidate in valid_candidates[:top_k]
+            for candidate in scored_candidates[:top_k]
         ]
 
     async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:

--- a/configs/pipelines/retrieval/retro_star.yaml
+++ b/configs/pipelines/retrieval/retro_star.yaml
@@ -1,0 +1,35 @@
+# RETRO* Retrieval Pipeline Configuration
+#
+# Wraps an existing retrieval pipeline, then reranks its candidates with
+# rubric-based LLM scoring inspired by Retro* (ICLR 2026).
+#
+# Parameters:
+#   llm: LLM config name from configs/llm/ (e.g., "mock", "openai-gpt5-mini")
+#   retrieval_pipeline_name: Existing retrieval pipeline config name to wrap
+#   candidate_top_k: Number of wrapped candidates to rerank before truncating
+#   relevance_definition: Task-specific relevance definition for the rubric
+#   num_samples: Number of reasoning trajectories per query-document pair
+#   sample_weights: Optional score-integration weights (same length as num_samples)
+#   max_document_tokens: Max candidate document tokens to include in the prompt
+#
+_target_: autorag_research.pipelines.retrieval.retro_star.RetroStarPipelineConfig
+description: "RETRO*-style rubric-based LLM reranking over wrapped retrieval candidates"
+name: retro_star
+llm: mock
+retrieval_pipeline_name: bm25
+candidate_top_k: 100
+relevance_definition: >
+  A document is relevant when it helps answer the query, including evidence
+  that is indirect but still necessary for the required reasoning.
+query_type: query
+document_type: document
+num_samples: 1
+sample_weights: null
+max_document_tokens: 768
+max_query_tokens: 256
+max_rerank_concurrency: 4
+top_k: 10
+batch_size: 128
+max_concurrency: 16
+max_retries: 3
+retry_delay: 1.0

--- a/docs/pipelines/retrieval/index.md
+++ b/docs/pipelines/retrieval/index.md
@@ -11,6 +11,7 @@ Algorithms that take a query and return relevant documents.
 | [Vector Search](vector-search.md) | Dense (vector similarity) | Text |
 | [HyDE](hyde.md) | Dense (hypothetical document embeddings) | Text |
 | [Query Rewrite](query-rewrite.md) | Rewrite query text before retrieval | Text |
+| [RETRO*](retro-star.md) | Rubric-based LLM reranking over retrieved candidates | Text |
 
 ## Base Class
 

--- a/docs/pipelines/retrieval/retro-star.md
+++ b/docs/pipelines/retrieval/retro-star.md
@@ -1,0 +1,135 @@
+# RETRO*
+
+Wrap an existing retrieval pipeline, then rerank its candidates with rubric-based LLM scoring inspired by the RETRO* paper.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Type | Retrieval |
+| Algorithm | Pointwise rubric-based reranking |
+| Modality | Text |
+| Paper | [Retro*: Optimizing LLMs for Reasoning-Intensive Document Retrieval](https://openreview.net/pdf?id=0WGl8PNMSA) |
+
+## How It Works
+
+1. Retrieve an initial candidate set from an existing retrieval pipeline such as BM25, vector search, or hybrid search.
+2. Prompt an LLM with a task-specific relevance rubric for each query-document pair.
+3. Parse the final `<score>` value from each reasoning trace.
+4. Optionally sample multiple reasoning traces per pair and integrate their scores.
+5. Return the highest-scoring documents as the wrapper pipeline output.
+
+## Scope
+
+This implementation covers the paper's practical inference-time reranking pattern only.
+
+Out of scope for this MVP:
+
+- the paper's SFT training stage
+- the paper's RL optimization stage
+- reproducing the published BRIGHT benchmark numbers end to end
+
+## Configuration
+
+```yaml
+_target_: autorag_research.pipelines.retrieval.retro_star.RetroStarPipelineConfig
+name: retro_star_bm25
+llm: openai-gpt5-mini
+retrieval_pipeline_name: bm25
+candidate_top_k: 100
+relevance_definition: >
+  A document is relevant when it helps answer the query, including evidence
+  that is indirect but still necessary for the required reasoning.
+query_type: query
+document_type: document
+num_samples: 4
+sample_weights: [0.1, 0.2, 0.3, 0.4]
+top_k: 10
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| name | str | required | Unique pipeline instance name |
+| llm | str | required | LLM config name (from `configs/llm/`) |
+| retrieval_pipeline_name | str | required | Existing retrieval pipeline config to wrap |
+| candidate_top_k | int | 100 | Number of wrapped candidates to rerank |
+| relevance_definition | str | generic reasoning-aware definition | Rubric definition inserted into the prompt |
+| query_type | str | `query` | Label used inside the prompt |
+| document_type | str | `document` | Label used inside the prompt |
+| num_samples | int | 1 | Number of reasoning traces to sample per candidate |
+| sample_weights | list[float] \| null | null | Optional score-integration weights |
+| max_document_tokens | int | 768 | Max candidate document tokens sent to the LLM |
+| max_query_tokens | int | 256 | Max query tokens sent to the LLM |
+| max_rerank_concurrency | int | 4 | Concurrent candidate-scoring calls per query |
+| top_k | int | 10 | Final results per query |
+
+## Default Prompt Behavior
+
+The built-in prompt asks the model to:
+
+1. analyze the query intent
+2. analyze the candidate document
+3. justify a 0-100 relevance score
+4. end with the final score inside `<score>` tags
+
+This mirrors the paper's rubric-based inference pattern while staying generic enough for arbitrary datasets.
+
+## Usage
+
+### Python API
+
+```python
+from langchain_openai import ChatOpenAI
+
+from autorag_research.orm.connection import DBConnection
+from autorag_research.pipelines.retrieval.bm25 import BM25RetrievalPipeline
+from autorag_research.pipelines.retrieval.retro_star import RetroStarRetrievalPipeline
+
+db = DBConnection.from_config()
+session_factory = db.get_session_factory()
+
+wrapped_retriever = BM25RetrievalPipeline(
+    session_factory=session_factory,
+    name="bm25",
+    tokenizer="bert",
+)
+
+pipeline = RetroStarRetrievalPipeline(
+    session_factory=session_factory,
+    name="retro_star_bm25",
+    llm=ChatOpenAI(model="gpt-5-mini"),
+    retrieval_pipeline=wrapped_retriever,
+    candidate_top_k=100,
+    num_samples=4,
+)
+```
+
+### YAML / Executor
+
+```yaml
+# configs/pipelines/retrieval/retro_star_bm25.yaml
+_target_: autorag_research.pipelines.retrieval.retro_star.RetroStarPipelineConfig
+name: retro_star_bm25
+llm: openai-gpt5-mini
+retrieval_pipeline_name: bm25
+candidate_top_k: 100
+num_samples: 4
+```
+
+The executor resolves `retrieval_pipeline_name`, instantiates the wrapped retriever, and injects it automatically.
+
+## When to Use
+
+Good for:
+
+- reasoning-intensive benchmarks such as BRIGHT
+- difficult queries where indirectly useful evidence matters
+- comparing a stronger LLM-based reranking baseline against simpler retrievers
+
+Consider other methods when:
+
+- you need a lightweight retriever without LLM latency
+- you want fully trained paper-faithful RETRO* checkpoints
+- you only need sparse or dense retrieval without reranking

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Retrieval:
           - pipelines/retrieval/index.md
           - pipelines/retrieval/bm25.md
+          - pipelines/retrieval/retro-star.md
           - pipelines/retrieval/vector-search.md
       - Generation:
           - pipelines/generation/index.md

--- a/tests/autorag_research/pipelines/retrieval/test_retro_star_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_retro_star_pipeline.py
@@ -1,0 +1,343 @@
+"""Tests for the RETRO* retrieval pipeline."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.orm.repository.chunk import ChunkRepository
+from autorag_research.orm.repository.chunk_retrieved_result import ChunkRetrievedResultRepository
+from autorag_research.orm.repository.query import QueryRepository
+from autorag_research.pipelines.retrieval.retro_star import (
+    DEFAULT_RETRO_STAR_PROMPT_TEMPLATE,
+    DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION,
+    RetroStarPipelineConfig,
+    RetroStarRetrievalPipeline,
+    _integrate_retro_scores,
+    _parse_retro_score,
+)
+from tests.autorag_research.pipelines.pipeline_test_utils import (
+    PipelineTestConfig,
+    PipelineTestVerifier,
+    create_mock_retrieval_pipeline,
+)
+
+
+def _mock_llm_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.__str__ = lambda _: content
+    return response
+
+
+@pytest.fixture
+def cleanup_pipeline_results(session_factory: sessionmaker[Session]):
+    """Cleanup fixture that deletes RETRO* pipeline results after test."""
+    created_pipeline_ids: list[int] = []
+
+    yield created_pipeline_ids
+
+    session = session_factory()
+    try:
+        result_repo = ChunkRetrievedResultRepository(session)
+        for pipeline_id in created_pipeline_ids:
+            result_repo.delete_by_pipeline(pipeline_id)
+        session.commit()
+    finally:
+        session.close()
+
+
+class TestRetroStarHelpers:
+    """Unit tests for RETRO* helper functions."""
+
+    def test_parse_retro_score_extracts_integer(self):
+        assert _parse_retro_score("analysis\n<score>84</score>") == 84
+
+    def test_parse_retro_score_clamps_out_of_range_values(self):
+        assert _parse_retro_score("<score>124</score>") == 100
+        assert _parse_retro_score("<score>-8</score>") == 0
+
+    def test_parse_retro_score_rejects_missing_score_tag(self):
+        with pytest.raises(ValueError, match="RETRO\\* response must contain"):
+            _parse_retro_score("no score tag present")
+
+    def test_integrate_retro_scores_returns_mean_by_default(self):
+        assert _integrate_retro_scores([30, 60, 90]) == pytest.approx(60.0)
+
+    def test_integrate_retro_scores_supports_explicit_weights(self):
+        assert _integrate_retro_scores([20, 80], weights=[1.0, 3.0]) == pytest.approx(65.0)
+
+
+class TestRetroStarPipelineConfig:
+    """Tests for RetroStarPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        llm = FakeListLLM(responses=["<score>80</score>"])
+        config = RetroStarPipelineConfig(
+            name="retro_star",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+        )
+
+        assert config.get_pipeline_class() == RetroStarRetrievalPipeline
+
+    def test_default_prompt_template_and_relevance_definition(self):
+        llm = FakeListLLM(responses=["<score>80</score>"])
+        config = RetroStarPipelineConfig(
+            name="retro_star",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+        )
+
+        assert config.prompt_template == DEFAULT_RETRO_STAR_PROMPT_TEMPLATE
+        assert config.relevance_definition == DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        llm = FakeListLLM(responses=["<score>80</score>"])
+        config = RetroStarPipelineConfig(
+            name="retro_star",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        llm = FakeListLLM(responses=["<score>80</score>"])
+        wrapped_retrieval = create_mock_retrieval_pipeline(pipeline_id=77)
+        config = RetroStarPipelineConfig(
+            name="retro_star",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+            candidate_top_k=25,
+            num_samples=3,
+            sample_weights=[0.2, 0.3, 0.5],
+        )
+
+        config.inject_retrieval_pipeline(wrapped_retrieval)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is wrapped_retrieval
+        assert kwargs["candidate_top_k"] == 25
+        assert kwargs["num_samples"] == 3
+        assert kwargs["sample_weights"] == [0.2, 0.3, 0.5]
+
+    @pytest.mark.api
+    def test_string_llm_conversion(self):
+        with patch("autorag_research.injection.load_llm") as mock_load:
+            mock_llm = MagicMock()
+            mock_load.return_value = mock_llm
+
+            config = RetroStarPipelineConfig(
+                name="retro_star",
+                llm="mock",
+                retrieval_pipeline_name="bm25",
+            )
+
+            mock_load.assert_called_once_with("mock")
+            assert config.llm is mock_llm
+
+
+class TestRetroStarRetrievalPipeline:
+    """Tests for RetroStarRetrievalPipeline."""
+
+    def test_creation_rejects_missing_query_or_doc_placeholder(self, session_factory):
+        with pytest.raises(ValueError, match="must contain"):
+            RetroStarRetrievalPipeline(
+                session_factory=session_factory,
+                name="retro_star_invalid_prompt",
+                llm=FakeListLLM(responses=["<score>80</score>"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                prompt_template="Missing placeholders altogether",
+            )
+
+    def test_pipeline_config(self, session_factory, cleanup_pipeline_results: list[int]):
+        pipeline = RetroStarRetrievalPipeline(
+            session_factory=session_factory,
+            name="retro_star_config",
+            llm=FakeListLLM(responses=["<score>80</score>"]),
+            retrieval_pipeline=create_mock_retrieval_pipeline(pipeline_id=123),
+            candidate_top_k=50,
+            num_samples=4,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        config = pipeline._get_pipeline_config()
+        assert config["type"] == "retro_star"
+        assert config["candidate_top_k"] == 50
+        assert config["num_samples"] == 4
+        assert config["retrieval_pipeline_id"] == 123
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_reranks_wrapped_candidates(
+        self, session_factory, cleanup_pipeline_results: list[int]
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 1, "score": 0.99, "content": "first document"},
+                {"doc_id": 2, "score": 0.40, "content": "second document"},
+            ]
+        )
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_llm_response("analysis\n<score>35</score>"),
+                _mock_llm_response("analysis\n<score>92</score>"),
+            ]
+        )
+
+        pipeline = RetroStarRetrievalPipeline(
+            session_factory=session_factory,
+            name="retro_star_by_text",
+            llm=llm,
+            retrieval_pipeline=wrapped_retrieval,
+            candidate_top_k=2,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_text("original query", top_k=1)
+
+        wrapped_retrieval.retrieve.assert_awaited_once_with("original query", 2)
+        assert results == [{"doc_id": 2, "score": 92.0, "content": "second document"}]
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_backfills_missing_candidate_content(
+        self,
+        session_factory,
+        cleanup_pipeline_results: list[int],
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 1, "score": 0.9},
+                {"doc_id": 2, "score": 0.8},
+            ]
+        )
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_llm_response("reasoning\n<score>55</score>"),
+                _mock_llm_response("reasoning\n<score>75</score>"),
+            ]
+        )
+
+        session = session_factory()
+        try:
+            chunk_repo = ChunkRepository(session)
+            chunk_contents = [chunk.contents for chunk in chunk_repo.get_by_ids([1, 2])]
+        finally:
+            session.close()
+
+        pipeline = RetroStarRetrievalPipeline(
+            session_factory=session_factory,
+            name="retro_star_backfill_content",
+            llm=llm,
+            retrieval_pipeline=wrapped_retrieval,
+            candidate_top_k=2,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        await pipeline._retrieve_by_text("query text", top_k=2)
+
+        prompts = [call.args[0] for call in llm.ainvoke.await_args_list]
+        assert any(chunk_contents[0] in prompt for prompt in prompts)
+        assert any(chunk_contents[1] in prompt for prompt in prompts)
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_uses_multi_sample_score_integration(
+        self,
+        session_factory,
+        cleanup_pipeline_results: list[int],
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 1, "score": 0.9, "content": "doc"}]
+        )
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_llm_response("first\n<score>20</score>"),
+                _mock_llm_response("second\n<score>80</score>"),
+            ]
+        )
+
+        pipeline = RetroStarRetrievalPipeline(
+            session_factory=session_factory,
+            name="retro_star_multi_sample",
+            llm=llm,
+            retrieval_pipeline=wrapped_retrieval,
+            candidate_top_k=1,
+            num_samples=2,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_text("query text", top_k=1)
+
+        assert results[0]["score"] == pytest.approx(50.0)
+        assert llm.ainvoke.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_id_fetches_query_text_then_reranks(
+        self,
+        session_factory,
+        cleanup_pipeline_results: list[int],
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 3, "score": 0.88, "content": "doc"}]
+        )
+        pipeline = RetroStarRetrievalPipeline(
+            session_factory=session_factory,
+            name="retro_star_by_id",
+            llm=FakeListLLM(responses=["analysis\n<score>88</score>"]),
+            retrieval_pipeline=wrapped_retrieval,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_id(1, top_k=2)
+
+        wrapped_retrieval.retrieve.assert_awaited_once()
+        assert results == [{"doc_id": 3, "score": 88.0, "content": "doc"}]
+
+    def test_run_full_pipeline(self, session_factory, cleanup_pipeline_results: list[int]):
+        session = session_factory()
+        try:
+            query_count = QueryRepository(session).count()
+        finally:
+            session.close()
+
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 1, "score": 0.91, "content": "Content 1"},
+                {"doc_id": 2, "score": 0.83, "content": "Content 2"},
+            ]
+        )
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[_mock_llm_response("<score>80</score>"), _mock_llm_response("<score>60</score>")]
+            * max(query_count, 1)
+        )
+
+        pipeline = RetroStarRetrievalPipeline(
+            session_factory=session_factory,
+            name="retro_star_full_run",
+            llm=llm,
+            retrieval_pipeline=wrapped_retrieval,
+            candidate_top_k=2,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        result = pipeline.run(top_k=2)
+
+        verifier = PipelineTestVerifier(
+            result,
+            pipeline.pipeline_id,
+            session_factory,
+            PipelineTestConfig(
+                pipeline_type="retrieval",
+                expected_total_queries=query_count,
+                expected_min_results=0,
+                check_persistence=True,
+            ),
+        )
+        verifier.verify_all()

--- a/tests/autorag_research/pipelines/retrieval/test_retro_star_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_retro_star_pipeline.py
@@ -54,9 +54,13 @@ class TestRetroStarHelpers:
     def test_parse_retro_score_extracts_integer(self):
         assert _parse_retro_score("analysis\n<score>84</score>") == 84
 
-    def test_parse_retro_score_clamps_out_of_range_values(self):
-        assert _parse_retro_score("<score>124</score>") == 100
-        assert _parse_retro_score("<score>-8</score>") == 0
+    def test_parse_retro_score_uses_final_score_tag(self):
+        assert _parse_retro_score("draft <score>10</score> revised <score>90</score>") == 90
+
+    @pytest.mark.parametrize("response_text", ["<score>124</score>", "<score>-8</score>"])
+    def test_parse_retro_score_rejects_out_of_range_values(self, response_text: str):
+        with pytest.raises(ValueError, match="RETRO\\* score must be an integer between 0 and 100"):
+            _parse_retro_score(response_text)
 
     def test_parse_retro_score_rejects_missing_score_tag(self):
         with pytest.raises(ValueError, match="RETRO\\* response must contain"):
@@ -315,6 +319,28 @@ class TestRetroStarRetrievalPipeline:
             )
 
         with pytest.raises(ValueError, match="RETRO\\* response must contain"):
+            await pipeline._retrieve_by_text("query text", top_k=1)
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_raises_on_out_of_range_score_output(
+        self,
+        session_factory,
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 1, "score": 0.9, "content": "doc"}]
+        )
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(side_effect=[_mock_llm_response("analysis\n<score>124</score>")])
+
+        with patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None):
+            pipeline = RetroStarRetrievalPipeline(
+                session_factory=session_factory,
+                name="retro_star_out_of_range_score_output",
+                llm=llm,
+                retrieval_pipeline=wrapped_retrieval,
+            )
+
+        with pytest.raises(ValueError, match="RETRO\\* score must be an integer between 0 and 100"):
             await pipeline._retrieve_by_text("query text", top_k=1)
 
     @pytest.mark.asyncio

--- a/tests/autorag_research/pipelines/retrieval/test_retro_star_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_retro_star_pipeline.py
@@ -68,6 +68,10 @@ class TestRetroStarHelpers:
     def test_integrate_retro_scores_supports_explicit_weights(self):
         assert _integrate_retro_scores([20, 80], weights=[1.0, 3.0]) == pytest.approx(65.0)
 
+    def test_integrate_retro_scores_rejects_negative_weights(self):
+        with pytest.raises(ValueError, match="weights must not contain negative values"):
+            _integrate_retro_scores([0, 100], weights=[-1.0, 2.0])
+
 
 class TestRetroStarPipelineConfig:
     """Tests for RetroStarPipelineConfig."""
@@ -152,6 +156,20 @@ class TestRetroStarRetrievalPipeline:
                 llm=FakeListLLM(responses=["<score>80</score>"]),
                 retrieval_pipeline=create_mock_retrieval_pipeline(),
                 prompt_template="Missing placeholders altogether",
+            )
+
+    def test_creation_rejects_negative_sample_weights(self, session_factory):
+        with (
+            patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="sample_weights must not contain negative values"),
+        ):
+            RetroStarRetrievalPipeline(
+                session_factory=session_factory,
+                name="retro_star_invalid_weights",
+                llm=FakeListLLM(responses=["<score>80</score>"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                num_samples=2,
+                sample_weights=[-0.1, 1.1],
             )
 
     def test_pipeline_config(self, session_factory, cleanup_pipeline_results: list[int]):
@@ -276,6 +294,28 @@ class TestRetroStarRetrievalPipeline:
 
         assert results[0]["score"] == pytest.approx(50.0)
         assert llm.ainvoke.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_raises_on_malformed_score_output(
+        self,
+        session_factory,
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 1, "score": 0.9, "content": "doc"}]
+        )
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(side_effect=[_mock_llm_response("reasoning without score tags")])
+
+        with patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None):
+            pipeline = RetroStarRetrievalPipeline(
+                session_factory=session_factory,
+                name="retro_star_invalid_score_output",
+                llm=llm,
+                retrieval_pipeline=wrapped_retrieval,
+            )
+
+        with pytest.raises(ValueError, match="RETRO\\* response must contain"):
+            await pipeline._retrieve_by_text("query text", top_k=1)
 
     @pytest.mark.asyncio
     async def test_retrieve_by_id_fetches_query_text_then_reranks(


### PR DESCRIPTION
## Summary
- add a RETRO*-style retrieval wrapper that reranks candidates from an existing retrieval pipeline with rubric-based LLM scoring
- support optional multi-sample score integration plus candidate-content backfill for wrapped results
- add config/docs coverage and deterministic retrieval pipeline tests

## Verification
- `uv run pytest tests/autorag_research/pipelines/retrieval -q`
- `uv run pytest tests/autorag_research/test_executor.py -q`
- `make check`
- `make test`

<!-- dani:stage=implementation;job=959f25326b8d4b7bb1747195dc440228;issue=178 -->
