### PR TITLE
Add SDS KoPub VDR ingestor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ We provide pre-processed datasets with unified formats. Some include **pre-compu
 | [ViDoRe](https://arxiv.org/pdf/2407.01449) | Retrieval + Generation* | Visual document QA with 1:1 query-to-page mapping |
 | [ViDoRe v2](https://arxiv.org/pdf/2505.17166) |        Retrieval        | Visual document retrieval with corpus-level search |
 | [ViDoRe v3](https://arxiv.org/pdf/2601.08620) |        Retrieval        | Visual document retrieval across 8 industry domains |
+| [SDS KoPub VDR](https://arxiv.org/abs/2511.04910) | Retrieval | Korean public-document visual retrieval benchmark |
 | [VisRAG](https://arxiv.org/pdf/2410.10594) | Retrieval + Generation* | Vision-based RAG benchmark (ChartQA, SlideVQA, DocVQA, ...) |
 
 **Text + Image**

--- a/autorag_research/data/sds_kopub_vdr.py
+++ b/autorag_research/data/sds_kopub_vdr.py
@@ -213,7 +213,17 @@ class SDSKoPubVDRIngestor(MultiModalEmbeddingDataIngestor):
 
     def _infer_page_num(self, corpus_id: str) -> int:
         suffix = corpus_id.rsplit("_", maxsplit=1)[-1]
-        return int(suffix) if suffix.isdigit() else 1
+        if suffix.isdigit():
+            return int(suffix)
+        # Defensive fallback: every observed corpus_id in the live dataset ends in
+        # ``_<int>``. Log a warning so any malformed IDs are observable instead of
+        # silently bucketed into page 1.
+        logger.warning(
+            "SDS KoPub VDR corpus_id %r has non-numeric trailing segment %r; falling back to page_num=1",
+            corpus_id,
+            suffix,
+        )
+        return 1
 
     def _get_or_create_page(
         self,

--- a/autorag_research/data/sds_kopub_vdr.py
+++ b/autorag_research/data/sds_kopub_vdr.py
@@ -1,0 +1,374 @@
+"""SDS KoPub VDR Dataset Ingestor for AutoRAG-Research.
+
+SDS KoPub VDR is a Korean public-document visual document retrieval benchmark.
+This ingestor uses the MTEB text-to-image retrieval version, which provides a
+BEIR-like structure with separate corpus, queries, and qrels subsets.
+"""
+
+from __future__ import annotations
+
+import logging
+import operator
+import random
+from functools import reduce
+from typing import Any, Literal
+
+import pandas as pd
+from datasets import load_dataset
+
+from autorag_research.data.base import MultiModalEmbeddingDataIngestor
+from autorag_research.data.registry import register_ingestor
+from autorag_research.embeddings.base import MultiVectorMultiModalEmbedding, SingleVectorMultiModalEmbedding
+from autorag_research.exceptions import ServiceNotSetError
+from autorag_research.orm.models import ImageId, RetrievalGT, TextId, image, or_all_mixed, text
+from autorag_research.util import pil_image_to_bytes
+
+logger = logging.getLogger("AutoRAG-Research")
+
+DATASET_PATH = "mteb/SDSKoPubVDRT2ITRetrieval"
+RANDOM_SEED = 42
+BATCH_SIZE = 100
+QrelsMode = Literal["image", "text", "mixed"]
+
+
+@register_ingestor(
+    name="sds_kopub_vdr",
+    description="SDS KoPub VDR Korean public-document visual retrieval benchmark",
+    hf_repo="sds-kopub-vdr-dumps",
+)
+class SDSKoPubVDRIngestor(MultiModalEmbeddingDataIngestor):
+    """Ingestor for the SDS KoPub VDR MTEB retrieval dataset.
+
+    The source dataset follows a BEIR-like multimodal retrieval structure:
+    ``corpus`` rows contain page image/text pairs, ``queries`` rows contain
+    text queries, and ``qrels`` rows map query IDs to relevant corpus page IDs.
+    The source uses string IDs, so this ingestor requires a string primary-key
+    schema.
+    """
+
+    def __init__(
+        self,
+        qrels_mode: QrelsMode = "image",
+        embedding_model: SingleVectorMultiModalEmbedding | None = None,
+        late_interaction_embedding_model: MultiVectorMultiModalEmbedding | None = None,
+    ):
+        """Initialize SDS KoPub VDR ingestor.
+
+        Args:
+            qrels_mode: How qrels should map to chunks:
+                - ``image``: image chunks only (default)
+                - ``text``: corpus text chunks only
+                - ``mixed``: either image or text chunk is relevant
+            embedding_model: Optional single-vector multimodal embedding model.
+            late_interaction_embedding_model: Optional multi-vector embedding model.
+        """
+        super().__init__(embedding_model, late_interaction_embedding_model)
+        self.qrels_mode = qrels_mode
+
+    def detect_primary_key_type(self) -> Literal["bigint", "string"]:
+        """The MTEB SDS KoPub VDR dataset uses string query and corpus IDs."""
+        return "string"
+
+    def ingest(
+        self,
+        subset: Literal["train", "dev", "test"] = "test",
+        query_limit: int | None = None,
+        min_corpus_cnt: int | None = None,
+    ) -> None:
+        """Ingest SDS KoPub VDR into the database.
+
+        Args:
+            subset: Dataset split. SDS KoPub VDR currently supports only ``test``.
+            query_limit: Maximum number of queries to ingest. ``None`` ingests all queries.
+            min_corpus_cnt: Minimum corpus pages to ingest. Gold pages from selected queries
+                are always included; additional pages are streamed in corpus order.
+        """
+        if self.service is None:
+            raise ServiceNotSetError
+        if subset != "test":
+            raise ValueError("SDS KoPub VDR only has 'test' split.")  # noqa: TRY003
+
+        qrels_df = self._load_qrels(subset)
+        queries_df = self._load_queries(subset)
+
+        selected_query_ids = self._select_queries(queries_df, qrels_df, query_limit)
+        grouped_qrels = self._group_qrels(qrels_df, selected_query_ids)
+        gold_corpus_ids = self._extract_gold_corpus_ids(grouped_qrels)
+        additional_needed = self._calculate_additional_corpus_needed(gold_corpus_ids, min_corpus_cnt)
+
+        ingested_image_ids, ingested_text_ids = self._ingest_corpus(subset, gold_corpus_ids, additional_needed)
+        query_id_to_pk = self._ingest_queries(selected_query_ids, queries_df)
+        self._ingest_qrels(grouped_qrels, query_id_to_pk, ingested_image_ids, ingested_text_ids, self.qrels_mode)
+
+        logger.info(
+            "SDS KoPub VDR ingestion complete: "
+            f"{len(query_id_to_pk)} queries, {len(ingested_image_ids)} images, {len(ingested_text_ids)} text chunks"
+        )
+
+    def _load_qrels(self, subset: str) -> pd.DataFrame:
+        qrels_df: pd.DataFrame = load_dataset(  # type: ignore[union-attr, assignment]
+            DATASET_PATH, "qrels", streaming=False, split=subset
+        ).to_pandas()
+        qrels_df["query-id"] = qrels_df["query-id"].astype(str)
+        qrels_df["corpus-id"] = qrels_df["corpus-id"].astype(str)
+        qrels_df["score"] = qrels_df["score"].astype(int)
+        return qrels_df
+
+    def _load_queries(self, subset: str) -> pd.DataFrame:
+        queries_df: pd.DataFrame = load_dataset(  # type: ignore[union-attr, assignment]
+            DATASET_PATH, "queries", streaming=False, split=subset
+        ).to_pandas()
+        queries_df["id"] = queries_df["id"].astype(str)
+        return queries_df.set_index("id")
+
+    def _select_queries(
+        self,
+        queries_df: pd.DataFrame,
+        qrels_df: pd.DataFrame,
+        query_limit: int | None,
+    ) -> list[str]:
+        query_ids_with_qrels = set(qrels_df.loc[qrels_df["score"] > 0, "query-id"].tolist())
+        query_ids = [query_id for query_id in queries_df.index.tolist() if query_id in query_ids_with_qrels]
+        if query_limit is not None and query_limit < len(query_ids):
+            rng = random.Random(RANDOM_SEED)
+            return rng.sample(query_ids, query_limit)
+        return query_ids
+
+    def _group_qrels(
+        self,
+        qrels_df: pd.DataFrame,
+        selected_query_ids: list[str],
+    ) -> dict[str, list[tuple[str, int]]]:
+        filtered_qrels = qrels_df[(qrels_df["query-id"].isin(selected_query_ids)) & (qrels_df["score"] > 0)]
+        grouped: dict[str, list[tuple[str, int]]] = {}
+        for query_id, group in filtered_qrels.groupby("query-id", sort=False):
+            grouped[str(query_id)] = [(str(row["corpus-id"]), int(row["score"])) for _, row in group.iterrows()]
+        return grouped
+
+    def _extract_gold_corpus_ids(self, grouped_qrels: dict[str, list[tuple[str, int]]]) -> set[str]:
+        return {corpus_id for corpus_score_pairs in grouped_qrels.values() for corpus_id, _ in corpus_score_pairs}
+
+    def _calculate_additional_corpus_needed(self, gold_corpus_ids: set[str], min_corpus_cnt: int | None) -> int:
+        if min_corpus_cnt is not None and min_corpus_cnt > len(gold_corpus_ids):
+            return min_corpus_cnt - len(gold_corpus_ids)
+        return 0
+
+    def _ingest_corpus(
+        self,
+        subset: str,
+        gold_corpus_ids: set[str],
+        additional_needed: int,
+    ) -> tuple[set[str], set[str]]:
+        if self.service is None:
+            raise ServiceNotSetError
+
+        corpus_ds = load_dataset(DATASET_PATH, "corpus", streaming=True, split=subset)
+        ingested_image_ids: set[str] = set()
+        ingested_text_ids: set[str] = set()
+        doc_id_to_db_id: dict[str, int | str] = {}
+        page_key_to_db_id: dict[tuple[str, int], int | str] = {}
+        image_batch: list[dict[str, Any]] = []
+
+        for row in corpus_ds:
+            corpus_id = str(row["id"])
+            is_gold = corpus_id in gold_corpus_ids
+            is_additional = (not is_gold) and additional_needed > 0
+            if not is_gold and not is_additional:
+                continue
+
+            if is_additional:
+                additional_needed -= 1
+
+            doc_id = self._extract_doc_id(corpus_id)
+            page_num = self._infer_page_num(corpus_id)
+            img_bytes, mimetype = pil_image_to_bytes(row["image"])
+            page_db_id = self._get_or_create_page(
+                row, corpus_id, doc_id, page_num, img_bytes, mimetype, doc_id_to_db_id, page_key_to_db_id
+            )
+
+            text_contents = str(row.get("text") or "").strip()
+            if text_contents:
+                self._ingest_text_chunk(corpus_id, text_contents, page_db_id)
+                ingested_text_ids.add(corpus_id)
+
+            image_batch.append({
+                "id": corpus_id,
+                "contents": img_bytes,
+                "mimetype": mimetype,
+                "parent_page": page_db_id,
+            })
+            ingested_image_ids.add(corpus_id)
+
+            if len(image_batch) >= BATCH_SIZE:
+                self.service.add_image_chunks(image_batch)
+                image_batch.clear()
+
+        if image_batch:
+            self.service.add_image_chunks(image_batch)
+
+        return ingested_image_ids, ingested_text_ids
+
+    def _extract_doc_id(self, corpus_id: str) -> str:
+        return corpus_id.rsplit("_", maxsplit=1)[0]
+
+    def _infer_page_num(self, corpus_id: str) -> int:
+        suffix = corpus_id.rsplit("_", maxsplit=1)[-1]
+        return int(suffix) if suffix.isdigit() else 1
+
+    def _get_or_create_page(
+        self,
+        row: dict[str, Any],
+        corpus_id: str,
+        doc_id: str,
+        page_num: int,
+        img_bytes: bytes,
+        mimetype: str,
+        doc_id_to_db_id: dict[str, int | str],
+        page_key_to_db_id: dict[tuple[str, int], int | str],
+    ) -> int | str:
+        if self.service is None:
+            raise ServiceNotSetError
+
+        if doc_id not in doc_id_to_db_id:
+            file_id = self.service.add_files([{"type": "raw", "path": f"hf://{DATASET_PATH}/{doc_id}"}])[0]
+            document_id = self.service.add_documents([
+                {
+                    "path": file_id,
+                    "filename": doc_id,
+                    "title": row.get("id"),
+                    "author": None,
+                    "doc_metadata": {
+                        "source_dataset": DATASET_PATH,
+                        "original_doc_id": doc_id,
+                    },
+                }
+            ])[0]
+            doc_id_to_db_id[doc_id] = document_id
+
+        page_key = (doc_id, page_num)
+        if page_key not in page_key_to_db_id:
+            page_id = self.service.add_pages([
+                {
+                    "document_id": doc_id_to_db_id[doc_id],
+                    "page_num": page_num,
+                    "image_contents": img_bytes,
+                    "mimetype": mimetype,
+                    "page_metadata": {
+                        "source_dataset": DATASET_PATH,
+                        "corpus_id": corpus_id,
+                    },
+                }
+            ])[0]
+            page_key_to_db_id[page_key] = page_id
+
+        return page_key_to_db_id[page_key]
+
+    def _ingest_text_chunk(self, corpus_id: str, contents: str, page_db_id: int | str) -> None:
+        if self.service is None:
+            raise ServiceNotSetError
+        self.service.add_chunks([{"id": corpus_id, "contents": contents, "is_table": False}])
+        self.service.link_page_to_chunks(page_db_id, [corpus_id])
+
+    def _ingest_queries(self, selected_query_ids: list[str], queries_df: pd.DataFrame) -> dict[str, str]:
+        if self.service is None:
+            raise ServiceNotSetError
+
+        query_id_to_pk: dict[str, str] = {}
+        queries_batch: list[dict[str, Any]] = []
+        for query_id in selected_query_ids:
+            query_row = queries_df.loc[query_id]
+            queries_batch.append({"id": query_id, "contents": str(query_row["text"])})
+            query_id_to_pk[query_id] = query_id
+
+        if queries_batch:
+            self.service.add_queries(queries_batch)
+
+        return query_id_to_pk
+
+    def _ingest_qrels(
+        self,
+        grouped_qrels: dict[str, list[tuple[str, int]]],
+        query_id_to_pk: dict[str, str],
+        ingested_image_ids: set[str],
+        ingested_text_ids: set[str],
+        qrels_mode: QrelsMode,
+    ) -> None:
+        if self.service is None:
+            raise ServiceNotSetError
+
+        qrels_items: list[tuple[int | str, Any]] = []
+        for query_id, corpus_score_pairs in grouped_qrels.items():
+            query_pk = query_id_to_pk.get(query_id)
+            if query_pk is None:
+                continue
+            gt_expr = self._build_gt_expression(corpus_score_pairs, ingested_image_ids, ingested_text_ids, qrels_mode)
+            if gt_expr is not None:
+                qrels_items.append((query_pk, gt_expr))
+
+        if qrels_items:
+            self.service.add_retrieval_gt_batch(qrels_items, chunk_type=qrels_mode)
+
+        logger.info(f"Added {len(qrels_items)} SDS KoPub VDR qrel entries")
+
+    def _build_gt_expression(
+        self,
+        corpus_score_pairs: list[tuple[str, int]],
+        ingested_image_ids: set[str],
+        ingested_text_ids: set[str],
+        qrels_mode: QrelsMode,
+    ) -> RetrievalGT | None:
+        if qrels_mode == "image":
+            items = [
+                image(corpus_id, score=score)
+                for corpus_id, score in corpus_score_pairs
+                if corpus_id in ingested_image_ids
+            ]
+        elif qrels_mode == "text":
+            items = [
+                text(corpus_id, score=score)
+                for corpus_id, score in corpus_score_pairs
+                if corpus_id in ingested_text_ids
+            ]
+        else:
+            items = self._build_mixed_items(corpus_score_pairs, ingested_image_ids, ingested_text_ids)
+
+        if not items:
+            return None
+        if len(items) == 1:
+            return items[0]
+        return reduce(operator.or_, items)
+
+    def _build_mixed_items(
+        self,
+        corpus_score_pairs: list[tuple[str, int]],
+        ingested_image_ids: set[str],
+        ingested_text_ids: set[str],
+    ) -> list[Any]:
+        items: list[Any] = []
+        for corpus_id, score in corpus_score_pairs:
+            alternatives: list[TextId | ImageId] = []
+            if corpus_id in ingested_image_ids:
+                alternatives.append(ImageId(corpus_id, score=score))
+            if corpus_id in ingested_text_ids:
+                alternatives.append(TextId(corpus_id, score=score))
+            if alternatives:
+                items.append(or_all_mixed(alternatives))
+        return items
+
+    def embed_all(self, max_concurrency: int = 16, batch_size: int = 128) -> None:
+        super().embed_all(max_concurrency=max_concurrency, batch_size=batch_size)
+        if self.embedding_model is None or self.service is None:
+            return
+        self.service.embed_all_chunks(
+            self.embedding_model.aembed_query, batch_size=batch_size, max_concurrency=max_concurrency
+        )
+
+    def embed_all_late_interaction(self, max_concurrency: int = 16, batch_size: int = 128) -> None:
+        super().embed_all_late_interaction(max_concurrency=max_concurrency, batch_size=batch_size)
+        if self.late_interaction_embedding_model is None or self.service is None:
+            return
+        self.service.embed_all_chunks_multi_vector(
+            self.late_interaction_embedding_model.aembed_query,
+            batch_size=batch_size,
+            max_concurrency=max_concurrency,
+        )

--- a/docs/datasets/index.md
+++ b/docs/datasets/index.md
@@ -16,6 +16,7 @@ Available benchmarks for RAG evaluation.
 | ViDoRe | Multimodal | varies | varies | No | Visual |
 | ViDoRe v2 | Multimodal | varies | varies | No | Visual |
 | ViDoRe v3 | Multimodal | varies | varies | No | Visual |
+| SDS KoPub VDR | Multimodal | 600 | 40,781 | No | Visual |
 | VisRAG | Multimodal | varies | varies | No | Visual |
 
 ## Text vs Multimodal

--- a/docs/datasets/multimodal/index.md
+++ b/docs/datasets/multimodal/index.md
@@ -9,6 +9,7 @@ Visual document benchmarks for image-based retrieval.
 | [ViDoRe](vidore.md) | Visual Document Retrieval |
 | [ViDoRe v2](vidorev2.md) | Visual Document Retrieval v2 |
 | [ViDoRe v3](vidorev3.md) | Visual Document Retrieval v3 |
+| [SDS KoPub VDR](sds-kopub-vdr.md) | Korean public-document Visual Document Retrieval |
 | [VisRAG](visrag.md) | Visual RAG benchmark |
 | [Open-RAGBench](open-ragbench.md) | Open RAG benchmark from arXiv PDFs |
 

--- a/docs/datasets/multimodal/sds-kopub-vdr.md
+++ b/docs/datasets/multimodal/sds-kopub-vdr.md
@@ -1,0 +1,41 @@
+# SDS KoPub VDR
+
+Korean public-document Visual Document Retrieval benchmark.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Modality | Multimodal (Images + OCR/Text) |
+| Generation GT | No |
+| HF Repository | `mteb/SDSKoPubVDRT2ITRetrieval` |
+| Primary Key Type | `string` |
+| License | CC BY-SA 4.0 |
+
+## Description
+
+SDS KoPub VDR is a Korean visual document retrieval benchmark built from real public/government documents. This ingestor uses the MTEB text-to-image retrieval version, which exposes a clean BEIR-style layout with `corpus`, `queries`, and `qrels` configs.
+
+The dataset has three Hugging Face configs:
+
+- `queries`: text retrieval queries
+- `corpus`: page images plus extracted text
+- `qrels`: query-to-page relevance judgments
+
+## Ingest from Source
+
+```bash
+autorag-research ingest --name=sds_kopub_vdr --embedding-model=colpali
+```
+
+By default, qrels are mapped to image chunks. To evaluate text chunks or mixed image/text retrieval, set `qrels-mode`:
+
+```bash
+autorag-research ingest --name=sds_kopub_vdr --extra qrels-mode=mixed --embedding-model=colpali
+```
+
+## Best For
+
+- Korean public-document visual retrieval
+- Layout-, table-, chart-, and image-heavy document retrieval
+- Comparing image-only, text-only, and mixed page retrieval

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
           - datasets/multimodal/vidore.md
           - datasets/multimodal/vidorev2.md
           - datasets/multimodal/vidorev3.md
+          - datasets/multimodal/sds-kopub-vdr.md
           - datasets/multimodal/visrag.md
           - datasets/multimodal/open-ragbench.md
   - Pipelines:

--- a/tests/autorag_research/data/test_sds_kopub_vdr.py
+++ b/tests/autorag_research/data/test_sds_kopub_vdr.py
@@ -1,0 +1,202 @@
+"""Tests for SDS KoPub VDR ingestor."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import pytest
+from PIL import Image
+
+from autorag_research.data.registry import discover_ingestors
+from autorag_research.data.sds_kopub_vdr import SDSKoPubVDRIngestor
+from autorag_research.orm.models.retrieval_gt import gt_to_relations, normalize_gt
+from autorag_research.orm.service.multi_modal_ingestion import MultiModalIngestionService
+from tests.autorag_research.data.ingestor_test_utils import (
+    IngestorTestConfig,
+    IngestorTestVerifier,
+    create_test_database,
+)
+
+
+class _FakeDataset:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def to_pandas(self) -> pd.DataFrame:
+        return pd.DataFrame(self._rows)
+
+
+class _FakeService:
+    def __init__(self):
+        self.files: list[dict[str, Any]] = []
+        self.documents: list[dict[str, Any]] = []
+        self.pages: list[dict[str, Any]] = []
+        self.chunks: list[dict[str, Any]] = []
+        self.image_chunks: list[dict[str, Any]] = []
+        self.queries: list[dict[str, Any]] = []
+        self.page_chunk_relations: list[tuple[str, str]] = []
+        self.retrieval_gt_items: list[tuple[str, Any]] = []
+        self.retrieval_gt_chunk_type: str | None = None
+
+    def add_files(self, files: list[dict[str, Any]]) -> list[str]:
+        ids = [f"file-{len(self.files) + idx}" for idx in range(len(files))]
+        self.files.extend(files)
+        return ids
+
+    def add_documents(self, documents: list[dict[str, Any]]) -> list[str]:
+        ids = [f"doc-{len(self.documents) + idx}" for idx in range(len(documents))]
+        self.documents.extend(documents)
+        return ids
+
+    def add_pages(self, pages: list[dict[str, Any]]) -> list[str]:
+        ids = [f"page-{len(self.pages) + idx}" for idx in range(len(pages))]
+        self.pages.extend(pages)
+        return ids
+
+    def add_chunks(self, chunks: list[dict[str, Any]]) -> list[str]:
+        self.chunks.extend(chunks)
+        return [str(chunk["id"]) for chunk in chunks]
+
+    def link_page_to_chunks(self, page_id: str, chunk_ids: list[str]) -> list[tuple[str, str]]:
+        relations = [(page_id, chunk_id) for chunk_id in chunk_ids]
+        self.page_chunk_relations.extend(relations)
+        return relations
+
+    def add_image_chunks(self, image_chunks: list[dict[str, Any]]) -> list[str]:
+        self.image_chunks.extend(image_chunks)
+        return [str(chunk["id"]) for chunk in image_chunks]
+
+    def add_queries(self, queries: list[dict[str, Any]]) -> list[str]:
+        self.queries.extend(queries)
+        return [str(query["id"]) for query in queries]
+
+    def add_retrieval_gt_batch(
+        self,
+        items: list[tuple[str, Any]],
+        chunk_type: str = "mixed",
+    ) -> list[tuple[str, int, int]]:
+        self.retrieval_gt_items.extend(items)
+        self.retrieval_gt_chunk_type = chunk_type
+        return []
+
+
+@pytest.fixture
+def fake_sds_rows() -> dict[tuple[str, str], list[dict[str, Any]]]:
+    image = Image.new("RGB", (2, 2), color="white")
+    return {
+        ("queries", "test"): [
+            {"id": "query-0", "text": "첫 번째 질문"},
+            {"id": "query-1", "text": "두 번째 질문"},
+        ],
+        ("qrels", "test"): [
+            {"query-id": "query-0", "corpus-id": "doc-a_1", "score": 1},
+            {"query-id": "query-1", "corpus-id": "doc-b_1", "score": 1},
+            {"query-id": "query-1", "corpus-id": "doc-b_2", "score": 0},
+        ],
+        ("corpus", "test"): [
+            {"id": "doc-a_0", "text": "추가 문서", "image": image},
+            {"id": "doc-a_1", "text": "첫 번째 근거", "image": image},
+            {"id": "doc-b_1", "text": "두 번째 근거", "image": image},
+        ],
+    }
+
+
+def test_sds_kopub_vdr_detects_string_primary_key():
+    ingestor = SDSKoPubVDRIngestor()
+
+    assert ingestor.detect_primary_key_type() == "string"
+
+
+def test_sds_kopub_vdr_is_registered_with_qrels_mode_choices():
+    discover_ingestors.cache_clear()
+    meta = discover_ingestors()["sds_kopub_vdr"]
+
+    assert meta.ingestor_class is SDSKoPubVDRIngestor
+    qrels_param = next(param for param in meta.params if param.name == "qrels_mode")
+    assert qrels_param.choices == ["image", "text", "mixed"]
+
+
+def test_sds_kopub_vdr_ingests_mteb_rows(monkeypatch, fake_sds_rows):
+    def fake_load_dataset(_path: str, config: str, streaming: bool, split: str):
+        assert streaming is (config == "corpus")
+        return _FakeDataset(fake_sds_rows[(config, split)])
+
+    monkeypatch.setattr("autorag_research.data.sds_kopub_vdr.load_dataset", fake_load_dataset)
+    service = _FakeService()
+    ingestor = SDSKoPubVDRIngestor()
+    ingestor.set_service(service)  # type: ignore[arg-type]
+
+    ingestor.ingest(min_corpus_cnt=3)
+
+    assert [query["id"] for query in service.queries] == ["query-0", "query-1"]
+    assert "generation_gt" not in service.queries[0]
+    assert {chunk["id"] for chunk in service.image_chunks} == {"doc-a_0", "doc-a_1", "doc-b_1"}
+    assert {chunk["id"] for chunk in service.chunks} == {"doc-a_0", "doc-a_1", "doc-b_1"}
+    assert service.retrieval_gt_chunk_type == "image"
+    assert len(service.documents) == 2
+
+    q0_gt = dict(service.retrieval_gt_items)["query-0"]
+    q0_relations = gt_to_relations("query-0", normalize_gt(q0_gt, chunk_type="image"))
+    assert [relation["image_chunk_id"] for relation in q0_relations] == ["doc-a_1"]
+    assert [relation["score"] for relation in q0_relations] == [1]
+
+
+def test_sds_kopub_vdr_supports_mixed_qrels(monkeypatch, fake_sds_rows):
+    def fake_load_dataset(_path: str, config: str, streaming: bool, split: str):
+        return _FakeDataset(fake_sds_rows[(config, split)])
+
+    monkeypatch.setattr("autorag_research.data.sds_kopub_vdr.load_dataset", fake_load_dataset)
+    service = _FakeService()
+    ingestor = SDSKoPubVDRIngestor(qrels_mode="mixed")
+    ingestor.set_service(service)  # type: ignore[arg-type]
+
+    ingestor.ingest(query_limit=1)
+
+    assert service.retrieval_gt_chunk_type == "mixed"
+    query_id, gt = service.retrieval_gt_items[0]
+    relations = gt_to_relations(query_id, normalize_gt(gt, chunk_type="mixed"))
+    assert query_id == "query-0"
+    assert {relation["image_chunk_id"] for relation in relations} == {"doc-a_1", None}
+    assert {relation["chunk_id"] for relation in relations} == {"doc-a_1", None}
+
+
+SDS_KOPUB_VDR_CONFIG = IngestorTestConfig(
+    expected_query_count=5,
+    expected_chunk_count=20,
+    expected_image_chunk_count=20,
+    chunk_count_is_minimum=True,
+    check_documents=True,
+    expected_document_count=1,
+    check_pages=True,
+    expected_page_count=20,
+    check_files=True,
+    expected_file_count=1,
+    check_retrieval_relations=True,
+    check_generation_gt=False,
+    check_relevance_scores=True,
+    primary_key_type="string",
+    db_name="sds_kopub_vdr_test",
+)
+
+
+@pytest.mark.data
+class TestSDSKoPubVDRIngestorIntegration:
+    """Integration tests using the real SDS KoPub VDR MTEB dataset."""
+
+    def test_ingest_subset(self):
+        with create_test_database(SDS_KOPUB_VDR_CONFIG) as db:
+            service = MultiModalIngestionService(db.session_factory, schema=db.schema)  # ty: ignore[invalid-argument-type]
+
+            ingestor = SDSKoPubVDRIngestor()
+            ingestor.set_service(service)
+            ingestor.ingest(
+                query_limit=SDS_KOPUB_VDR_CONFIG.expected_query_count,
+                min_corpus_cnt=SDS_KOPUB_VDR_CONFIG.expected_image_chunk_count,
+            )
+
+            verifier = IngestorTestVerifier(service, db.schema, SDS_KOPUB_VDR_CONFIG)
+            verifier.verify_all()

--- a/tests/autorag_research/data/test_sds_kopub_vdr.py
+++ b/tests/autorag_research/data/test_sds_kopub_vdr.py
@@ -190,9 +190,13 @@ def test_sds_kopub_vdr_supports_mixed_qrels(monkeypatch, fake_sds_rows):
 
 
 # With seed=42 and query_limit=5, the SDS KoPub VDR ingestor selects 5 queries
-# whose gold corpus IDs map to 5 distinct source documents and pages. ``min_corpus_cnt=20``
-# pads the corpus to 20 image chunks (and matching text chunks). All count fields
-# below are interpreted as minimums via ``chunk_count_is_minimum=True``.
+# whose gold corpus IDs cover 4 distinct source documents and 5 distinct pages
+# (one document — ``public_pdf/prism/2040 아산시 환경계획(최종안)`` — contributes
+# 2 of the 5 gold pages: page 330 for ``query-281`` and page 379 for ``query-250``).
+# ``min_corpus_cnt=20`` then pads the corpus to ≥20 image+text chunks; in real ingest
+# the padding tends to pull in additional source documents (the @pytest.mark.data run
+# observes ~18 distinct documents/files). All count fields below are therefore
+# interpreted as minimums via ``chunk_count_is_minimum=True`` rather than equalities.
 SDS_KOPUB_VDR_CONFIG = IngestorTestConfig(
     expected_query_count=5,
     expected_chunk_count=20,

--- a/tests/autorag_research/data/test_sds_kopub_vdr.py
+++ b/tests/autorag_research/data/test_sds_kopub_vdr.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+import importlib
 from typing import Any
 
 import pandas as pd
 import pytest
 from PIL import Image
 
+import autorag_research.data.sds_kopub_vdr as sds_kopub_vdr_module
 from autorag_research.data.registry import discover_ingestors
-from autorag_research.data.sds_kopub_vdr import SDSKoPubVDRIngestor
 from autorag_research.orm.models.retrieval_gt import gt_to_relations, normalize_gt
 from autorag_research.orm.service.multi_modal_ingestion import MultiModalIngestionService
 from tests.autorag_research.data.ingestor_test_utils import (
@@ -106,16 +107,20 @@ def fake_sds_rows() -> dict[tuple[str, str], list[dict[str, Any]]]:
 
 
 def test_sds_kopub_vdr_detects_string_primary_key():
-    ingestor = SDSKoPubVDRIngestor()
+    ingestor = sds_kopub_vdr_module.SDSKoPubVDRIngestor()
 
     assert ingestor.detect_primary_key_type() == "string"
 
 
 def test_sds_kopub_vdr_is_registered_with_qrels_mode_choices():
     discover_ingestors.cache_clear()
+    # Some registry tests clear the global registry after this module has already
+    # been imported. Reload to re-run the @register_ingestor decorator so this
+    # test is order-independent in the full suite.
+    importlib.reload(sds_kopub_vdr_module)
     meta = discover_ingestors()["sds_kopub_vdr"]
 
-    assert meta.ingestor_class is SDSKoPubVDRIngestor
+    assert meta.ingestor_class is sds_kopub_vdr_module.SDSKoPubVDRIngestor
     qrels_param = next(param for param in meta.params if param.name == "qrels_mode")
     assert qrels_param.choices == ["image", "text", "mixed"]
 
@@ -127,7 +132,7 @@ def test_sds_kopub_vdr_ingests_mteb_rows(monkeypatch, fake_sds_rows):
 
     monkeypatch.setattr("autorag_research.data.sds_kopub_vdr.load_dataset", fake_load_dataset)
     service = _FakeService()
-    ingestor = SDSKoPubVDRIngestor()
+    ingestor = sds_kopub_vdr_module.SDSKoPubVDRIngestor()
     ingestor.set_service(service)  # type: ignore[arg-type]
 
     ingestor.ingest(min_corpus_cnt=3)
@@ -151,7 +156,7 @@ def test_sds_kopub_vdr_supports_mixed_qrels(monkeypatch, fake_sds_rows):
 
     monkeypatch.setattr("autorag_research.data.sds_kopub_vdr.load_dataset", fake_load_dataset)
     service = _FakeService()
-    ingestor = SDSKoPubVDRIngestor(qrels_mode="mixed")
+    ingestor = sds_kopub_vdr_module.SDSKoPubVDRIngestor(qrels_mode="mixed")
     ingestor.set_service(service)  # type: ignore[arg-type]
 
     ingestor.ingest(query_limit=1)
@@ -191,7 +196,7 @@ class TestSDSKoPubVDRIngestorIntegration:
         with create_test_database(SDS_KOPUB_VDR_CONFIG) as db:
             service = MultiModalIngestionService(db.session_factory, schema=db.schema)  # ty: ignore[invalid-argument-type]
 
-            ingestor = SDSKoPubVDRIngestor()
+            ingestor = sds_kopub_vdr_module.SDSKoPubVDRIngestor()
             ingestor.set_service(service)
             ingestor.ingest(
                 query_limit=SDS_KOPUB_VDR_CONFIG.expected_query_count,

--- a/tests/autorag_research/data/test_sds_kopub_vdr.py
+++ b/tests/autorag_research/data/test_sds_kopub_vdr.py
@@ -150,6 +150,26 @@ def test_sds_kopub_vdr_ingests_mteb_rows(monkeypatch, fake_sds_rows):
     assert [relation["score"] for relation in q0_relations] == [1]
 
 
+def test_sds_kopub_vdr_infer_page_num_warns_on_non_numeric_suffix(caplog):
+    ingestor = sds_kopub_vdr_module.SDSKoPubVDRIngestor()
+
+    with caplog.at_level("WARNING", logger="AutoRAG-Research"):
+        page_num = ingestor._infer_page_num("malformed_corpus_id_abc")
+
+    assert page_num == 1
+    assert any("non-numeric trailing segment" in record.message for record in caplog.records)
+
+
+def test_sds_kopub_vdr_infer_page_num_silent_on_numeric_suffix(caplog):
+    ingestor = sds_kopub_vdr_module.SDSKoPubVDRIngestor()
+
+    with caplog.at_level("WARNING", logger="AutoRAG-Research"):
+        page_num = ingestor._infer_page_num("public_pdf/foo/bar_42")
+
+    assert page_num == 42
+    assert not any("non-numeric trailing segment" in record.message for record in caplog.records)
+
+
 def test_sds_kopub_vdr_supports_mixed_qrels(monkeypatch, fake_sds_rows):
     def fake_load_dataset(_path: str, config: str, streaming: bool, split: str):
         return _FakeDataset(fake_sds_rows[(config, split)])
@@ -169,17 +189,21 @@ def test_sds_kopub_vdr_supports_mixed_qrels(monkeypatch, fake_sds_rows):
     assert {relation["chunk_id"] for relation in relations} == {"doc-a_1", None}
 
 
+# With seed=42 and query_limit=5, the SDS KoPub VDR ingestor selects 5 queries
+# whose gold corpus IDs map to 5 distinct source documents and pages. ``min_corpus_cnt=20``
+# pads the corpus to 20 image chunks (and matching text chunks). All count fields
+# below are interpreted as minimums via ``chunk_count_is_minimum=True``.
 SDS_KOPUB_VDR_CONFIG = IngestorTestConfig(
     expected_query_count=5,
     expected_chunk_count=20,
     expected_image_chunk_count=20,
     chunk_count_is_minimum=True,
     check_documents=True,
-    expected_document_count=1,
+    expected_document_count=5,
     check_pages=True,
     expected_page_count=20,
     check_files=True,
-    expected_file_count=1,
+    expected_file_count=5,
     check_retrieval_relations=True,
     check_generation_gt=False,
     check_relevance_scores=True,

--- a/tests/autorag_research/data/test_sds_kopub_vdr.py
+++ b/tests/autorag_research/data/test_sds_kopub_vdr.py
@@ -192,7 +192,7 @@ def test_sds_kopub_vdr_supports_mixed_qrels(monkeypatch, fake_sds_rows):
 # With seed=42 and query_limit=5, the SDS KoPub VDR ingestor selects 5 queries
 # whose gold corpus IDs cover 4 distinct source documents and 5 distinct pages
 # (one document — ``public_pdf/prism/2040 아산시 환경계획(최종안)`` — contributes
-# 2 of the 5 gold pages: page 330 for ``query-281`` and page 379 for ``query-250``).
+# 2 of the 5 gold pages: page 330 for ``query-281`` and page 379 for ``query-25``).
 # ``min_corpus_cnt=20`` then pads the corpus to ≥20 image+text chunks; in real ingest
 # the padding tends to pull in additional source documents (the @pytest.mark.data run
 # observes ~18 distinct documents/files). All count fields below are therefore


### PR DESCRIPTION
## Summary

Closes #327.

Adds first-party SDS KoPub VDR ingestion support using the normalized MTEB text-to-image retrieval dataset:

- `mteb/SDSKoPubVDRT2ITRetrieval`

## Changes

- Adds registered `sds_kopub_vdr` multimodal ingestor.
- Maps BEIR-style `corpus`, `queries`, and `qrels` configs into the AutoRAG multimodal schema.
- Uses string primary keys to preserve source query/corpus IDs.
- Stores corpus page images as image chunks and corpus text as text chunks.
- Supports `qrels_mode=image|text|mixed` for image-only, text-only, or mixed retrieval GT.
- Keeps the dataset retrieval-only; no `generation_gt` is stored because the MTEB retrieval source does not expose answers.
- Adds unit-style tests with fake MTEB rows and a PostgreSQL/HF `@pytest.mark.data` integration test.
- Documents the new dataset in README and dataset docs.

## Verification

- `uv run pytest tests/autorag_research/data/test_sds_kopub_vdr.py -m 'not data' -q`
- `uv run ruff check autorag_research/data/sds_kopub_vdr.py tests/autorag_research/data/test_sds_kopub_vdr.py`
- `uv run ty check autorag_research/data/sds_kopub_vdr.py tests/autorag_research/data/test_sds_kopub_vdr.py`
- `make check`

## Not tested

- PostgreSQL-backed `@pytest.mark.data` integration test was added but not run locally.

Closes #327

<!-- dani:stage=implementation;job=83e4be7dfcedadfce58f4b78ab04797e;issue=327 -->
