### PR TITLE
Feature/#117

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Standalone retrieval pipelines. Use them on their own for retrieval-only evaluat
 | [RETRO*](https://openreview.net/pdf?id=0WGl8PNMSA)                               | Rubric-based LLM reranking over retrieved candidates                   | ICLR 26   |
 | [Hybrid RRF](https://cormack.uwaterloo.ca/cormacksigir09-rrf.pdf)                | Reciprocal Rank Fusion of two retrieval pipelines                      | -         |
 | [Hybrid CC](https://arxiv.org/pdf/2210.11934)                                    | Convex Combination fusion of two retrieval pipelines                   | -         |
+| [Power of Noise](https://arxiv.org/abs/2401.14887)                             | Base retriever + seeded random noise wrapper                          | SIGIR 24  |
 
 ### 2. Generation Pipeline
 

--- a/autorag_research/orm/repository/chunk.py
+++ b/autorag_research/orm/repository/chunk.py
@@ -120,6 +120,21 @@ class ChunkRepository(BaseVectorRepository[Any], BaseEmbeddingRepository[Any]):
         )
         return self.session.execute(stmt).unique().scalar_one_or_none()
 
+    def get_all_ids(self, limit: int | None = None, offset: int = 0) -> list[int | str]:
+        """Get all chunk IDs ordered by ID.
+
+        Args:
+            limit: Maximum number of chunk IDs to return.
+            offset: Number of chunk IDs to skip.
+
+        Returns:
+            Ordered list of chunk IDs.
+        """
+        stmt = select(self.model_cls.id).order_by(self.model_cls.id).offset(offset)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        return list(self.session.execute(stmt).scalars().all())
+
     def get_chunks_with_empty_content(self, limit: int | None = None) -> list[Any]:
         """Retrieve chunks that have empty or whitespace-only contents.
 

--- a/autorag_research/pipelines/retrieval/__init__.py
+++ b/autorag_research/pipelines/retrieval/__init__.py
@@ -14,6 +14,10 @@ from autorag_research.pipelines.retrieval.hyde import (
     HyDEPipelineConfig,
     HyDERetrievalPipeline,
 )
+from autorag_research.pipelines.retrieval.power_of_noise import (
+    PowerOfNoiseRetrievalPipeline,
+    PowerOfNoiseRetrievalPipelineConfig,
+)
 from autorag_research.pipelines.retrieval.query_rewrite import (
     QueryRewritePipelineConfig,
     QueryRewriteRetrievalPipeline,
@@ -39,6 +43,8 @@ __all__ = [
     "HybridCCRetrievalPipelineConfig",
     "HybridRRFRetrievalPipeline",
     "HybridRRFRetrievalPipelineConfig",
+    "PowerOfNoiseRetrievalPipeline",
+    "PowerOfNoiseRetrievalPipelineConfig",
     "QueryRewritePipelineConfig",
     "QueryRewriteRetrievalPipeline",
     "RetroStarPipelineConfig",

--- a/autorag_research/pipelines/retrieval/loader.py
+++ b/autorag_research/pipelines/retrieval/loader.py
@@ -21,6 +21,11 @@ PIPELINE_TYPES = ["pipelines", "retrieval"]
 class RetrievalPipelineLoader:
     """Load retrieval pipelines and inject nested retrieval dependencies."""
 
+    _DEPENDENCY_FIELDS: tuple[tuple[str, str], ...] = (
+        ("retrieval_pipeline_name", "_retrieval_pipeline"),
+        ("inner_retrieval_pipeline_name", "_inner_retrieval_pipeline"),
+    )
+
     def __init__(
         self,
         session_factory: sessionmaker[Session],
@@ -43,11 +48,22 @@ class RetrievalPipelineLoader:
         resolution_key: str | None = None,
     ) -> None:
         """Resolve retrieval-pipeline dependencies for configs that declare them."""
-        dependency_name = getattr(config, "retrieval_pipeline_name", "")
         inject_retrieval_pipeline = getattr(config, "inject_retrieval_pipeline", None)
-        existing_pipeline = getattr(config, "_retrieval_pipeline", None)
 
-        if not dependency_name or not callable(inject_retrieval_pipeline):
+        if not callable(inject_retrieval_pipeline):
+            return
+
+        dependency_name = ""
+        existing_pipeline = None
+        for dependency_attr, existing_attr in self._DEPENDENCY_FIELDS:
+            candidate_name = getattr(config, dependency_attr, "")
+            if not candidate_name:
+                continue
+            dependency_name = candidate_name
+            existing_pipeline = getattr(config, existing_attr, None)
+            break
+
+        if not dependency_name:
             return
 
         if existing_pipeline is not None:

--- a/autorag_research/pipelines/retrieval/power_of_noise.py
+++ b/autorag_research/pipelines/retrieval/power_of_noise.py
@@ -180,9 +180,7 @@ class PowerOfNoiseRetrievalPipeline(BaseRetrievalPipeline):
                 query = uow.queries.get_with_retrieval_relations(query_id)
                 if query is not None:
                     excluded_ids.update(
-                        relation.chunk_id
-                        for relation in query.retrieval_relations
-                        if relation.chunk_id is not None
+                        relation.chunk_id for relation in query.retrieval_relations if relation.chunk_id is not None
                     )
 
                     answers = [answer.casefold() for answer in (query.generation_gt or []) if answer]

--- a/autorag_research/pipelines/retrieval/power_of_noise.py
+++ b/autorag_research/pipelines/retrieval/power_of_noise.py
@@ -1,0 +1,271 @@
+"""Power of Noise retrieval pipeline for AutoRAG-Research.
+
+This module implements a configurable retrieval wrapper inspired by
+*The Power of Noise: Redefining Retrieval for RAG Systems*.
+It combines an existing retrieval pipeline with seeded random noise
+samples from the corpus so researchers can study how noisy context
+composition affects downstream RAG behavior.
+"""
+
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseRetrievalPipelineConfig
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.hybrid import HybridRetrievalPipeline
+
+NoiseOrder = Literal["retrieved_first", "noise_first", "interleave"]
+NoiseMode = Literal["random", "answer_aware_random"]
+
+
+@dataclass(kw_only=True)
+class PowerOfNoiseRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
+    """Configuration for the Power of Noise retrieval pipeline."""
+
+    base_retrieval_pipeline_name: str
+    noise_count: int = 0
+    noise_ratio: float | None = None
+    noise_order: NoiseOrder = "retrieved_first"
+    noise_mode: NoiseMode = "random"
+    seed: int = 0
+
+    def __post_init__(self) -> None:
+        if self.noise_count < 0:
+            msg = "noise_count must be >= 0"
+            raise ValueError(msg)
+        if self.noise_ratio is not None and not 0 <= self.noise_ratio <= 1:
+            msg = "noise_ratio must be between 0 and 1"
+            raise ValueError(msg)
+
+    def get_pipeline_class(self) -> type["PowerOfNoiseRetrievalPipeline"]:
+        """Return the PowerOfNoiseRetrievalPipeline class."""
+        return PowerOfNoiseRetrievalPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for PowerOfNoiseRetrievalPipeline constructor."""
+        return {
+            "base_retrieval_pipeline": self.base_retrieval_pipeline_name,
+            "noise_count": self.noise_count,
+            "noise_ratio": self.noise_ratio,
+            "noise_order": self.noise_order,
+            "noise_mode": self.noise_mode,
+            "seed": self.seed,
+        }
+
+
+class PowerOfNoiseRetrievalPipeline(BaseRetrievalPipeline):
+    """Wrap a base retriever and inject seeded corpus noise."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        base_retrieval_pipeline: BaseRetrievalPipeline | str,
+        noise_count: int = 0,
+        noise_ratio: float | None = None,
+        noise_order: NoiseOrder = "retrieved_first",
+        noise_mode: NoiseMode = "random",
+        seed: int = 0,
+        schema: Any | None = None,
+        config_dir: Path | None = None,
+    ):
+        if noise_count < 0:
+            msg = "noise_count must be >= 0"
+            raise ValueError(msg)
+        if noise_ratio is not None and not 0 <= noise_ratio <= 1:
+            msg = "noise_ratio must be between 0 and 1"
+            raise ValueError(msg)
+
+        if isinstance(base_retrieval_pipeline, str):
+            base_retrieval_pipeline = HybridRetrievalPipeline._load_pipeline(
+                base_retrieval_pipeline,
+                session_factory,
+                schema,
+                config_dir,
+            )
+
+        self._base_retrieval_pipeline = base_retrieval_pipeline
+        self.noise_count = noise_count
+        self.noise_ratio = noise_ratio
+        self.noise_order = noise_order
+        self.noise_mode = noise_mode
+        self.seed = seed
+
+        super().__init__(session_factory, name, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return pipeline configuration for persistence."""
+        return {
+            "type": "power_of_noise",
+            "base_retrieval_pipeline": self._base_retrieval_pipeline.name,
+            "noise_count": self.noise_count,
+            "noise_ratio": self.noise_ratio,
+            "noise_order": self.noise_order,
+            "noise_mode": self.noise_mode,
+            "seed": self.seed,
+        }
+
+    def _resolve_noise_count(self, top_k: int) -> int:
+        """Resolve how many noisy documents to inject for a request."""
+        if top_k <= 0:
+            return 0
+
+        if self.noise_count > 0:
+            return min(top_k, self.noise_count)
+
+        if self.noise_ratio is None:
+            return 0
+
+        return min(top_k, max(0, round(top_k * self.noise_ratio)))
+
+    def _compose_results(
+        self,
+        base_results: list[dict[str, Any]],
+        noise_results: list[dict[str, Any]],
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        """Compose retrieved and noisy documents into the final context order."""
+        if self.noise_order == "retrieved_first":
+            combined = [*base_results, *noise_results]
+        elif self.noise_order == "noise_first":
+            combined = [*noise_results, *base_results]
+        else:
+            combined: list[dict[str, Any]] = []
+            for index in range(max(len(base_results), len(noise_results))):
+                if index < len(base_results):
+                    combined.append(base_results[index])
+                if index < len(noise_results):
+                    combined.append(noise_results[index])
+
+        return combined[:top_k]
+
+    def _build_seed_key(self, query_value: int | str) -> str:
+        """Build a deterministic random seed key per query."""
+        return f"{self.seed}:{query_value}"
+
+    def _load_chunk_results(self, chunk_ids: list[int | str]) -> list[dict[str, Any]]:
+        """Load chunk contents and return them in retrieval-result shape."""
+        if not chunk_ids:
+            return []
+
+        with self._service._create_uow() as uow:
+            chunks = uow.chunks.get_by_ids(chunk_ids)
+            chunk_by_id = {chunk.id: chunk for chunk in chunks}
+
+        return [
+            {
+                "doc_id": chunk_id,
+                "score": 0.0,
+                "content": chunk_by_id[chunk_id].contents,
+            }
+            for chunk_id in chunk_ids
+            if chunk_id in chunk_by_id
+        ]
+
+    def _get_noise_candidate_ids(
+        self,
+        *,
+        excluded_doc_ids: set[int | str],
+        query_id: int | str | None = None,
+    ) -> list[int | str]:
+        """Return chunk IDs eligible for noise injection."""
+        with self._service._create_uow() as uow:
+            excluded_ids = set(excluded_doc_ids)
+
+            if self.noise_mode == "answer_aware_random" and query_id is not None:
+                query = uow.queries.get_with_retrieval_relations(query_id)
+                if query is not None:
+                    excluded_ids.update(
+                        relation.chunk_id
+                        for relation in query.retrieval_relations
+                        if relation.chunk_id is not None
+                    )
+
+                    answers = [answer.casefold() for answer in (query.generation_gt or []) if answer]
+                    if answers:
+                        candidate_ids: list[int | str] = []
+                        for chunk in uow.chunks.get_all():
+                            if chunk.id in excluded_ids:
+                                continue
+                            contents = (chunk.contents or "").casefold()
+                            if any(answer in contents for answer in answers):
+                                continue
+                            candidate_ids.append(cast(int | str, chunk.id))
+                        sorted_candidate_ids = sorted(candidate_ids, key=str)
+                        return cast(list[int | str], sorted_candidate_ids)
+
+            all_chunk_ids = [cast(int | str, chunk_id) for chunk_id in uow.chunks.get_all_ids()]
+            sorted_all_chunk_ids = sorted(
+                (chunk_id for chunk_id in all_chunk_ids if chunk_id not in excluded_ids),
+                key=str,
+            )
+            return cast(list[int | str], sorted_all_chunk_ids)
+
+    def _sample_noise_results(
+        self,
+        *,
+        sample_size: int,
+        query_value: int | str,
+        excluded_doc_ids: set[int | str],
+        query_id: int | str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Sample deterministic noise documents from the corpus."""
+        if sample_size <= 0:
+            return []
+
+        candidate_ids = self._get_noise_candidate_ids(query_id=query_id, excluded_doc_ids=excluded_doc_ids)
+        if not candidate_ids:
+            return []
+
+        rng = random.Random(self._build_seed_key(query_value))
+        selected_ids = rng.sample(candidate_ids, k=min(sample_size, len(candidate_ids)))
+        return self._load_chunk_results(selected_ids)
+
+    async def _retrieve_with_noise(
+        self,
+        *,
+        query_value: int | str,
+        top_k: int,
+        base_retriever: Any,
+        query_id: int | str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Retrieve with the base pipeline and inject noise when configured."""
+        planned_noise_count = self._resolve_noise_count(top_k)
+        base_top_k = max(top_k - planned_noise_count, 0)
+        base_results = await base_retriever(base_top_k) if base_top_k > 0 else []
+
+        if planned_noise_count == 0:
+            return base_results[:top_k]
+
+        excluded_doc_ids = {result["doc_id"] for result in base_results if result.get("doc_id") is not None}
+        noise_results = self._sample_noise_results(
+            sample_size=planned_noise_count,
+            query_value=query_value,
+            query_id=query_id,
+            excluded_doc_ids=excluded_doc_ids,
+        )
+        return self._compose_results(base_results, noise_results, top_k)
+
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        """Retrieve from the base pipeline, then inject seeded noise docs."""
+        return await self._retrieve_with_noise(
+            query_value=query_id,
+            query_id=query_id,
+            top_k=top_k,
+            base_retriever=lambda base_top_k: self._base_retrieval_pipeline._retrieve_by_id(query_id, base_top_k),
+        )
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        """Retrieve from the base pipeline for ad-hoc text and add seeded noise."""
+        return await self._retrieve_with_noise(
+            query_value=query_text,
+            top_k=top_k,
+            base_retriever=lambda base_top_k: self._base_retrieval_pipeline._retrieve_by_text(query_text, base_top_k),
+        )
+
+
+__all__ = ["PowerOfNoiseRetrievalPipeline", "PowerOfNoiseRetrievalPipelineConfig"]

--- a/configs/pipelines/retrieval/power_of_noise.yaml
+++ b/configs/pipelines/retrieval/power_of_noise.yaml
@@ -1,0 +1,28 @@
+# Power of Noise Retrieval Pipeline Configuration
+#
+# Wraps an existing retrieval pipeline and injects seeded random noise
+# documents from the corpus. Useful for paper-style ablations comparing
+# retrieval quality against downstream RAG behavior under noisy context.
+#
+# Parameters:
+#   base_retrieval_pipeline_name: Existing retrieval pipeline to wrap
+#   noise_count: Fixed number of noisy documents to inject (takes precedence over noise_ratio)
+#   noise_ratio: Fraction of final top_k budget reserved for noise when noise_count is 0
+#   noise_order: retrieved_first | noise_first | interleave
+#   noise_mode: random | answer_aware_random
+#   seed: Deterministic sampling seed
+#
+_target_: autorag_research.pipelines.retrieval.power_of_noise.PowerOfNoiseRetrievalPipelineConfig
+description: "Seeded noise-injection wrapper for retrieval ablations"
+name: power_of_noise
+base_retrieval_pipeline_name: vector_search
+noise_count: 2
+noise_ratio: null
+noise_order: retrieved_first
+noise_mode: random
+seed: 42
+top_k: 10
+batch_size: 128
+max_concurrency: 16
+max_retries: 3
+retry_delay: 1.0

--- a/docs/pipelines/retrieval/index.md
+++ b/docs/pipelines/retrieval/index.md
@@ -12,6 +12,7 @@ Algorithms that take a query and return relevant documents.
 | [HyDE](hyde.md) | Dense (hypothetical document embeddings) | Text |
 | [Query Rewrite](query-rewrite.md) | Rewrite query text before retrieval | Text |
 | [RETRO*](retro-star.md) | Rubric-based LLM reranking over retrieved candidates | Text |
+| [Power of Noise](power-of-noise.md) | Retrieval wrapper + seeded noise injection | Text |
 
 ## Base Class
 

--- a/docs/pipelines/retrieval/power-of-noise.md
+++ b/docs/pipelines/retrieval/power-of-noise.md
@@ -1,0 +1,49 @@
+# Power of Noise
+
+A retrieval wrapper inspired by [The Power of Noise: Redefining Retrieval for RAG Systems](https://arxiv.org/abs/2401.14887).
+Instead of only returning the base retriever's highest-ranked documents, this pipeline mixes in seeded random corpus documents so you can evaluate how noisy context changes downstream RAG quality.
+
+## When to use it
+
+- Reproduce paper-style retrieval-noise ablations
+- Compare retrieval metrics vs generation quality under noisy context
+- Test whether a generator is robust to distractor documents
+
+## Key features
+
+- Wraps any existing retrieval pipeline
+- Deterministic sampling with `seed`
+- Supports fixed `noise_count` or ratio-based `noise_ratio`
+- Supports `retrieved_first`, `noise_first`, or `interleave` ordering
+- Includes an evaluation-only `answer_aware_random` mode that excludes known positives and answer-containing chunks when query metadata is available
+
+## Config
+
+```yaml
+_target_: autorag_research.pipelines.retrieval.power_of_noise.PowerOfNoiseRetrievalPipelineConfig
+name: power_of_noise
+base_retrieval_pipeline_name: vector_search
+noise_count: 2
+noise_order: interleave
+noise_mode: random
+seed: 42
+top_k: 10
+```
+
+## Parameters
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `base_retrieval_pipeline_name` | `str` | required | Existing retrieval pipeline to wrap |
+| `noise_count` | `int` | `0` | Fixed number of noisy documents to inject |
+| `noise_ratio` | `float \| null` | `null` | Fraction of `top_k` reserved for noise when `noise_count == 0` |
+| `noise_order` | `str` | `retrieved_first` | Final ordering: `retrieved_first`, `noise_first`, or `interleave` |
+| `noise_mode` | `str` | `random` | `random` for deployable seeded noise, `answer_aware_random` for evaluation-only exclusion of positives / answer-containing chunks |
+| `seed` | `int` | `0` | Deterministic sampling seed |
+
+## Notes
+
+- `noise_count` takes precedence over `noise_ratio`.
+- `answer_aware_random` needs a DB-backed query with `generation_gt` and/or retrieval relations. For ad-hoc raw text queries, the wrapper falls back to standard random noise sampling.
+- The wrapper preserves the base retriever's scores and assigns noise documents a score of `0.0`.
+- `noise_count` and `noise_ratio` define the noise budget. If the base retriever under-fills its share, the wrapper does **not** silently add extra noise beyond that configured budget.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
           - pipelines/retrieval/bm25.md
           - pipelines/retrieval/retro-star.md
           - pipelines/retrieval/vector-search.md
+          - pipelines/retrieval/power-of-noise.md
       - Generation:
           - pipelines/generation/index.md
           - pipelines/generation/basic-rag.md

--- a/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
@@ -362,8 +362,7 @@ class TestPowerOfNoiseRetrievalPipeline:
         results = await pipeline._retrieve_by_text("ad hoc query", top_k=4)
 
         assert len(results) == 2
-        assert [result["doc_id"] for result in results[:1]] == [2]
-        assert results[1]["doc_id"] != 2
+        assert [result["doc_id"] for result in results] == [2, 7]
 
     @pytest.mark.asyncio
     async def test_noise_ratio_controls_noise_budget(

--- a/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
@@ -1,0 +1,319 @@
+"""Tests for PowerOfNoiseRetrievalPipeline."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.orm.repository.chunk_retrieved_result import ChunkRetrievedResultRepository
+from autorag_research.orm.schema import Chunk
+from autorag_research.pipelines.retrieval.power_of_noise import (
+    PowerOfNoiseRetrievalPipeline,
+    PowerOfNoiseRetrievalPipelineConfig,
+)
+from tests.autorag_research.pipelines.pipeline_test_utils import (
+    PipelineTestConfig,
+    PipelineTestVerifier,
+)
+
+
+@pytest.fixture
+
+def cleanup_pipeline_results(session_factory: sessionmaker[Session]):
+    """Delete created retrieval results and temporary chunks after each test."""
+    created_pipeline_ids: list[int] = []
+    created_chunk_ids: list[int] = []
+
+    yield created_pipeline_ids, created_chunk_ids
+
+    session = session_factory()
+    try:
+        result_repo = ChunkRetrievedResultRepository(session)
+        for pipeline_id in created_pipeline_ids:
+            result_repo.delete_by_pipeline(pipeline_id)
+        if created_chunk_ids:
+            session.execute(delete(Chunk).where(Chunk.id.in_(created_chunk_ids)))
+        session.commit()
+    finally:
+        session.close()
+
+
+@pytest.fixture
+
+def base_pipeline_stub() -> SimpleNamespace:
+    """Provide a stub retrieval pipeline for wrapper tests."""
+    return SimpleNamespace(
+        name="vector_search",
+        _retrieve_by_id=AsyncMock(return_value=[
+            {"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"},
+            {"doc_id": 3, "score": 0.8, "content": "Chunk 2-1"},
+        ]),
+        _retrieve_by_text=AsyncMock(return_value=[
+            {"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"},
+            {"doc_id": 3, "score": 0.8, "content": "Chunk 2-1"},
+        ]),
+    )
+
+
+class TestPowerOfNoisePipelineConfig:
+    """Tests for PowerOfNoiseRetrievalPipelineConfig."""
+
+    def test_config_get_pipeline_class(self):
+        config = PowerOfNoiseRetrievalPipelineConfig(
+            name="power_of_noise",
+            base_retrieval_pipeline_name="vector_search",
+        )
+
+        assert config.get_pipeline_class() == PowerOfNoiseRetrievalPipeline
+
+    def test_config_get_pipeline_kwargs(self):
+        config = PowerOfNoiseRetrievalPipelineConfig(
+            name="power_of_noise",
+            base_retrieval_pipeline_name="vector_search",
+            noise_count=2,
+            noise_order="interleave",
+            noise_mode="answer_aware_random",
+            seed=13,
+        )
+
+        assert config.get_pipeline_kwargs() == {
+            "base_retrieval_pipeline": "vector_search",
+            "noise_count": 2,
+            "noise_ratio": None,
+            "noise_order": "interleave",
+            "noise_mode": "answer_aware_random",
+            "seed": 13,
+        }
+
+
+class TestPowerOfNoiseRetrievalPipeline:
+    """Tests for PowerOfNoiseRetrievalPipeline."""
+
+    @pytest.mark.asyncio
+    async def test_retrieved_first_appends_deterministic_noise(
+        self,
+        session_factory: sessionmaker[Session],
+        base_pipeline_stub: SimpleNamespace,
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        created_pipeline_ids, _ = cleanup_pipeline_results
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_retrieved_first",
+            base_retrieval_pipeline=base_pipeline_stub,
+            noise_count=2,
+            noise_order="retrieved_first",
+            seed=7,
+        )
+        created_pipeline_ids.append(pipeline.pipeline_id)
+
+        results_a = await pipeline._retrieve_by_text("ad hoc query", top_k=4)
+        results_b = await pipeline._retrieve_by_text("ad hoc query", top_k=4)
+
+        assert [result["doc_id"] for result in results_a[:2]] == [2, 3]
+        assert results_a == results_b
+        assert all(result["doc_id"] not in {2, 3} for result in results_a[2:])
+
+    @pytest.mark.asyncio
+    async def test_noise_first_places_noise_before_retrieved_docs(
+        self,
+        session_factory: sessionmaker[Session],
+        base_pipeline_stub: SimpleNamespace,
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        created_pipeline_ids, _ = cleanup_pipeline_results
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_noise_first",
+            base_retrieval_pipeline=base_pipeline_stub,
+            noise_count=2,
+            noise_order="noise_first",
+            seed=7,
+        )
+        created_pipeline_ids.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_text("ad hoc query", top_k=4)
+
+        assert [result["doc_id"] for result in results[-2:]] == [2, 3]
+        assert all(result["doc_id"] not in {2, 3} for result in results[:2])
+
+    @pytest.mark.asyncio
+    async def test_interleave_alternates_retrieved_and_noise(
+        self,
+        session_factory: sessionmaker[Session],
+        base_pipeline_stub: SimpleNamespace,
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        created_pipeline_ids, _ = cleanup_pipeline_results
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_interleave",
+            base_retrieval_pipeline=base_pipeline_stub,
+            noise_count=2,
+            noise_order="interleave",
+            seed=7,
+        )
+        created_pipeline_ids.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_text("ad hoc query", top_k=4)
+
+        assert results[0]["doc_id"] == 2
+        assert results[2]["doc_id"] == 3
+        assert results[1]["doc_id"] not in {2, 3}
+        assert results[3]["doc_id"] not in {2, 3}
+
+    def test_pipeline_config_includes_noise_settings(
+        self,
+        session_factory: sessionmaker[Session],
+        base_pipeline_stub: SimpleNamespace,
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        created_pipeline_ids, _ = cleanup_pipeline_results
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_config",
+            base_retrieval_pipeline=base_pipeline_stub,
+            noise_count=2,
+            noise_ratio=0.5,
+            noise_order="interleave",
+            noise_mode="answer_aware_random",
+            seed=11,
+        )
+        created_pipeline_ids.append(pipeline.pipeline_id)
+
+        assert pipeline._get_pipeline_config() == {
+            "type": "power_of_noise",
+            "base_retrieval_pipeline": "vector_search",
+            "noise_count": 2,
+            "noise_ratio": 0.5,
+            "noise_order": "interleave",
+            "noise_mode": "answer_aware_random",
+            "seed": 11,
+        }
+
+    def test_answer_aware_candidates_exclude_ground_truth_and_answer_chunks(
+        self,
+        session_factory: sessionmaker[Session],
+        base_pipeline_stub: SimpleNamespace,
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        created_pipeline_ids, created_chunk_ids = cleanup_pipeline_results
+        session = session_factory()
+        try:
+            answer_chunk = Chunk(contents="alpha appears in this distractor")
+            safe_chunk = Chunk(contents="totally unrelated evidence")
+            session.add_all([answer_chunk, safe_chunk])
+            session.commit()
+            created_chunk_ids.extend([answer_chunk.id, safe_chunk.id])
+        finally:
+            session.close()
+
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_answer_aware",
+            base_retrieval_pipeline=base_pipeline_stub,
+            noise_count=2,
+            noise_mode="answer_aware_random",
+            seed=5,
+        )
+        created_pipeline_ids.append(pipeline.pipeline_id)
+
+        candidate_ids = pipeline._get_noise_candidate_ids(query_id=1, excluded_doc_ids={2})
+
+        assert 1 not in candidate_ids  # retrieval GT chunk for query 1
+        assert answer_chunk.id not in candidate_ids
+        assert safe_chunk.id in candidate_ids
+        assert 2 not in candidate_ids
+
+    @pytest.mark.asyncio
+    async def test_noise_count_is_fixed_even_when_base_underfills(
+        self,
+        session_factory: sessionmaker[Session],
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        created_pipeline_ids, _ = cleanup_pipeline_results
+        underfilled_base = SimpleNamespace(
+            name="vector_search",
+            _retrieve_by_id=AsyncMock(return_value=[{"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"}]),
+            _retrieve_by_text=AsyncMock(return_value=[{"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"}]),
+        )
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_fixed_budget",
+            base_retrieval_pipeline=underfilled_base,
+            noise_count=1,
+            seed=17,
+        )
+        created_pipeline_ids.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_text("ad hoc query", top_k=4)
+
+        assert len(results) == 2
+        assert [result["doc_id"] for result in results[:1]] == [2]
+        assert results[1]["doc_id"] != 2
+
+    @pytest.mark.asyncio
+    async def test_noise_ratio_controls_noise_budget(
+        self,
+        session_factory: sessionmaker[Session],
+        base_pipeline_stub: SimpleNamespace,
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        created_pipeline_ids, _ = cleanup_pipeline_results
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_ratio_budget",
+            base_retrieval_pipeline=base_pipeline_stub,
+            noise_ratio=0.5,
+            seed=19,
+        )
+        created_pipeline_ids.append(pipeline.pipeline_id)
+
+        results = await pipeline._retrieve_by_text("ad hoc query", top_k=4)
+
+        assert len(results) == 4
+        assert [result["doc_id"] for result in results[:2]] == [2, 3]
+        assert all(result["doc_id"] not in {2, 3} for result in results[2:])
+
+    def test_run_persists_results(
+        self,
+        session_factory: sessionmaker[Session],
+        base_pipeline_stub: SimpleNamespace,
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        from autorag_research.orm.repository.query import QueryRepository
+
+        created_pipeline_ids, _ = cleanup_pipeline_results
+
+        session = session_factory()
+        try:
+            query_repo = QueryRepository(session)
+            query_count = query_repo.count()
+        finally:
+            session.close()
+
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_run",
+            base_retrieval_pipeline=base_pipeline_stub,
+            noise_count=1,
+            seed=3,
+        )
+        created_pipeline_ids.append(pipeline.pipeline_id)
+
+        result = pipeline.run(top_k=3)
+
+        verifier = PipelineTestVerifier(
+            result,
+            pipeline.pipeline_id,
+            session_factory,
+            PipelineTestConfig(
+                pipeline_type="retrieval",
+                expected_total_queries=query_count,
+                expected_min_results=query_count * 3,
+                check_persistence=True,
+            ),
+        )
+        verifier.verify_all()

--- a/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
@@ -1,14 +1,18 @@
 """Tests for PowerOfNoiseRetrievalPipeline."""
 
+from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import delete
 from sqlalchemy.orm import Session, sessionmaker
 
+from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.orm.repository.chunk_retrieved_result import ChunkRetrievedResultRepository
 from autorag_research.orm.schema import Chunk
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
 from autorag_research.pipelines.retrieval.power_of_noise import (
     PowerOfNoiseRetrievalPipeline,
     PowerOfNoiseRetrievalPipelineConfig,
@@ -19,8 +23,70 @@ from tests.autorag_research.pipelines.pipeline_test_utils import (
 )
 
 
-@pytest.fixture
+class _FakeLeafRetrievalPipeline(BaseRetrievalPipeline):
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        return {"type": "fake_leaf"}
 
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        return []
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        return []
+
+
+class _FakeWrapperRetrievalPipeline(BaseRetrievalPipeline):
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        inner_retrieval_pipeline: BaseRetrievalPipeline,
+        schema: Any | None = None,
+    ):
+        self.inner_retrieval_pipeline = inner_retrieval_pipeline
+        super().__init__(session_factory, name, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        return {
+            "type": "fake_wrapper",
+            "inner_pipeline_name": self.inner_retrieval_pipeline.name,
+        }
+
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        return []
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        return []
+
+
+@dataclass(kw_only=True)
+class _FakeLeafPipelineConfig(BaseRetrievalPipelineConfig):
+    def get_pipeline_class(self) -> type[BaseRetrievalPipeline]:
+        return _FakeLeafRetrievalPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        return {}
+
+
+@dataclass(kw_only=True)
+class _FakeWrapperPipelineConfig(BaseRetrievalPipelineConfig):
+    inner_retrieval_pipeline_name: str
+    _inner_retrieval_pipeline: BaseRetrievalPipeline | None = None
+
+    def get_pipeline_class(self) -> type[BaseRetrievalPipeline]:
+        return _FakeWrapperRetrievalPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        if self._inner_retrieval_pipeline is None:
+            msg = f"Inner retrieval pipeline '{self.inner_retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {"inner_retrieval_pipeline": self._inner_retrieval_pipeline}
+
+    def inject_retrieval_pipeline(self, pipeline: BaseRetrievalPipeline) -> None:
+        self._inner_retrieval_pipeline = pipeline
+
+
+@pytest.fixture
 def cleanup_pipeline_results(session_factory: sessionmaker[Session]):
     """Delete created retrieval results and temporary chunks after each test."""
     created_pipeline_ids: list[int] = []
@@ -41,19 +107,22 @@ def cleanup_pipeline_results(session_factory: sessionmaker[Session]):
 
 
 @pytest.fixture
-
 def base_pipeline_stub() -> SimpleNamespace:
     """Provide a stub retrieval pipeline for wrapper tests."""
     return SimpleNamespace(
         name="vector_search",
-        _retrieve_by_id=AsyncMock(return_value=[
-            {"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"},
-            {"doc_id": 3, "score": 0.8, "content": "Chunk 2-1"},
-        ]),
-        _retrieve_by_text=AsyncMock(return_value=[
-            {"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"},
-            {"doc_id": 3, "score": 0.8, "content": "Chunk 2-1"},
-        ]),
+        _retrieve_by_id=AsyncMock(
+            return_value=[
+                {"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"},
+                {"doc_id": 3, "score": 0.8, "content": "Chunk 2-1"},
+            ]
+        ),
+        _retrieve_by_text=AsyncMock(
+            return_value=[
+                {"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"},
+                {"doc_id": 3, "score": 0.8, "content": "Chunk 2-1"},
+            ]
+        ),
     )
 
 
@@ -90,6 +159,48 @@ class TestPowerOfNoisePipelineConfig:
 
 class TestPowerOfNoiseRetrievalPipeline:
     """Tests for PowerOfNoiseRetrievalPipeline."""
+
+    def test_named_base_pipeline_loads_nested_retrieval_dependencies(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        session_factory: sessionmaker[Session],
+        cleanup_pipeline_results: tuple[list[int], list[int]],
+    ):
+        created_pipeline_ids, _ = cleanup_pipeline_results
+        config_map = {
+            "fake_wrapper_cfg": _FakeWrapperPipelineConfig(
+                name="fake_wrapper",
+                inner_retrieval_pipeline_name="fake_leaf",
+            ),
+            "fake_leaf_cfg": _FakeLeafPipelineConfig(name="fake_leaf"),
+        }
+
+        def fake_resolve_config(_self, config_groups: list[str], name: str) -> str:
+            assert config_groups == ["pipelines", "retrieval"]
+            return f"{name}_cfg"
+
+        monkeypatch.setattr(
+            "autorag_research.cli.config_resolver.ConfigResolver.resolve_config",
+            fake_resolve_config,
+        )
+        monkeypatch.setattr(
+            "autorag_research.pipelines.retrieval.loader.instantiate",
+            lambda pipeline_cfg: config_map[pipeline_cfg],
+        )
+
+        pipeline = PowerOfNoiseRetrievalPipeline(
+            session_factory=session_factory,
+            name="test_power_of_noise_named_dependency_loader",
+            base_retrieval_pipeline="fake_wrapper",
+        )
+        created_pipeline_ids.extend([
+            pipeline.pipeline_id,
+            pipeline._base_retrieval_pipeline.pipeline_id,
+            pipeline._base_retrieval_pipeline.inner_retrieval_pipeline.pipeline_id,
+        ])
+
+        assert pipeline._base_retrieval_pipeline.name == "fake_wrapper"
+        assert pipeline._base_retrieval_pipeline.inner_retrieval_pipeline.name == "fake_leaf"
 
     @pytest.mark.asyncio
     async def test_retrieved_first_appends_deterministic_noise(


### PR DESCRIPTION
## Summary
- add the Power of Noise retrieval wrapper, config export, and docs wiring for issue #117
- preserve fixed noise budgets for both `noise_count` and `noise_ratio`, even when the base retriever under-fills
- add regression coverage for ordering, determinism, answer-aware exclusions, underfilled-base behavior, ratio budgeting, and persisted run output

## Verification
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py -q`
- `uv run pytest tests/autorag_research/pipelines/retrieval -q`
- `make check`
- `make docs-test`
- `uv run python` runtime check for underfilled-base case (`{'len': 2, 'doc_ids': [2, 7]}`)

## Risks
- `answer_aware_random` still scans all chunks in Python, so large corpora may need a follow-up optimization

<!-- dani:stage=implementation;job=0a232b15f6bd4570b480ff6498050ce6;issue=117 -->
