### PR TITLE
Feature/#339

### DIFF
--- a/autorag_research/evaluation/metrics/__init__.py
+++ b/autorag_research/evaluation/metrics/__init__.py
@@ -10,6 +10,7 @@ from autorag_research.evaluation.metrics.generation import (
     ResponseRelevancyConfig,
     RougeConfig,
     SemScoreConfig,
+    UniEvalConfig,
     bert_score,
     bleu,
     huggingface_evaluate,
@@ -17,6 +18,7 @@ from autorag_research.evaluation.metrics.generation import (
     response_relevancy,
     rouge,
     sem_score,
+    unieval,
 )
 from autorag_research.evaluation.metrics.retrieval import (
     F1Config,
@@ -56,6 +58,7 @@ __all__ = [
     "ResponseRelevancyConfig",
     "RougeConfig",
     "SemScoreConfig",
+    "UniEvalConfig",
     "bert_score",
     "bleu",
     "calculate_cosine_similarity",
@@ -75,4 +78,5 @@ __all__ = [
     "retrieval_recall",
     "rouge",
     "sem_score",
+    "unieval",
 ]

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -176,9 +176,52 @@ def _build_unieval_document(retrieved_contents: list[str]) -> str:
     return " ".join(content.strip() for content in retrieved_contents)
 
 
-def _select_unieval_reference(references: list[str]) -> str:
-    """Select the primary reference expected by the summarization UniEval scorer."""
-    return references[0].strip()
+def _prepare_unieval_references(references: list[str]) -> list[str]:
+    """Normalize available references for UniEval relevance scoring."""
+    return [reference.strip() for reference in references if reference.strip()]
+
+
+def _prepare_unieval_prompts(
+    metric_input: MetricInput,
+    dimension: str,
+    sentence_level_dimensions: set[str],
+) -> list[str]:
+    """Build UniEval prompts for a single metric input."""
+    generated_text = cast(str, metric_input.generated_texts).strip()
+    if dimension == "relevance":
+        return [
+            _build_unieval_prompt(
+                dimension=dimension,
+                generated_text=generated_text,
+                reference=reference,
+            )
+            for reference in _prepare_unieval_references(cast(list[str], metric_input.generation_gt))
+        ]
+
+    document = None
+    if dimension in {"coherence", "consistency"}:
+        document = _build_unieval_document(cast(list[str], metric_input.retrieved_contents))
+
+    text_units = (
+        _split_unieval_sentences(generated_text) if dimension in sentence_level_dimensions else [generated_text]
+    )
+    return [
+        _build_unieval_prompt(
+            dimension=dimension,
+            generated_text=text_unit,
+            document=document,
+        )
+        for text_unit in text_units
+    ]
+
+
+def _aggregate_unieval_scores(dimension: str, scores: list[float]) -> float:
+    """Aggregate prompt-level UniEval scores back to one sample-level score."""
+    if dimension in {"fluency", "consistency"}:
+        return float(sum(scores) / len(scores))
+    if dimension == "relevance":
+        return max(scores)
+    return scores[0]
 
 
 @convert_inputs_to_list
@@ -481,9 +524,9 @@ def unieval(
 
     Consistency intentionally skips samples with missing retrieved context instead of
     silently falling back to hidden ground truth, keeping the metric faithful to the
-    actual evidence available to the generation pipeline. Relevance uses the first
-    available reference because the upstream summarization evaluator expects a single
-    reference string per sample.
+    actual evidence available to the generation pipeline. Relevance keeps the official
+    single-reference prompt contract, but evaluates every available reference and keeps
+    the best score so multi-reference inputs stay order-independent.
     """
     normalized_dimension = _validate_unieval_dimension(dimension)
     field_map = {
@@ -501,29 +544,13 @@ def unieval(
         if not metric_input.is_fields_notnone(field_map[normalized_dimension]):
             continue
 
-        generated_text = cast(str, metric_input.generated_texts).strip()
-        document = None
-        if normalized_dimension in {"coherence", "consistency"}:
-            document = _build_unieval_document(cast(list[str], metric_input.retrieved_contents))
-        reference = None
-        if normalized_dimension == "relevance":
-            reference = _select_unieval_reference(cast(list[str], metric_input.generation_gt))
+        prompts = _prepare_unieval_prompts(metric_input, normalized_dimension, sentence_level_dimensions)
+        if not prompts:
+            continue
 
-        text_units = (
-            _split_unieval_sentences(generated_text)
-            if normalized_dimension in sentence_level_dimensions
-            else [generated_text.strip()]
-        )
-        prompt_counts.append((index, len(text_units)))
-        for text_unit in text_units:
-            prepared_inputs.append(
-                _build_unieval_prompt(
-                    dimension=normalized_dimension,
-                    generated_text=text_unit,
-                    document=document,
-                    reference=reference,
-                )
-            )
+        prompt_count = len(prompts)
+        prepared_inputs.extend(prompts)
+        prompt_counts.append((index, prompt_count))
 
     if not prepared_inputs:
         return results
@@ -545,7 +572,7 @@ def unieval(
     prompt_offset = 0
     for index, count in prompt_counts:
         current_scores = prompt_scores[prompt_offset : prompt_offset + count]
-        results[index] = float(sum(current_scores) / count)
+        results[index] = _aggregate_unieval_scores(normalized_dimension, current_scores)
         prompt_offset += count
 
     return results

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -4,7 +4,7 @@ import os
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from langchain_core.embeddings import Embeddings
@@ -149,17 +149,36 @@ def _build_unieval_prompt(
     *,
     dimension: str,
     generated_text: str,
-    query: str | None = None,
-    context: str | None = None,
+    document: str | None = None,
+    reference: str | None = None,
 ) -> str:
     """Build the Bool-QA prompt for a UniEval dimension."""
     if dimension == "fluency":
-        return f"question: Is this a fluent answer? </s> answer: {generated_text}"
+        return f"question: Is this a fluent paragraph? </s> paragraph: {generated_text}"
     if dimension == "coherence":
-        return f"question: Is this a coherent answer? </s> answer: {generated_text}"
+        return (
+            "question: Is this a coherent summary to the document? "
+            f"</s> summary: {generated_text} </s> document: {document}"
+        )
     if dimension == "consistency":
-        return f"question: Is this answer consistent with the context? </s> answer: {generated_text} </s> context: {context}"
-    return f"question: Is this answer relevant to the question? </s> answer: {generated_text} </s> question: {query}"
+        return (
+            "question: Is this claim consistent with the document? "
+            f"</s> claim: {generated_text} </s> document: {document}"
+        )
+    return (
+        "question: Is this summary relevant to the reference? "
+        f"</s> summary: {generated_text} </s> reference: {reference}"
+    )
+
+
+def _build_unieval_document(retrieved_contents: list[str]) -> str:
+    """Join retrieved passages into the document field used by UniEval summarization prompts."""
+    return " ".join(content.strip() for content in retrieved_contents)
+
+
+def _select_unieval_reference(references: list[str]) -> str:
+    """Select the primary reference expected by the summarization UniEval scorer."""
+    return references[0].strip()
 
 
 @convert_inputs_to_list
@@ -454,31 +473,26 @@ def unieval(
 ) -> list[float | None]:
     """Compute one UniEval dimension using the shared summarization checkpoint.
 
-    The implementation follows the official Bool-QA scoring path while adapting prompts
-    to AutoRAG generation inputs:
-    - fluency/coherence: generated text only
-    - relevance: query + generated text
-    - consistency: retrieved source context + generated text
+    The implementation follows the official UniEval summarization Bool-QA contract:
+    - fluency: generated text only, averaged per sentence
+    - coherence: retrieved source context + generated text, scored per sample
+    - consistency: retrieved source context + generated text, averaged per sentence
+    - relevance: reference + generated text, scored per sample
 
     Consistency intentionally skips samples with missing retrieved context instead of
     silently falling back to hidden ground truth, keeping the metric faithful to the
-    actual evidence available to the generation pipeline.
+    actual evidence available to the generation pipeline. Relevance uses the first
+    available reference because the upstream summarization evaluator expects a single
+    reference string per sample.
     """
     normalized_dimension = _validate_unieval_dimension(dimension)
     field_map = {
         "fluency": ["generated_texts"],
-        "coherence": ["generated_texts"],
+        "coherence": ["generated_texts", "retrieved_contents"],
         "consistency": ["generated_texts", "retrieved_contents"],
-        "relevance": ["generated_texts", "query"],
+        "relevance": ["generated_texts", "generation_gt"],
     }
     sentence_level_dimensions = {"fluency", "consistency"}
-
-    effective_scorer = scorer or get_unieval_scorer(
-        model_name_or_path=model_name_or_path,
-        max_length=max_length,
-        device=device,
-        cache_dir=cache_dir,
-    )
 
     prepared_inputs: list[str] = []
     prompt_counts: list[tuple[int, int]] = []
@@ -487,10 +501,13 @@ def unieval(
         if not metric_input.is_fields_notnone(field_map[normalized_dimension]):
             continue
 
-        generated_text = metric_input.generated_texts or ""
-        context = None
-        if normalized_dimension == "consistency" and metric_input.retrieved_contents is not None:
-            context = " ".join(metric_input.retrieved_contents)
+        generated_text = cast(str, metric_input.generated_texts).strip()
+        document = None
+        if normalized_dimension in {"coherence", "consistency"}:
+            document = _build_unieval_document(cast(list[str], metric_input.retrieved_contents))
+        reference = None
+        if normalized_dimension == "relevance":
+            reference = _select_unieval_reference(cast(list[str], metric_input.generation_gt))
 
         text_units = (
             _split_unieval_sentences(generated_text)
@@ -503,13 +520,20 @@ def unieval(
                 _build_unieval_prompt(
                     dimension=normalized_dimension,
                     generated_text=text_unit,
-                    query=metric_input.query,
-                    context=context,
+                    document=document,
+                    reference=reference,
                 )
             )
 
     if not prepared_inputs:
         return results
+
+    effective_scorer = scorer or get_unieval_scorer(
+        model_name_or_path=model_name_or_path,
+        max_length=max_length,
+        device=device,
+        cache_dir=cache_dir,
+    )
 
     prompt_scores = effective_scorer.score(prepared_inputs, batch_size=batch_size)
     if len(prompt_scores) != len(prepared_inputs):

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -19,6 +19,7 @@ from rouge_score.rouge_scorer import RougeScorer
 from sacrebleu.metrics.bleu import BLEU
 
 from autorag_research.config import BaseGenerationMetricConfig
+from autorag_research.evaluation.metrics.unieval import UniEvalScorer, get_unieval_scorer
 from autorag_research.evaluation.metrics.util import calculate_cosine_similarity, metric_loop
 from autorag_research.exceptions import EmbeddingError
 from autorag_research.injection import with_embedding, with_llm
@@ -55,6 +56,8 @@ Input:
 """
 
 _JSON_BLOCK_PATTERN = re.compile(r"\{.*\}", re.DOTALL)
+UNIEVAL_MODEL_NAME = "MingZhong/unieval-sum"
+UNIEVAL_DIMENSIONS = ("coherence", "consistency", "fluency", "relevance")
 
 
 def _extract_llm_text(response: Any) -> str:
@@ -122,6 +125,41 @@ def _calculate_response_relevancy_score(
     cosine_sim = np.dot(generated_vectors, query_vector.T).reshape(-1) / norm
     all_noncommittal = np.all(noncommittal_flags)
     return float(cosine_sim.mean() * int(not all_noncommittal))
+
+
+def _validate_unieval_dimension(dimension: str) -> str:
+    """Validate and normalize UniEval dimension name."""
+    normalized = dimension.strip().lower()
+    if normalized not in UNIEVAL_DIMENSIONS:
+        msg = f"Unsupported UniEval dimension: {dimension}"
+        raise ValueError(msg)
+    return normalized
+
+
+def _split_unieval_sentences(text: str) -> list[str]:
+    """Split text into sentences with a regex fallback when punkt data is unavailable."""
+    try:
+        sentences = [sentence.strip() for sentence in nltk.sent_tokenize(text) if sentence.strip()]
+    except LookupError:
+        sentences = [sentence.strip() for sentence in re.split(r"(?<=[.!?])\s+", text) if sentence.strip()]
+    return sentences or [text.strip()]
+
+
+def _build_unieval_prompt(
+    *,
+    dimension: str,
+    generated_text: str,
+    query: str | None = None,
+    context: str | None = None,
+) -> str:
+    """Build the Bool-QA prompt for a UniEval dimension."""
+    if dimension == "fluency":
+        return f"question: Is this a fluent answer? </s> answer: {generated_text}"
+    if dimension == "coherence":
+        return f"question: Is this a coherent answer? </s> answer: {generated_text}"
+    if dimension == "consistency":
+        return f"question: Is this answer consistent with the context? </s> answer: {generated_text} </s> context: {context}"
+    return f"question: Is this answer relevant to the question? </s> answer: {generated_text} </s> question: {query}"
 
 
 @convert_inputs_to_list
@@ -403,6 +441,92 @@ def response_relevancy(
     return scores
 
 
+@convert_inputs_to_list
+def unieval(
+    metric_inputs: list[MetricInput],
+    dimension: str,
+    model_name_or_path: str = UNIEVAL_MODEL_NAME,
+    batch_size: int = 8,
+    max_length: int = 1024,
+    device: str = "cpu",
+    cache_dir: str | None = None,
+    scorer: UniEvalScorer | None = None,
+) -> list[float | None]:
+    """Compute one UniEval dimension using the shared summarization checkpoint.
+
+    The implementation follows the official Bool-QA scoring path while adapting prompts
+    to AutoRAG generation inputs:
+    - fluency/coherence: generated text only
+    - relevance: query + generated text
+    - consistency: retrieved source context + generated text
+
+    Consistency intentionally skips samples with missing retrieved context instead of
+    silently falling back to hidden ground truth, keeping the metric faithful to the
+    actual evidence available to the generation pipeline.
+    """
+    normalized_dimension = _validate_unieval_dimension(dimension)
+    field_map = {
+        "fluency": ["generated_texts"],
+        "coherence": ["generated_texts"],
+        "consistency": ["generated_texts", "retrieved_contents"],
+        "relevance": ["generated_texts", "query"],
+    }
+    sentence_level_dimensions = {"fluency", "consistency"}
+
+    effective_scorer = scorer or get_unieval_scorer(
+        model_name_or_path=model_name_or_path,
+        max_length=max_length,
+        device=device,
+        cache_dir=cache_dir,
+    )
+
+    prepared_inputs: list[str] = []
+    prompt_counts: list[tuple[int, int]] = []
+    results: list[float | None] = [None] * len(metric_inputs)
+    for index, metric_input in enumerate(metric_inputs):
+        if not metric_input.is_fields_notnone(field_map[normalized_dimension]):
+            continue
+
+        generated_text = metric_input.generated_texts or ""
+        context = None
+        if normalized_dimension == "consistency" and metric_input.retrieved_contents is not None:
+            context = " ".join(metric_input.retrieved_contents)
+
+        text_units = (
+            _split_unieval_sentences(generated_text)
+            if normalized_dimension in sentence_level_dimensions
+            else [generated_text.strip()]
+        )
+        prompt_counts.append((index, len(text_units)))
+        for text_unit in text_units:
+            prepared_inputs.append(
+                _build_unieval_prompt(
+                    dimension=normalized_dimension,
+                    generated_text=text_unit,
+                    query=metric_input.query,
+                    context=context,
+                )
+            )
+
+    if not prepared_inputs:
+        return results
+
+    prompt_scores = effective_scorer.score(prepared_inputs, batch_size=batch_size)
+    if len(prompt_scores) != len(prepared_inputs):
+        msg = (
+            f"UniEval scorer returned {len(prompt_scores)} scores for {len(prepared_inputs)} prompts "
+            f"for dimension '{normalized_dimension}'"
+        )
+        raise ValueError(msg)
+    prompt_offset = 0
+    for index, count in prompt_counts:
+        current_scores = prompt_scores[prompt_offset : prompt_offset + count]
+        results[index] = float(sum(current_scores) / count)
+        prompt_offset += count
+
+    return results
+
+
 # Metric Configurations
 @dataclass
 class BleuConfig(BaseGenerationMetricConfig):
@@ -539,6 +663,41 @@ class ResponseRelevancyConfig(BaseGenerationMetricConfig):
             "llm": self.llm,
             "embedding_model": self.embedding_model,
             "prompt_template": self.prompt_template,
+        }
+
+
+@dataclass
+class UniEvalConfig(BaseGenerationMetricConfig):
+    """Configuration for one UniEval dimension."""
+
+    dimension: str = "consistency"
+    model_name_or_path: str = UNIEVAL_MODEL_NAME
+    batch_size: int = 8
+    max_length: int = 1024
+    device: str = "cpu"
+    cache_dir: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate UniEval configuration."""
+        self.dimension = _validate_unieval_dimension(self.dimension)
+
+    def get_metric_name(self) -> str:
+        """Return the metric name."""
+        return f"unieval_{self.dimension}"
+
+    def get_metric_func(self) -> Callable:
+        """Return the metric function."""
+        return unieval
+
+    def get_metric_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for the metric function."""
+        return {
+            "dimension": self.dimension,
+            "model_name_or_path": self.model_name_or_path,
+            "batch_size": self.batch_size,
+            "max_length": self.max_length,
+            "device": self.device,
+            "cache_dir": self.cache_dir,
         }
 
 

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -152,7 +152,11 @@ def _build_unieval_prompt(
     document: str | None = None,
     reference: str | None = None,
 ) -> str:
-    """Build the Bool-QA prompt for a UniEval dimension."""
+    """Build the Bool-QA prompt for a UniEval dimension.
+
+    These strings intentionally mirror UniEval's published `add_question`
+    summarization prompts, including the `</s>` separators.
+    """
     if dimension == "fluency":
         return f"question: Is this a fluent paragraph? </s> paragraph: {generated_text}"
     if dimension == "coherence":

--- a/autorag_research/evaluation/metrics/unieval.py
+++ b/autorag_research/evaluation/metrics/unieval.py
@@ -1,0 +1,116 @@
+"""UniEval scorer helpers."""
+
+import logging
+from functools import lru_cache
+from typing import Protocol
+
+logger = logging.getLogger("AutoRAG-Research")
+
+
+class UniEvalScorer(Protocol):
+    """Protocol for UniEval scorers used by generation metrics."""
+
+    def score(self, inputs: list[str], batch_size: int = 8) -> list[float]:
+        """Return one score per prompt."""
+
+
+class HuggingFaceUniEvalScorer:
+    """Thin wrapper around the official UniEval yes/no scoring logic."""
+
+    def __init__(
+        self,
+        model_name_or_path: str,
+        max_length: int = 1024,
+        device: str = "cpu",
+        cache_dir: str | None = None,
+    ) -> None:
+        try:
+            import torch
+            from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoTokenizer
+        except ImportError as exc:  # pragma: no cover - exercised via higher-level patch tests
+            msg = (
+                "UniEval requires torch, transformers, and sentencepiece-compatible tokenizer support. "
+                "Install the project extras with `uv sync --all-extras --all-groups`."
+            )
+            raise ImportError(msg) from exc
+
+        self._torch = torch
+        self.device = device
+        self.max_length = max_length
+        self.config = AutoConfig.from_pretrained(model_name_or_path, cache_dir=cache_dir)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, cache_dir=cache_dir)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(
+            model_name_or_path,
+            config=self.config,
+            cache_dir=cache_dir,
+        )
+        self.model.eval()
+        self.model.to(device)
+
+        self.pos_id = self.tokenizer("Yes", add_special_tokens=False)["input_ids"][0]
+        self.neg_id = self.tokenizer("No", add_special_tokens=False)["input_ids"][0]
+
+    def score(self, inputs: list[str], batch_size: int = 8) -> list[float]:
+        """Compute official-style Yes/(Yes+No) scores for Bool-QA prompts."""
+        if not inputs:
+            return []
+
+        target_tokens = ["No"] * len(inputs)
+        scores: list[float] = []
+
+        for start in range(0, len(inputs), batch_size):
+            batch_inputs = inputs[start : start + batch_size]
+            batch_targets = target_tokens[start : start + batch_size]
+            with self._torch.no_grad():
+                encoded_src = self.tokenizer(
+                    batch_inputs,
+                    max_length=self.max_length,
+                    truncation=True,
+                    padding=True,
+                    return_tensors="pt",
+                )
+                encoded_tgt = self.tokenizer(
+                    batch_targets,
+                    max_length=self.max_length,
+                    truncation=True,
+                    padding=True,
+                    return_tensors="pt",
+                )
+                decoder_tokens = encoded_tgt["input_ids"].to(self.device)[:, 0].unsqueeze(-1)
+
+                output = self.model(
+                    input_ids=encoded_src["input_ids"].to(self.device),
+                    attention_mask=encoded_src["attention_mask"].to(self.device),
+                    labels=decoder_tokens,
+                )
+                logits = output.logits.reshape(-1, self.model.config.vocab_size)
+                probabilities = self._torch.softmax(logits, dim=1)
+                yes_scores = probabilities[:, self.pos_id]
+                no_scores = probabilities[:, self.neg_id]
+                batch_scores = yes_scores / (yes_scores + no_scores)
+                scores.extend(float(score) for score in batch_scores.tolist())
+
+        return scores
+
+
+@lru_cache(maxsize=8)
+def get_unieval_scorer(
+    model_name_or_path: str = "MingZhong/unieval-sum",
+    max_length: int = 1024,
+    device: str = "cpu",
+    cache_dir: str | None = None,
+) -> UniEvalScorer:
+    """Return a cached UniEval scorer instance."""
+    logger.debug(
+        "Loading UniEval scorer model_name_or_path=%s max_length=%s device=%s cache_dir=%s",
+        model_name_or_path,
+        max_length,
+        device,
+        cache_dir,
+    )
+    return HuggingFaceUniEvalScorer(
+        model_name_or_path=model_name_or_path,
+        max_length=max_length,
+        device=device,
+        cache_dir=cache_dir,
+    )

--- a/configs/metrics/generation/unieval_coherence.yaml
+++ b/configs/metrics/generation/unieval_coherence.yaml
@@ -1,0 +1,7 @@
+_target_: autorag_research.evaluation.metrics.generation.UniEvalConfig
+description: "UniEval coherence - Bool-QA coherence scoring with MingZhong/unieval-sum"
+dimension: coherence
+model_name_or_path: MingZhong/unieval-sum
+batch_size: 8
+max_length: 1024
+device: cpu

--- a/configs/metrics/generation/unieval_coherence.yaml
+++ b/configs/metrics/generation/unieval_coherence.yaml
@@ -1,5 +1,5 @@
 _target_: autorag_research.evaluation.metrics.generation.UniEvalConfig
-description: "UniEval coherence - Bool-QA coherence scoring with MingZhong/unieval-sum"
+description: "UniEval coherence - summary coherence scoring against retrieved document context"
 dimension: coherence
 model_name_or_path: MingZhong/unieval-sum
 batch_size: 8

--- a/configs/metrics/generation/unieval_consistency.yaml
+++ b/configs/metrics/generation/unieval_consistency.yaml
@@ -1,0 +1,7 @@
+_target_: autorag_research.evaluation.metrics.generation.UniEvalConfig
+description: "UniEval consistency - source-faithfulness scoring against retrieved context"
+dimension: consistency
+model_name_or_path: MingZhong/unieval-sum
+batch_size: 8
+max_length: 1024
+device: cpu

--- a/configs/metrics/generation/unieval_fluency.yaml
+++ b/configs/metrics/generation/unieval_fluency.yaml
@@ -1,0 +1,7 @@
+_target_: autorag_research.evaluation.metrics.generation.UniEvalConfig
+description: "UniEval fluency - sentence-level fluency scoring with MingZhong/unieval-sum"
+dimension: fluency
+model_name_or_path: MingZhong/unieval-sum
+batch_size: 8
+max_length: 1024
+device: cpu

--- a/configs/metrics/generation/unieval_relevance.yaml
+++ b/configs/metrics/generation/unieval_relevance.yaml
@@ -1,5 +1,5 @@
 _target_: autorag_research.evaluation.metrics.generation.UniEvalConfig
-description: "UniEval relevance - answer relevance scoring against the query"
+description: "UniEval relevance - summary relevance scoring against the generation reference"
 dimension: relevance
 model_name_or_path: MingZhong/unieval-sum
 batch_size: 8

--- a/configs/metrics/generation/unieval_relevance.yaml
+++ b/configs/metrics/generation/unieval_relevance.yaml
@@ -1,0 +1,7 @@
+_target_: autorag_research.evaluation.metrics.generation.UniEvalConfig
+description: "UniEval relevance - answer relevance scoring against the query"
+dimension: relevance
+model_name_or_path: MingZhong/unieval-sum
+batch_size: 8
+max_length: 1024
+device: cpu

--- a/tests/autorag_research/cli/test_utils.py
+++ b/tests/autorag_research/cli/test_utils.py
@@ -155,7 +155,9 @@ class TestDiscoverMetrics:
         result = discover_metrics("generation")
 
         assert "rouge" in result
+        assert "unieval_coherence" in result
         assert "unieval_consistency" in result
+        assert "unieval_fluency" in result
         assert "unieval_relevance" in result
 
 

--- a/tests/autorag_research/cli/test_utils.py
+++ b/tests/autorag_research/cli/test_utils.py
@@ -155,6 +155,8 @@ class TestDiscoverMetrics:
         result = discover_metrics("generation")
 
         assert "rouge" in result
+        assert "unieval_consistency" in result
+        assert "unieval_relevance" in result
 
 
 class TestDiscoverEmbeddingConfigs:

--- a/tests/autorag_research/evaluation/metrics/test_unieval.py
+++ b/tests/autorag_research/evaluation/metrics/test_unieval.py
@@ -130,6 +130,51 @@ def test_unieval_relevance_requires_generation_gt_and_uses_reference_prompt():
     ]
 
 
+def test_unieval_relevance_checks_all_references_without_order_dependence():
+    first_scorer = DummyUniEvalScorer(responses=[0.14, 0.86])
+    second_scorer = DummyUniEvalScorer(responses=[0.86, 0.14])
+
+    first_scores = unieval(
+        metric_inputs=[
+            MetricInput(
+                generation_gt=["Wrong first reference", "Paris is France's capital."],
+                generated_texts="Paris is the capital of France.",
+            )
+        ],
+        dimension="relevance",
+        scorer=first_scorer,
+    )
+    second_scores = unieval(
+        metric_inputs=[
+            MetricInput(
+                generation_gt=["Paris is France's capital.", "Wrong second reference"],
+                generated_texts="Paris is the capital of France.",
+            )
+        ],
+        dimension="relevance",
+        scorer=second_scorer,
+    )
+
+    assert first_scores == [pytest.approx(0.86)]
+    assert second_scores == [pytest.approx(0.86)]
+    assert first_scorer.calls == [
+        [
+            "question: Is this summary relevant to the reference? </s> summary: Paris is the capital of France. "
+            "</s> reference: Wrong first reference",
+            "question: Is this summary relevant to the reference? </s> summary: Paris is the capital of France. "
+            "</s> reference: Paris is France's capital.",
+        ]
+    ]
+    assert second_scorer.calls == [
+        [
+            "question: Is this summary relevant to the reference? </s> summary: Paris is the capital of France. "
+            "</s> reference: Paris is France's capital.",
+            "question: Is this summary relevant to the reference? </s> summary: Paris is the capital of France. "
+            "</s> reference: Wrong second reference",
+        ]
+    ]
+
+
 def test_unieval_relevance_returns_none_without_generation_gt():
     scores = unieval(
         metric_inputs=[MetricInput(generated_texts="Paris is the capital of France.")],

--- a/tests/autorag_research/evaluation/metrics/test_unieval.py
+++ b/tests/autorag_research/evaluation/metrics/test_unieval.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+
+import pytest
+
+from autorag_research.evaluation.metrics.generation import UniEvalConfig, unieval
+from autorag_research.schema import MetricInput
+
+
+@dataclass
+class DummyUniEvalScorer:
+    responses: list[float]
+
+    def __post_init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def score(self, inputs: list[str], batch_size: int = 8) -> list[float]:
+        self.calls.append(inputs)
+        return self.responses[: len(inputs)]
+
+
+def test_unieval_fluency_averages_sentence_scores():
+    scorer = DummyUniEvalScorer(responses=[0.2, 0.8])
+
+    scores = unieval(
+        metric_inputs=[MetricInput(generated_texts="First sentence. Second sentence.")],
+        dimension="fluency",
+        scorer=scorer,
+    )
+
+    assert scores == [pytest.approx(0.5)]
+    assert scorer.calls == [
+        [
+            "question: Is this a fluent answer? </s> answer: First sentence.",
+            "question: Is this a fluent answer? </s> answer: Second sentence.",
+        ]
+    ]
+
+
+def test_unieval_relevance_uses_query_prompt():
+    scorer = DummyUniEvalScorer(responses=[0.73])
+
+    scores = unieval(
+        metric_inputs=[
+            MetricInput(
+                query="What is the capital of France?",
+                generated_texts="Paris is the capital of France.",
+            )
+        ],
+        dimension="relevance",
+        scorer=scorer,
+    )
+
+    assert scores == [pytest.approx(0.73)]
+    assert scorer.calls == [
+        [
+            "question: Is this answer relevant to the question? </s> answer: Paris is the capital of France. "
+            "</s> question: What is the capital of France?"
+        ]
+    ]
+
+
+def test_unieval_consistency_requires_retrieved_context():
+    scores = unieval(
+        metric_inputs=[MetricInput(generated_texts="Paris is the capital of France.")],
+        dimension="consistency",
+        scorer=DummyUniEvalScorer(responses=[0.9]),
+    )
+
+    assert scores == [None]
+
+
+def test_unieval_config_uses_dimension_specific_metric_name():
+    config = UniEvalConfig(dimension="consistency", batch_size=4, device="cpu")
+
+    assert config.get_metric_name() == "unieval_consistency"
+    assert config.get_metric_kwargs()["dimension"] == "consistency"
+    assert config.get_metric_kwargs()["batch_size"] == 4
+
+
+def test_unieval_invalid_dimension_raises_value_error():
+    with pytest.raises(ValueError, match="Unsupported UniEval dimension"):
+        UniEvalConfig(dimension="unsupported")
+
+
+def test_unieval_model_loading_failure_surfaces_helpful_error(monkeypatch: pytest.MonkeyPatch):
+    def raise_import_error(**_: object) -> object:
+        import importlib
+
+        importlib.import_module("transformers_missing_for_unieval_test")
+        return object()
+
+    monkeypatch.setattr(
+        "autorag_research.evaluation.metrics.generation.get_unieval_scorer",
+        raise_import_error,
+    )
+
+    with pytest.raises(ImportError, match="transformers_missing_for_unieval_test"):
+        unieval(
+            metric_inputs=[MetricInput(generated_texts="A coherent answer.")],
+            dimension="coherence",
+        )
+
+
+def test_unieval_raises_when_scorer_returns_wrong_number_of_scores():
+    with pytest.raises(ValueError, match="returned 1 scores for 2 prompts"):
+        unieval(
+            metric_inputs=[MetricInput(generated_texts="First sentence. Second sentence.")],
+            dimension="fluency",
+            scorer=DummyUniEvalScorer(responses=[0.2]),
+        )

--- a/tests/autorag_research/evaluation/metrics/test_unieval.py
+++ b/tests/autorag_research/evaluation/metrics/test_unieval.py
@@ -30,19 +30,90 @@ def test_unieval_fluency_averages_sentence_scores():
     assert scores == [pytest.approx(0.5)]
     assert scorer.calls == [
         [
-            "question: Is this a fluent answer? </s> answer: First sentence.",
-            "question: Is this a fluent answer? </s> answer: Second sentence.",
+            "question: Is this a fluent paragraph? </s> paragraph: First sentence.",
+            "question: Is this a fluent paragraph? </s> paragraph: Second sentence.",
         ]
     ]
 
 
-def test_unieval_relevance_uses_query_prompt():
+def test_unieval_coherence_requires_retrieved_context_and_uses_document_prompt():
+    scorer = DummyUniEvalScorer(responses=[0.61])
+
+    scores = unieval(
+        metric_inputs=[
+            MetricInput(
+                generated_texts="Paris is the capital of France. It is in Europe.",
+                retrieved_contents=["France is a country in Europe.", "Paris is its capital city."],
+            )
+        ],
+        dimension="coherence",
+        scorer=scorer,
+    )
+
+    assert scores == [pytest.approx(0.61)]
+    assert scorer.calls == [
+        [
+            "question: Is this a coherent summary to the document? </s> summary: Paris is the capital of France. "
+            "It is in Europe. </s> document: France is a country in Europe. Paris is its capital city."
+        ]
+    ]
+
+
+def test_unieval_coherence_returns_none_without_retrieved_context():
+    scores = unieval(
+        metric_inputs=[MetricInput(generated_texts="Paris is the capital of France.")],
+        dimension="coherence",
+        scorer=DummyUniEvalScorer(responses=[0.9]),
+    )
+
+    assert scores == [None]
+
+
+def test_unieval_consistency_requires_retrieved_context():
+    scorer = DummyUniEvalScorer(responses=[0.9])
+
+    scores = unieval(
+        metric_inputs=[MetricInput(generated_texts="Paris is the capital of France.")],
+        dimension="consistency",
+        scorer=scorer,
+    )
+
+    assert scores == [None]
+    assert scorer.calls == []
+
+
+def test_unieval_consistency_averages_sentence_scores_against_document():
+    scorer = DummyUniEvalScorer(responses=[0.25, 0.75])
+
+    scores = unieval(
+        metric_inputs=[
+            MetricInput(
+                generated_texts="Paris is the capital of France. It is in Europe.",
+                retrieved_contents=["France is a country in Europe.", "Paris is its capital city."],
+            )
+        ],
+        dimension="consistency",
+        scorer=scorer,
+    )
+
+    assert scores == [pytest.approx(0.5)]
+    assert scorer.calls == [
+        [
+            "question: Is this claim consistent with the document? </s> claim: Paris is the capital of France. "
+            "</s> document: France is a country in Europe. Paris is its capital city.",
+            "question: Is this claim consistent with the document? </s> claim: It is in Europe. "
+            "</s> document: France is a country in Europe. Paris is its capital city.",
+        ]
+    ]
+
+
+def test_unieval_relevance_requires_generation_gt_and_uses_reference_prompt():
     scorer = DummyUniEvalScorer(responses=[0.73])
 
     scores = unieval(
         metric_inputs=[
             MetricInput(
-                query="What is the capital of France?",
+                generation_gt=["Paris is France's capital."],
                 generated_texts="Paris is the capital of France.",
             )
         ],
@@ -53,27 +124,36 @@ def test_unieval_relevance_uses_query_prompt():
     assert scores == [pytest.approx(0.73)]
     assert scorer.calls == [
         [
-            "question: Is this answer relevant to the question? </s> answer: Paris is the capital of France. "
-            "</s> question: What is the capital of France?"
+            "question: Is this summary relevant to the reference? </s> summary: Paris is the capital of France. "
+            "</s> reference: Paris is France's capital."
         ]
     ]
 
 
-def test_unieval_consistency_requires_retrieved_context():
+def test_unieval_relevance_returns_none_without_generation_gt():
     scores = unieval(
         metric_inputs=[MetricInput(generated_texts="Paris is the capital of France.")],
-        dimension="consistency",
+        dimension="relevance",
         scorer=DummyUniEvalScorer(responses=[0.9]),
     )
 
     assert scores == [None]
 
 
-def test_unieval_config_uses_dimension_specific_metric_name():
-    config = UniEvalConfig(dimension="consistency", batch_size=4, device="cpu")
+@pytest.mark.parametrize(
+    ("dimension", "metric_name"),
+    [
+        ("coherence", "unieval_coherence"),
+        ("consistency", "unieval_consistency"),
+        ("fluency", "unieval_fluency"),
+        ("relevance", "unieval_relevance"),
+    ],
+)
+def test_unieval_config_uses_dimension_specific_metric_name(dimension: str, metric_name: str):
+    config = UniEvalConfig(dimension=dimension, batch_size=4, device="cpu")
 
-    assert config.get_metric_name() == "unieval_consistency"
-    assert config.get_metric_kwargs()["dimension"] == "consistency"
+    assert config.get_metric_name() == metric_name
+    assert config.get_metric_kwargs()["dimension"] == dimension
     assert config.get_metric_kwargs()["batch_size"] == 4
 
 
@@ -96,9 +176,28 @@ def test_unieval_model_loading_failure_surfaces_helpful_error(monkeypatch: pytes
 
     with pytest.raises(ImportError, match="transformers_missing_for_unieval_test"):
         unieval(
-            metric_inputs=[MetricInput(generated_texts="A coherent answer.")],
+            metric_inputs=[
+                MetricInput(generated_texts="A coherent answer.", retrieved_contents=["supporting document"])
+            ],
             dimension="coherence",
         )
+
+
+def test_unieval_skips_scorer_loading_when_all_inputs_are_missing_required_fields(monkeypatch: pytest.MonkeyPatch):
+    def fail_to_load(**_: object) -> object:
+        raise AssertionError
+
+    monkeypatch.setattr(
+        "autorag_research.evaluation.metrics.generation.get_unieval_scorer",
+        fail_to_load,
+    )
+
+    scores = unieval(
+        metric_inputs=[MetricInput(generated_texts="Paris is the capital of France.")],
+        dimension="relevance",
+    )
+
+    assert scores == [None]
 
 
 def test_unieval_raises_when_scorer_returns_wrong_number_of_scores():


### PR DESCRIPTION
<!-- dani:stage=implementation;job=5c0ec4b8e05e41a58f64e979e6786a44;issue=339 -->

## Summary
- add a shared lazy-loaded UniEval scorer backed by `MingZhong/unieval-sum`
- expose scalar generation metrics for coherence, consistency, fluency, and relevance via separate configs
- add focused offline tests for prompt shaping, config naming/discovery, missing-context behavior, and scorer loading failures

## Verification
- `make check`
- `uv run pytest tests/autorag_research/evaluation/metrics/test_unieval.py tests/autorag_research/evaluation/metrics/test_generation.py tests/autorag_research/cli/test_utils.py -q -m 'not gpu and not api and not data'`
- `uv run python` smoke test for inline UniEval fluency scoring with a dummy scorer
- `make test`

## Notes
- consistency intentionally requires `retrieved_contents`; it does not fall back to `retrieval_gt_contents` to avoid leaking hidden ground truth into a source-faithfulness metric
