### PR TITLE
Add AlignScore metric (ACL 2023)

### DIFF
--- a/autorag_research/evaluation/metrics/__init__.py
+++ b/autorag_research/evaluation/metrics/__init__.py
@@ -4,6 +4,7 @@ This module provides evaluation metrics for generation and retrieval tasks.
 """
 
 from autorag_research.evaluation.metrics.generation import (
+    AlignScoreConfig,
     BartScoreF1Config,
     BartScoreFaithfulnessConfig,
     BartScorePrecisionConfig,
@@ -17,6 +18,7 @@ from autorag_research.evaluation.metrics.generation import (
     SemScoreConfig,
     TokenF1Config,
     UniEvalConfig,
+    align_score,
     bart_score_f1,
     bart_score_faithfulness,
     bart_score_precision,
@@ -57,6 +59,7 @@ from autorag_research.evaluation.metrics.util import (
 )
 
 __all__ = [
+    "AlignScoreConfig",
     "BartScoreF1Config",
     "BartScoreFaithfulnessConfig",
     "BartScorePrecisionConfig",
@@ -77,6 +80,7 @@ __all__ = [
     "SemScoreConfig",
     "TokenF1Config",
     "UniEvalConfig",
+    "align_score",
     "bart_score_f1",
     "bart_score_faithfulness",
     "bart_score_precision",

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -71,10 +71,11 @@ BARTSCORE_DEPENDENCY_MESSAGE = (
 UNIEVAL_MODEL_NAME = "MingZhong/unieval-sum"
 UNIEVAL_DIMENSIONS = ("coherence", "consistency", "fluency", "relevance")
 ALIGNSCORE_MODEL_NAME = "liuyanyi/AlignScore-large-hf"
+ALIGNSCORE_REVISION = "cc13dc572fce8aa32778a437fb66a02d39a5b8e3"
 ALIGNSCORE_BATCH_SIZE = 8
 ALIGNSCORE_MAX_LENGTH = 1024
 ALIGNSCORE_DEVICE = "cpu"
-ALIGNSCORE_TRUST_REMOTE_CODE = True
+ALIGNSCORE_TRUST_REMOTE_CODE = False
 ALIGNSCORE_AGGREGATIONS = ("mean", "min")
 ALIGNSCORE_DEPENDENCY_MESSAGE = (
     "AlignScore requires the optional `torch` and `transformers` dependencies. "
@@ -356,6 +357,38 @@ def _import_alignscore_torch() -> Any:
         raise ImportError(ALIGNSCORE_DEPENDENCY_MESSAGE) from e
 
 
+def _requires_alignscore_remote_code(model_name_or_path: str) -> bool:
+    """Return whether the known AlignScore checkpoint requires remote code."""
+    return model_name_or_path == ALIGNSCORE_MODEL_NAME
+
+
+def _is_pinned_commit_revision(revision: str | None) -> bool:
+    """Return whether a Hugging Face revision is pinned to an immutable commit SHA."""
+    return revision is not None and re.fullmatch(r"[0-9a-f]{40}", revision) is not None
+
+
+def _validate_alignscore_remote_code_trust(
+    model_name_or_path: str,
+    trust_remote_code: bool,
+    revision: str | None,
+) -> None:
+    """Fail clearly before loading known remote-code AlignScore checkpoints without a trust boundary."""
+    if not _requires_alignscore_remote_code(model_name_or_path):
+        return
+    if not trust_remote_code:
+        msg = (
+            f"AlignScore checkpoint {model_name_or_path!r} requires trust_remote_code=True. "
+            f"Enable trust_remote_code explicitly and pin revision={ALIGNSCORE_REVISION!r} before loading it."
+        )
+        raise ValueError(msg)
+    if not _is_pinned_commit_revision(revision):
+        msg = (
+            f"AlignScore checkpoint {model_name_or_path!r} executes remote code and requires a pinned commit revision. "
+            f"Set revision={ALIGNSCORE_REVISION!r} or another immutable 40-character commit SHA."
+        )
+        raise ValueError(msg)
+
+
 def _import_alignscore_runtime() -> tuple[Any, Any, Any]:
     """Import AlignScore runtime dependencies lazily."""
     torch = _import_alignscore_torch()
@@ -384,7 +417,9 @@ class HuggingFaceAlignScoreScorer(AlignScoreScorer):
         device: str = ALIGNSCORE_DEVICE,
         cache_dir: str | None = None,
         trust_remote_code: bool = ALIGNSCORE_TRUST_REMOTE_CODE,
+        revision: str | None = None,
     ) -> None:
+        _validate_alignscore_remote_code_trust(model_name_or_path, trust_remote_code, revision)
         torch, AutoModelForSequenceClassification, AutoTokenizer = _import_alignscore_runtime()
         self._torch = torch
         self.device = _resolve_alignscore_device(device)
@@ -393,11 +428,13 @@ class HuggingFaceAlignScoreScorer(AlignScoreScorer):
             model_name_or_path,
             cache_dir=cache_dir,
             trust_remote_code=trust_remote_code,
+            revision=revision,
         )
         self.model = AutoModelForSequenceClassification.from_pretrained(
             model_name_or_path,
             cache_dir=cache_dir,
             trust_remote_code=trust_remote_code,
+            revision=revision,
         )
         self.model.eval()
         self.model.to(self.device)
@@ -459,14 +496,16 @@ def get_alignscore_scorer(
     device: str = ALIGNSCORE_DEVICE,
     cache_dir: str | None = None,
     trust_remote_code: bool = ALIGNSCORE_TRUST_REMOTE_CODE,
+    revision: str | None = None,
 ) -> AlignScoreScorer:
     """Return a cached AlignScore scorer instance."""
     logger.debug(
-        "Loading AlignScore scorer model_name_or_path=%s max_length=%s device=%s cache_dir=%s",
+        "Loading AlignScore scorer model_name_or_path=%s max_length=%s device=%s cache_dir=%s revision=%s",
         model_name_or_path,
         max_length,
         device,
         cache_dir,
+        revision,
     )
     return HuggingFaceAlignScoreScorer(
         model_name_or_path=model_name_or_path,
@@ -474,6 +513,7 @@ def get_alignscore_scorer(
         device=device,
         cache_dir=cache_dir,
         trust_remote_code=trust_remote_code,
+        revision=revision,
     )
 
 
@@ -1093,6 +1133,7 @@ def align_score(
     device: str = ALIGNSCORE_DEVICE,
     cache_dir: str | None = None,
     trust_remote_code: bool = ALIGNSCORE_TRUST_REMOTE_CODE,
+    revision: str | None = None,
     aggregation: str = "mean",
     scorer: AlignScoreScorer | None = None,
 ) -> list[float | None]:
@@ -1130,6 +1171,7 @@ def align_score(
         device=device,
         cache_dir=cache_dir,
         trust_remote_code=trust_remote_code,
+        revision=revision,
     )
     claim_scores = effective_scorer.score(prepared_contexts, prepared_claims, batch_size=batch_size)
     if len(claim_scores) != len(prepared_claims):
@@ -1320,6 +1362,7 @@ class AlignScoreConfig(BaseGenerationMetricConfig):
     device: str = ALIGNSCORE_DEVICE
     cache_dir: str | None = None
     trust_remote_code: bool = ALIGNSCORE_TRUST_REMOTE_CODE
+    revision: str | None = None
     aggregation: str = "mean"
 
     def __post_init__(self) -> None:
@@ -1343,6 +1386,7 @@ class AlignScoreConfig(BaseGenerationMetricConfig):
             "device": self.device,
             "cache_dir": self.cache_dir,
             "trust_remote_code": self.trust_remote_code,
+            "revision": self.revision,
             "aggregation": self.aggregation,
         }
 

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -70,6 +70,16 @@ BARTSCORE_DEPENDENCY_MESSAGE = (
 )
 UNIEVAL_MODEL_NAME = "MingZhong/unieval-sum"
 UNIEVAL_DIMENSIONS = ("coherence", "consistency", "fluency", "relevance")
+ALIGNSCORE_MODEL_NAME = "liuyanyi/AlignScore-large-hf"
+ALIGNSCORE_BATCH_SIZE = 8
+ALIGNSCORE_MAX_LENGTH = 1024
+ALIGNSCORE_DEVICE = "cpu"
+ALIGNSCORE_AGGREGATIONS = ("mean", "min")
+ALIGNSCORE_DEPENDENCY_MESSAGE = (
+    "AlignScore requires the optional `torch` and `transformers` dependencies. "
+    "Install them with `pip install 'autorag-research[gpu]'` or run "
+    "`uv sync --all-extras --all-groups` in a development checkout."
+)
 
 
 def _get_normalized_tokens(text: str) -> list[str]:
@@ -287,6 +297,162 @@ def _aggregate_unieval_scores(dimension: str, scores: list[float]) -> float:
     if dimension == "relevance":
         return max(scores)
     return scores[0]
+
+
+def _validate_alignscore_aggregation(aggregation: str) -> str:
+    """Validate and normalize AlignScore claim aggregation."""
+    normalized = aggregation.strip().lower()
+    if normalized not in ALIGNSCORE_AGGREGATIONS:
+        msg = f"Unsupported AlignScore aggregation: {aggregation}"
+        raise ValueError(msg)
+    return normalized
+
+
+def _split_alignscore_claims(text: str) -> list[str]:
+    """Split generated text into claim-sized sentence units for AlignScore."""
+    stripped_text = text.strip()
+    if not stripped_text:
+        return []
+    try:
+        sentences = [sentence.strip() for sentence in nltk.sent_tokenize(stripped_text) if sentence.strip()]
+    except LookupError:
+        sentences = [sentence.strip() for sentence in re.split(r"(?<=[.!?])\s+", stripped_text) if sentence.strip()]
+    return sentences or [stripped_text]
+
+
+def _build_alignscore_context(retrieved_contents: list[str]) -> str:
+    """Join retrieved passages into the source context scored by AlignScore."""
+    return "\n\n".join(content.strip() for content in retrieved_contents if content.strip())
+
+
+def _aggregate_alignscore_scores(scores: list[float], aggregation: str) -> float:
+    """Aggregate claim-level AlignScore outputs into one sample-level score."""
+    normalized_aggregation = _validate_alignscore_aggregation(aggregation)
+    if normalized_aggregation == "min":
+        return min(scores)
+    return float(sum(scores) / len(scores))
+
+
+def _resolve_alignscore_device(device: str) -> str:
+    """Resolve a concrete torch device string for AlignScore."""
+    if device != "auto":
+        return device
+
+    torch = _import_alignscore_torch()
+    if torch.cuda.is_available():
+        return "cuda"
+    mps_backend = getattr(getattr(torch, "backends", None), "mps", None)
+    if mps_backend is not None and mps_backend.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _import_alignscore_torch() -> Any:
+    """Import torch with an AlignScore-specific dependency error message."""
+    try:
+        return importlib.import_module("torch")
+    except ImportError as e:
+        raise ImportError(ALIGNSCORE_DEPENDENCY_MESSAGE) from e
+
+
+def _import_alignscore_runtime() -> tuple[Any, Any, Any]:
+    """Import AlignScore runtime dependencies lazily."""
+    torch = _import_alignscore_torch()
+    try:
+        transformers = importlib.import_module("transformers")
+    except ImportError as e:
+        raise ImportError(ALIGNSCORE_DEPENDENCY_MESSAGE) from e
+    return torch, transformers.AutoModelForSequenceClassification, transformers.AutoTokenizer
+
+
+class AlignScoreScorer:
+    """Protocol-like base for AlignScore scorers used by generation metrics."""
+
+    def score(self, contexts: list[str], claims: list[str], batch_size: int = ALIGNSCORE_BATCH_SIZE) -> list[float]:
+        """Return one support score per context/claim pair."""
+        raise NotImplementedError
+
+
+class HuggingFaceAlignScoreScorer(AlignScoreScorer):
+    """Thin wrapper around a Hugging Face-format AlignScore sequence classifier."""
+
+    def __init__(
+        self,
+        model_name_or_path: str = ALIGNSCORE_MODEL_NAME,
+        max_length: int = ALIGNSCORE_MAX_LENGTH,
+        device: str = ALIGNSCORE_DEVICE,
+        cache_dir: str | None = None,
+    ) -> None:
+        torch, AutoModelForSequenceClassification, AutoTokenizer = _import_alignscore_runtime()
+        self._torch = torch
+        self.device = _resolve_alignscore_device(device)
+        self.max_length = max_length
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, cache_dir=cache_dir)
+        self.model = AutoModelForSequenceClassification.from_pretrained(model_name_or_path, cache_dir=cache_dir)
+        self.model.eval()
+        self.model.to(self.device)
+        self.positive_label_id = self._resolve_positive_label_id()
+
+    def _resolve_positive_label_id(self) -> int:
+        """Find the factual-consistency/entailment class id from model config labels."""
+        id2label = getattr(self.model.config, "id2label", {}) or {}
+        for label_id, label in id2label.items():
+            if any(token in str(label).strip().lower() for token in ("entail", "support", "positive", "consistent")):
+                return int(label_id)
+        return max(0, int(getattr(self.model.config, "num_labels", 2)) - 1)
+
+    def score(self, contexts: list[str], claims: list[str], batch_size: int = ALIGNSCORE_BATCH_SIZE) -> list[float]:
+        """Compute factual consistency probabilities for aligned context/claim pairs."""
+        if len(contexts) != len(claims):
+            msg = f"AlignScore received {len(contexts)} contexts for {len(claims)} claims"
+            raise ValueError(msg)
+        if not contexts:
+            return []
+
+        scores: list[float] = []
+        for start in range(0, len(contexts), batch_size):
+            batch_contexts = contexts[start : start + batch_size]
+            batch_claims = claims[start : start + batch_size]
+            with self._torch.no_grad():
+                encoded = self.tokenizer(
+                    batch_contexts,
+                    batch_claims,
+                    max_length=self.max_length,
+                    truncation=True,
+                    padding=True,
+                    return_tensors="pt",
+                )
+                encoded = {key: value.to(self.device) for key, value in encoded.items()}
+                logits = self.model(**encoded).logits
+                if logits.shape[-1] == 1:
+                    probabilities = self._torch.sigmoid(logits).reshape(-1)
+                else:
+                    probabilities = self._torch.softmax(logits, dim=-1)[:, self.positive_label_id]
+                scores.extend(float(score) for score in probabilities.tolist())
+        return scores
+
+
+@lru_cache(maxsize=4)
+def get_alignscore_scorer(
+    model_name_or_path: str = ALIGNSCORE_MODEL_NAME,
+    max_length: int = ALIGNSCORE_MAX_LENGTH,
+    device: str = ALIGNSCORE_DEVICE,
+    cache_dir: str | None = None,
+) -> AlignScoreScorer:
+    """Return a cached AlignScore scorer instance."""
+    logger.debug(
+        "Loading AlignScore scorer model_name_or_path=%s max_length=%s device=%s cache_dir=%s",
+        model_name_or_path,
+        max_length,
+        device,
+        cache_dir,
+    )
+    return HuggingFaceAlignScoreScorer(
+        model_name_or_path=model_name_or_path,
+        max_length=max_length,
+        device=device,
+        cache_dir=cache_dir,
+    )
 
 
 @convert_inputs_to_list
@@ -896,6 +1062,65 @@ def unieval(
     return results
 
 
+@convert_inputs_to_list
+def align_score(
+    metric_inputs: list[MetricInput],
+    model_name_or_path: str = ALIGNSCORE_MODEL_NAME,
+    batch_size: int = ALIGNSCORE_BATCH_SIZE,
+    max_length: int = ALIGNSCORE_MAX_LENGTH,
+    device: str = ALIGNSCORE_DEVICE,
+    cache_dir: str | None = None,
+    aggregation: str = "mean",
+    scorer: AlignScoreScorer | None = None,
+) -> list[float | None]:
+    """Compute AlignScore factual consistency against retrieved source context.
+
+    AlignScore (Zha et al., ACL 2023) estimates information alignment between a
+    source context and generated text. The wrapper follows the RAG faithfulness
+    use case by splitting each generated answer into sentence-level claims,
+    scoring every claim against the concatenated retrieved context, then
+    aggregating claim scores into one higher-is-better query score.
+    """
+    normalized_aggregation = _validate_alignscore_aggregation(aggregation)
+    prepared_contexts: list[str] = []
+    prepared_claims: list[str] = []
+    claim_counts: list[tuple[int, int]] = []
+    results: list[float | None] = [None] * len(metric_inputs)
+
+    for index, metric_input in enumerate(metric_inputs):
+        if not metric_input.is_fields_notnone(["retrieved_contents", "generated_texts"]):
+            continue
+        context = _build_alignscore_context(cast(list[str], metric_input.retrieved_contents))
+        claims = _split_alignscore_claims(cast(str, metric_input.generated_texts))
+        if not context or not claims:
+            continue
+        prepared_contexts.extend([context] * len(claims))
+        prepared_claims.extend(claims)
+        claim_counts.append((index, len(claims)))
+
+    if not prepared_claims:
+        return results
+
+    effective_scorer = scorer or get_alignscore_scorer(
+        model_name_or_path=model_name_or_path,
+        max_length=max_length,
+        device=device,
+        cache_dir=cache_dir,
+    )
+    claim_scores = effective_scorer.score(prepared_contexts, prepared_claims, batch_size=batch_size)
+    if len(claim_scores) != len(prepared_claims):
+        msg = f"AlignScore scorer returned {len(claim_scores)} scores for {len(prepared_claims)} claims"
+        raise ValueError(msg)
+
+    score_offset = 0
+    for index, count in claim_counts:
+        current_scores = claim_scores[score_offset : score_offset + count]
+        results[index] = _aggregate_alignscore_scores(current_scores, normalized_aggregation)
+        score_offset += count
+
+    return results
+
+
 # Metric Configurations
 @dataclass
 class BleuConfig(BaseGenerationMetricConfig):
@@ -1058,6 +1283,41 @@ class ResponseRelevancyConfig(BaseGenerationMetricConfig):
             "llm": self.llm,
             "embedding_model": self.embedding_model,
             "prompt_template": self.prompt_template,
+        }
+
+
+@dataclass
+class AlignScoreConfig(BaseGenerationMetricConfig):
+    """Configuration for AlignScore factual consistency metric."""
+
+    model_name_or_path: str = ALIGNSCORE_MODEL_NAME
+    batch_size: int = ALIGNSCORE_BATCH_SIZE
+    max_length: int = ALIGNSCORE_MAX_LENGTH
+    device: str = ALIGNSCORE_DEVICE
+    cache_dir: str | None = None
+    aggregation: str = "mean"
+
+    def __post_init__(self) -> None:
+        """Validate AlignScore configuration."""
+        self.aggregation = _validate_alignscore_aggregation(self.aggregation)
+
+    def get_metric_name(self) -> str:
+        """Return the metric name."""
+        return "align_score"
+
+    def get_metric_func(self) -> Callable:
+        """Return the metric function."""
+        return align_score
+
+    def get_metric_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for the metric function."""
+        return {
+            "model_name_or_path": self.model_name_or_path,
+            "batch_size": self.batch_size,
+            "max_length": self.max_length,
+            "device": self.device,
+            "cache_dir": self.cache_dir,
+            "aggregation": self.aggregation,
         }
 
 

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -77,6 +77,7 @@ ALIGNSCORE_MAX_LENGTH = 1024
 ALIGNSCORE_DEVICE = "cpu"
 ALIGNSCORE_TRUST_REMOTE_CODE = False
 ALIGNSCORE_AGGREGATIONS = ("mean", "min")
+ALIGNSCORE_CONTEXT_WINDOW_SENTENCES = 5
 ALIGNSCORE_DEPENDENCY_MESSAGE = (
     "AlignScore requires the optional `torch` and `transformers` dependencies. "
     "Install them with `pip install 'autorag-research[gpu]'` or run "
@@ -322,9 +323,20 @@ def _split_alignscore_claims(text: str) -> list[str]:
     return sentences or [stripped_text]
 
 
-def _build_alignscore_context(retrieved_contents: list[str]) -> str:
-    """Join retrieved passages into the source context scored by AlignScore."""
-    return "\n\n".join(content.strip() for content in retrieved_contents if content.strip())
+def _build_alignscore_context_windows(retrieved_contents: list[str]) -> list[str]:
+    """Build independently scored retrieved-context windows for AlignScore."""
+    context_windows: list[str] = []
+    for content in retrieved_contents:
+        stripped_content = content.strip()
+        if not stripped_content:
+            continue
+        sentences = _split_alignscore_claims(stripped_content)
+        if len(sentences) <= ALIGNSCORE_CONTEXT_WINDOW_SENTENCES:
+            context_windows.append(stripped_content)
+            continue
+        for start in range(0, len(sentences), ALIGNSCORE_CONTEXT_WINDOW_SENTENCES):
+            context_windows.append(" ".join(sentences[start : start + ALIGNSCORE_CONTEXT_WINDOW_SENTENCES]))
+    return context_windows
 
 
 def _aggregate_alignscore_scores(scores: list[float], aggregation: str) -> float:
@@ -1142,25 +1154,27 @@ def align_score(
     AlignScore (Zha et al., ACL 2023) estimates information alignment between a
     source context and generated text. The wrapper follows the RAG faithfulness
     use case by splitting each generated answer into sentence-level claims,
-    scoring every claim against the concatenated retrieved context, then
-    aggregating claim scores into one higher-is-better query score.
+    scoring every claim against each retrieved passage/window, taking the best
+    support score per claim, then aggregating claim scores into one
+    higher-is-better query score.
     """
     normalized_aggregation = _validate_alignscore_aggregation(aggregation)
     prepared_contexts: list[str] = []
     prepared_claims: list[str] = []
-    claim_counts: list[tuple[int, int]] = []
+    claim_counts: list[tuple[int, int, int]] = []
     results: list[float | None] = [None] * len(metric_inputs)
 
     for index, metric_input in enumerate(metric_inputs):
         if not metric_input.is_fields_notnone(["retrieved_contents", "generated_texts"]):
             continue
-        context = _build_alignscore_context(cast(list[str], metric_input.retrieved_contents))
+        context_windows = _build_alignscore_context_windows(cast(list[str], metric_input.retrieved_contents))
         claims = _split_alignscore_claims(cast(str, metric_input.generated_texts))
-        if not context or not claims:
+        if not context_windows or not claims:
             continue
-        prepared_contexts.extend([context] * len(claims))
-        prepared_claims.extend(claims)
-        claim_counts.append((index, len(claims)))
+        for claim in claims:
+            prepared_contexts.extend(context_windows)
+            prepared_claims.extend([claim] * len(context_windows))
+        claim_counts.append((index, len(claims), len(context_windows)))
 
     if not prepared_claims:
         return results
@@ -1179,10 +1193,14 @@ def align_score(
         raise ValueError(msg)
 
     score_offset = 0
-    for index, count in claim_counts:
-        current_scores = claim_scores[score_offset : score_offset + count]
-        results[index] = _aggregate_alignscore_scores(current_scores, normalized_aggregation)
-        score_offset += count
+    for index, claim_count, context_window_count in claim_counts:
+        current_scores = claim_scores[score_offset : score_offset + (claim_count * context_window_count)]
+        claim_support_scores = [
+            max(current_scores[start : start + context_window_count])
+            for start in range(0, len(current_scores), context_window_count)
+        ]
+        results[index] = _aggregate_alignscore_scores(claim_support_scores, normalized_aggregation)
+        score_offset += claim_count * context_window_count
 
     return results
 

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -74,6 +74,7 @@ ALIGNSCORE_MODEL_NAME = "liuyanyi/AlignScore-large-hf"
 ALIGNSCORE_BATCH_SIZE = 8
 ALIGNSCORE_MAX_LENGTH = 1024
 ALIGNSCORE_DEVICE = "cpu"
+ALIGNSCORE_TRUST_REMOTE_CODE = True
 ALIGNSCORE_AGGREGATIONS = ("mean", "min")
 ALIGNSCORE_DEPENDENCY_MESSAGE = (
     "AlignScore requires the optional `torch` and `transformers` dependencies. "
@@ -382,13 +383,22 @@ class HuggingFaceAlignScoreScorer(AlignScoreScorer):
         max_length: int = ALIGNSCORE_MAX_LENGTH,
         device: str = ALIGNSCORE_DEVICE,
         cache_dir: str | None = None,
+        trust_remote_code: bool = ALIGNSCORE_TRUST_REMOTE_CODE,
     ) -> None:
         torch, AutoModelForSequenceClassification, AutoTokenizer = _import_alignscore_runtime()
         self._torch = torch
         self.device = _resolve_alignscore_device(device)
         self.max_length = max_length
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, cache_dir=cache_dir)
-        self.model = AutoModelForSequenceClassification.from_pretrained(model_name_or_path, cache_dir=cache_dir)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name_or_path,
+            cache_dir=cache_dir,
+            trust_remote_code=trust_remote_code,
+        )
+        self.model = AutoModelForSequenceClassification.from_pretrained(
+            model_name_or_path,
+            cache_dir=cache_dir,
+            trust_remote_code=trust_remote_code,
+        )
         self.model.eval()
         self.model.to(self.device)
         self.positive_label_id = self._resolve_positive_label_id()
@@ -400,6 +410,20 @@ class HuggingFaceAlignScoreScorer(AlignScoreScorer):
             if any(token in str(label).strip().lower() for token in ("entail", "support", "positive", "consistent")):
                 return int(label_id)
         return max(0, int(getattr(self.model.config, "num_labels", 2)) - 1)
+
+    def _extract_alignment_probabilities(self, model_output: Any) -> Any:
+        """Convert AlignScore or generic classifier outputs into support probabilities."""
+        if hasattr(model_output, "tri_label_logits"):
+            return self._torch.softmax(model_output.tri_label_logits, dim=-1)[:, 0]
+        if hasattr(model_output, "seq_relationship_logits"):
+            return self._torch.softmax(model_output.seq_relationship_logits, dim=-1)[:, 1]
+        if hasattr(model_output, "reg_label_logits"):
+            return model_output.reg_label_logits.reshape(-1)
+
+        logits = model_output.logits
+        if logits.shape[-1] == 1:
+            return self._torch.sigmoid(logits).reshape(-1)
+        return self._torch.softmax(logits, dim=-1)[:, self.positive_label_id]
 
     def score(self, contexts: list[str], claims: list[str], batch_size: int = ALIGNSCORE_BATCH_SIZE) -> list[float]:
         """Compute factual consistency probabilities for aligned context/claim pairs."""
@@ -418,16 +442,12 @@ class HuggingFaceAlignScoreScorer(AlignScoreScorer):
                     batch_contexts,
                     batch_claims,
                     max_length=self.max_length,
-                    truncation=True,
-                    padding=True,
+                    truncation="only_first",
+                    padding="max_length",
                     return_tensors="pt",
                 )
                 encoded = {key: value.to(self.device) for key, value in encoded.items()}
-                logits = self.model(**encoded).logits
-                if logits.shape[-1] == 1:
-                    probabilities = self._torch.sigmoid(logits).reshape(-1)
-                else:
-                    probabilities = self._torch.softmax(logits, dim=-1)[:, self.positive_label_id]
+                probabilities = self._extract_alignment_probabilities(self.model(**encoded))
                 scores.extend(float(score) for score in probabilities.tolist())
         return scores
 
@@ -438,6 +458,7 @@ def get_alignscore_scorer(
     max_length: int = ALIGNSCORE_MAX_LENGTH,
     device: str = ALIGNSCORE_DEVICE,
     cache_dir: str | None = None,
+    trust_remote_code: bool = ALIGNSCORE_TRUST_REMOTE_CODE,
 ) -> AlignScoreScorer:
     """Return a cached AlignScore scorer instance."""
     logger.debug(
@@ -452,6 +473,7 @@ def get_alignscore_scorer(
         max_length=max_length,
         device=device,
         cache_dir=cache_dir,
+        trust_remote_code=trust_remote_code,
     )
 
 
@@ -1070,6 +1092,7 @@ def align_score(
     max_length: int = ALIGNSCORE_MAX_LENGTH,
     device: str = ALIGNSCORE_DEVICE,
     cache_dir: str | None = None,
+    trust_remote_code: bool = ALIGNSCORE_TRUST_REMOTE_CODE,
     aggregation: str = "mean",
     scorer: AlignScoreScorer | None = None,
 ) -> list[float | None]:
@@ -1106,6 +1129,7 @@ def align_score(
         max_length=max_length,
         device=device,
         cache_dir=cache_dir,
+        trust_remote_code=trust_remote_code,
     )
     claim_scores = effective_scorer.score(prepared_contexts, prepared_claims, batch_size=batch_size)
     if len(claim_scores) != len(prepared_claims):
@@ -1295,6 +1319,7 @@ class AlignScoreConfig(BaseGenerationMetricConfig):
     max_length: int = ALIGNSCORE_MAX_LENGTH
     device: str = ALIGNSCORE_DEVICE
     cache_dir: str | None = None
+    trust_remote_code: bool = ALIGNSCORE_TRUST_REMOTE_CODE
     aggregation: str = "mean"
 
     def __post_init__(self) -> None:
@@ -1317,6 +1342,7 @@ class AlignScoreConfig(BaseGenerationMetricConfig):
             "max_length": self.max_length,
             "device": self.device,
             "cache_dir": self.cache_dir,
+            "trust_remote_code": self.trust_remote_code,
             "aggregation": self.aggregation,
         }
 

--- a/configs/metrics/generation/align_score.yaml
+++ b/configs/metrics/generation/align_score.yaml
@@ -1,0 +1,8 @@
+_target_: autorag_research.evaluation.metrics.generation.AlignScoreConfig
+description: "AlignScore - ACL 2023 factual consistency against retrieved context"
+model_name_or_path: liuyanyi/AlignScore-large-hf
+batch_size: 8
+max_length: 1024
+device: cpu
+cache_dir: null
+aggregation: mean

--- a/configs/metrics/generation/align_score.yaml
+++ b/configs/metrics/generation/align_score.yaml
@@ -5,4 +5,6 @@ batch_size: 8
 max_length: 1024
 device: cpu
 cache_dir: null
+trust_remote_code: true
+revision: cc13dc572fce8aa32778a437fb66a02d39a5b8e3
 aggregation: mean

--- a/tests/autorag_research/cli/test_utils.py
+++ b/tests/autorag_research/cli/test_utils.py
@@ -155,6 +155,7 @@ class TestDiscoverMetrics:
         """discover_metrics finds rouge in real configs/metrics/generation/."""
         result = discover_metrics("generation")
 
+        assert "align_score" in result
         assert "exact_match" in result
         assert "rouge" in result
         assert "token_f1" in result

--- a/tests/autorag_research/evaluation/metrics/test_generation.py
+++ b/tests/autorag_research/evaluation/metrics/test_generation.py
@@ -1,15 +1,19 @@
 import math
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 
 import pytest
+import yaml
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models.fake import FakeListLLM
 from langchain_openai import OpenAIEmbeddings
 
 from autorag_research import cli
 from autorag_research.evaluation.metrics.generation import (
+    ALIGNSCORE_MODEL_NAME,
+    ALIGNSCORE_REVISION,
     AlignScoreConfig,
     BartScoreF1Config,
     BartScoreFaithfulnessConfig,
@@ -626,10 +630,15 @@ class FakeAlignScoreTensor:
     def __init__(self, values: list[list[float]] | list[float]) -> None:
         self.values = values
 
+    def _matrix_values(self) -> list[list[float]]:
+        assert self.values and isinstance(self.values[0], list)
+        return cast(list[list[float]], self.values)
+
     @property
     def shape(self) -> tuple[int, ...]:
         if self.values and isinstance(self.values[0], list):
-            return (len(self.values), len(self.values[0]))
+            matrix_values = self._matrix_values()
+            return (len(matrix_values), len(matrix_values[0]))
         return (len(self.values),)
 
     def to(self, _device: str) -> "FakeAlignScoreTensor":
@@ -637,7 +646,7 @@ class FakeAlignScoreTensor:
 
     def reshape(self, *_shape: int) -> "FakeAlignScoreTensor":
         if self.values and isinstance(self.values[0], list):
-            return FakeAlignScoreTensor([item for row in self.values for item in row])
+            return FakeAlignScoreTensor([item for row in self._matrix_values() for item in row])
         return self
 
     def tolist(self) -> list[float] | list[list[float]]:
@@ -646,7 +655,7 @@ class FakeAlignScoreTensor:
     def __getitem__(self, key: tuple[slice, int]) -> "FakeAlignScoreTensor":
         rows, column = key
         assert rows == slice(None)
-        return FakeAlignScoreTensor([row[column] for row in self.values])
+        return FakeAlignScoreTensor([row[column] for row in self._matrix_values()])
 
 
 class FakeAlignScoreNoGrad:
@@ -666,7 +675,7 @@ class FakeAlignScoreTorch:
     def softmax(tensor: FakeAlignScoreTensor, dim: int) -> FakeAlignScoreTensor:
         assert dim == -1
         normalized_rows = []
-        for row in tensor.values:
+        for row in tensor._matrix_values():
             denominator = sum(math.exp(value) for value in row)
             normalized_rows.append([math.exp(value) / denominator for value in row])
         return FakeAlignScoreTensor(normalized_rows)
@@ -800,6 +809,8 @@ def test_align_score_config_exposes_metric_function_and_kwargs():
         max_length=256,
         device="cpu",
         cache_dir="custom-cache",
+        trust_remote_code=True,
+        revision="custom-revision",
         aggregation="min",
     )
 
@@ -813,7 +824,75 @@ def test_align_score_config_exposes_metric_function_and_kwargs():
         "cache_dir": "custom-cache",
         "aggregation": "min",
         "trust_remote_code": True,
+        "revision": "custom-revision",
     }
+
+
+def test_align_score_shipped_config_pins_revision_and_explicit_trust():
+    config_path = Path("configs/metrics/generation/align_score.yaml")
+    config = yaml.safe_load(config_path.read_text())
+
+    assert config["model_name_or_path"] == ALIGNSCORE_MODEL_NAME
+    assert config["trust_remote_code"] is True
+    assert config["revision"] == ALIGNSCORE_REVISION
+
+
+def test_align_score_default_checkpoint_requires_explicit_remote_code_trust():
+    import autorag_research.evaluation.metrics.generation as generation_module
+
+    with pytest.raises(ValueError, match="trust_remote_code=True") as exc_info:
+        generation_module.HuggingFaceAlignScoreScorer(
+            model_name_or_path=ALIGNSCORE_MODEL_NAME,
+            trust_remote_code=False,
+        )
+
+    assert ALIGNSCORE_MODEL_NAME in str(exc_info.value)
+
+
+def test_align_score_default_checkpoint_rejects_unpinned_remote_code_revision():
+    import autorag_research.evaluation.metrics.generation as generation_module
+
+    with pytest.raises(ValueError, match="pinned commit revision") as exc_info:
+        generation_module.HuggingFaceAlignScoreScorer(
+            model_name_or_path=ALIGNSCORE_MODEL_NAME,
+            trust_remote_code=True,
+            revision=None,
+        )
+
+    assert ALIGNSCORE_MODEL_NAME in str(exc_info.value)
+
+
+def test_align_score_custom_model_does_not_inherit_builtin_revision(monkeypatch: pytest.MonkeyPatch):
+    import autorag_research.evaluation.metrics.generation as generation_module
+
+    fake_torch, fake_model, fake_tokenizer, model_load_calls, tokenizer_load_calls, _tokenizer_encode_calls = (
+        _make_fake_alignscore_runtime()
+    )
+
+    monkeypatch.setattr(
+        generation_module,
+        "_import_alignscore_runtime",
+        lambda: (fake_torch, fake_model, fake_tokenizer),
+    )
+
+    generation_module.HuggingFaceAlignScoreScorer(model_name_or_path="local/custom-alignscore")
+
+    assert model_load_calls == [
+        {
+            "model_name_or_path": "local/custom-alignscore",
+            "cache_dir": None,
+            "trust_remote_code": False,
+            "revision": None,
+        }
+    ]
+    assert tokenizer_load_calls == [
+        {
+            "model_name_or_path": "local/custom-alignscore",
+            "cache_dir": None,
+            "trust_remote_code": False,
+            "revision": None,
+        }
+    ]
 
 
 def test_align_score_default_huggingface_scorer_uses_alignscore_remote_contract(
@@ -831,14 +910,28 @@ def test_align_score_default_huggingface_scorer_uses_alignscore_remote_contract(
         lambda: (fake_torch, fake_model, fake_tokenizer),
     )
 
-    scorer = generation_module.HuggingFaceAlignScoreScorer(model_name_or_path="liuyanyi/AlignScore-large-hf")
+    scorer = generation_module.HuggingFaceAlignScoreScorer(
+        model_name_or_path="liuyanyi/AlignScore-large-hf",
+        trust_remote_code=True,
+        revision=ALIGNSCORE_REVISION,
+    )
     scores = scorer.score(["context 1", "context 2"], ["claim 1", "claim 2"], batch_size=2)
 
     assert model_load_calls == [
-        {"model_name_or_path": "liuyanyi/AlignScore-large-hf", "cache_dir": None, "trust_remote_code": True}
+        {
+            "model_name_or_path": "liuyanyi/AlignScore-large-hf",
+            "cache_dir": None,
+            "trust_remote_code": True,
+            "revision": ALIGNSCORE_REVISION,
+        }
     ]
     assert tokenizer_load_calls == [
-        {"model_name_or_path": "liuyanyi/AlignScore-large-hf", "cache_dir": None, "trust_remote_code": True}
+        {
+            "model_name_or_path": "liuyanyi/AlignScore-large-hf",
+            "cache_dir": None,
+            "trust_remote_code": True,
+            "revision": ALIGNSCORE_REVISION,
+        }
     ]
     assert tokenizer_encode_calls == [
         {

--- a/tests/autorag_research/evaluation/metrics/test_generation.py
+++ b/tests/autorag_research/evaluation/metrics/test_generation.py
@@ -626,6 +626,16 @@ class DummyAlignScoreScorer:
         return self.responses[: len(claims)]
 
 
+class MappingAlignScoreScorer:
+    def __init__(self, responses: dict[tuple[str, str], float]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[list[str], list[str], int]] = []
+
+    def score(self, contexts: list[str], claims: list[str], batch_size: int = 8) -> list[float]:
+        self.calls.append((contexts, claims, batch_size))
+        return [self.responses[(context, claim)] for context, claim in zip(contexts, claims, strict=True)]
+
+
 class FakeAlignScoreTensor:
     def __init__(self, values: list[list[float]] | list[float]) -> None:
         self.values = values
@@ -737,7 +747,14 @@ def _make_fake_alignscore_runtime():
 
 
 def test_align_score_scores_sentence_claims_against_retrieved_context():
-    scorer = DummyAlignScoreScorer(responses=[0.25, 0.75])
+    scorer = MappingAlignScoreScorer(
+        responses={
+            ("France is in Europe.", "Paris is the capital of France."): 0.25,
+            ("Paris is France's capital.", "Paris is the capital of France."): 0.75,
+            ("France is in Europe.", "It is in Europe."): 0.25,
+            ("Paris is France's capital.", "It is in Europe."): 0.1,
+        }
+    )
 
     scores = align_score(
         metric_inputs=[
@@ -753,9 +770,78 @@ def test_align_score_scores_sentence_claims_against_retrieved_context():
     assert scores == [pytest.approx(0.5)]
     assert scorer.calls == [
         (
-            ["France is in Europe.\n\nParis is France's capital."] * 2,
-            ["Paris is the capital of France.", "It is in Europe."],
+            [
+                "France is in Europe.",
+                "Paris is France's capital.",
+                "France is in Europe.",
+                "Paris is France's capital.",
+            ],
+            [
+                "Paris is the capital of France.",
+                "Paris is the capital of France.",
+                "It is in Europe.",
+                "It is in Europe.",
+            ],
             4,
+        )
+    ]
+
+
+def test_align_score_uses_later_retrieved_passage_when_it_best_supports_claim():
+    scorer = MappingAlignScoreScorer(
+        responses={
+            ("Irrelevant early passage.", "Paris is the capital of France."): 0.05,
+            ("Paris is the capital of France.", "Paris is the capital of France."): 0.95,
+        }
+    )
+
+    scores = align_score(
+        metric_inputs=[
+            MetricInput(
+                retrieved_contents=["Irrelevant early passage.", "Paris is the capital of France."],
+                generated_texts="Paris is the capital of France.",
+            )
+        ],
+        scorer=scorer,
+        batch_size=4,
+    )
+
+    assert scores == [pytest.approx(0.95)]
+    assert scorer.calls == [
+        (
+            ["Irrelevant early passage.", "Paris is the capital of France."],
+            ["Paris is the capital of France.", "Paris is the capital of France."],
+            4,
+        )
+    ]
+
+
+def test_align_score_uses_later_sentence_window_when_passage_is_long():
+    early_window = "One. Two. Three. Four. Five."
+    later_window = "Paris is the capital of France."
+    scorer = MappingAlignScoreScorer(
+        responses={
+            (early_window, "Paris is the capital of France."): 0.02,
+            (later_window, "Paris is the capital of France."): 0.98,
+        }
+    )
+
+    scores = align_score(
+        metric_inputs=[
+            MetricInput(
+                retrieved_contents=[f"{early_window} {later_window}"],
+                generated_texts="Paris is the capital of France.",
+            )
+        ],
+        scorer=scorer,
+    )
+
+    assert scores == [pytest.approx(0.98)]
+    assert scorer.calls == [
+        (
+            [early_window, later_window],
+            ["Paris is the capital of France.", "Paris is the capital of France."],
+            8,
         )
     ]
 

--- a/tests/autorag_research/evaluation/metrics/test_generation.py
+++ b/tests/autorag_research/evaluation/metrics/test_generation.py
@@ -8,12 +8,14 @@ from langchain_openai import OpenAIEmbeddings
 
 from autorag_research import cli
 from autorag_research.evaluation.metrics.generation import (
+    AlignScoreConfig,
     BartScoreF1Config,
     BartScoreFaithfulnessConfig,
     BartScorePrecisionConfig,
     BartScoreRecallConfig,
     ExactMatchConfig,
     TokenF1Config,
+    align_score,
     bart_score_f1,
     bart_score_faithfulness,
     bart_score_precision,
@@ -604,5 +606,124 @@ def test_bart_score_runtime_guard_points_to_optional_dependencies(
 
     with pytest.raises(ImportError, match=r"autorag-research\[gpu\]") as exc_info:
         generation_module._import_bartscore_runtime()
+
+    assert "uv sync --all-extras --all-groups" in str(exc_info.value)
+
+
+class DummyAlignScoreScorer:
+    def __init__(self, responses: list[float]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[list[str], list[str], int]] = []
+
+    def score(self, contexts: list[str], claims: list[str], batch_size: int = 8) -> list[float]:
+        self.calls.append((contexts, claims, batch_size))
+        return self.responses[: len(claims)]
+
+
+def test_align_score_scores_sentence_claims_against_retrieved_context():
+    scorer = DummyAlignScoreScorer(responses=[0.25, 0.75])
+
+    scores = align_score(
+        metric_inputs=[
+            MetricInput(
+                retrieved_contents=["France is in Europe.", "Paris is France's capital."],
+                generated_texts="Paris is the capital of France. It is in Europe.",
+            )
+        ],
+        scorer=scorer,
+        batch_size=4,
+    )
+
+    assert scores == [pytest.approx(0.5)]
+    assert scorer.calls == [
+        (
+            ["France is in Europe.\n\nParis is France's capital."] * 2,
+            ["Paris is the capital of France.", "It is in Europe."],
+            4,
+        )
+    ]
+
+
+def test_align_score_min_aggregation_keeps_worst_supported_claim():
+    scorer = DummyAlignScoreScorer(responses=[0.91, 0.12])
+
+    scores = align_score(
+        metric_inputs=[
+            MetricInput(
+                retrieved_contents=["Grounded context."],
+                generated_texts="Grounded claim. Unsupported claim.",
+            )
+        ],
+        scorer=scorer,
+        aggregation="min",
+    )
+
+    assert scores == [pytest.approx(0.12)]
+
+
+def test_align_score_returns_none_without_context_or_generated_text():
+    scorer = DummyAlignScoreScorer(responses=[0.9])
+
+    scores = align_score(
+        metric_inputs=[
+            MetricInput(generated_texts="Paris is France's capital."),
+            MetricInput(retrieved_contents=["Paris is France's capital."]),
+            MetricInput(retrieved_contents=["   "], generated_texts="Paris is France's capital."),
+        ],
+        scorer=scorer,
+    )
+
+    assert scores == [None, None, None]
+    assert scorer.calls == []
+
+
+def test_align_score_rejects_unknown_aggregation():
+    with pytest.raises(ValueError, match="Unsupported AlignScore aggregation"):
+        align_score(
+            metric_inputs=[MetricInput(retrieved_contents=["Context"], generated_texts="Claim")],
+            scorer=DummyAlignScoreScorer(responses=[0.5]),
+            aggregation="median",
+        )
+
+
+def test_align_score_config_exposes_metric_function_and_kwargs():
+    config = AlignScoreConfig(
+        model_name_or_path="custom-alignscore",
+        batch_size=2,
+        max_length=256,
+        device="cpu",
+        cache_dir="custom-cache",
+        aggregation="min",
+    )
+
+    assert config.get_metric_name() == "align_score"
+    assert config.get_metric_func() is align_score
+    assert config.get_metric_kwargs() == {
+        "model_name_or_path": "custom-alignscore",
+        "batch_size": 2,
+        "max_length": 256,
+        "device": "cpu",
+        "cache_dir": "custom-cache",
+        "aggregation": "min",
+    }
+
+
+def test_align_score_runtime_guard_points_to_optional_dependencies(monkeypatch: pytest.MonkeyPatch):
+    import autorag_research.evaluation.metrics.generation as generation_module
+
+    original_import_module = generation_module.importlib.import_module
+
+    def fake_import_module(name: str):
+        if name == "transformers":
+            msg = "missing transformers"
+            raise ImportError(msg)
+        if name == "torch":
+            return object()
+        return original_import_module(name)
+
+    monkeypatch.setattr(generation_module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match=r"autorag-research\[gpu\]") as exc_info:
+        generation_module._import_alignscore_runtime()
 
     assert "uv sync --all-extras --all-groups" in str(exc_info.value)

--- a/tests/autorag_research/evaluation/metrics/test_generation.py
+++ b/tests/autorag_research/evaluation/metrics/test_generation.py
@@ -1,4 +1,6 @@
+import math
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -620,6 +622,111 @@ class DummyAlignScoreScorer:
         return self.responses[: len(claims)]
 
 
+class FakeAlignScoreTensor:
+    def __init__(self, values: list[list[float]] | list[float]) -> None:
+        self.values = values
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        if self.values and isinstance(self.values[0], list):
+            return (len(self.values), len(self.values[0]))
+        return (len(self.values),)
+
+    def to(self, _device: str) -> "FakeAlignScoreTensor":
+        return self
+
+    def reshape(self, *_shape: int) -> "FakeAlignScoreTensor":
+        if self.values and isinstance(self.values[0], list):
+            return FakeAlignScoreTensor([item for row in self.values for item in row])
+        return self
+
+    def tolist(self) -> list[float] | list[list[float]]:
+        return self.values
+
+    def __getitem__(self, key: tuple[slice, int]) -> "FakeAlignScoreTensor":
+        rows, column = key
+        assert rows == slice(None)
+        return FakeAlignScoreTensor([row[column] for row in self.values])
+
+
+class FakeAlignScoreNoGrad:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class FakeAlignScoreTorch:
+    @staticmethod
+    def no_grad() -> FakeAlignScoreNoGrad:
+        return FakeAlignScoreNoGrad()
+
+    @staticmethod
+    def softmax(tensor: FakeAlignScoreTensor, dim: int) -> FakeAlignScoreTensor:
+        assert dim == -1
+        normalized_rows = []
+        for row in tensor.values:
+            denominator = sum(math.exp(value) for value in row)
+            normalized_rows.append([math.exp(value) / denominator for value in row])
+        return FakeAlignScoreTensor(normalized_rows)
+
+    @staticmethod
+    def sigmoid(_tensor: FakeAlignScoreTensor) -> FakeAlignScoreTensor:
+        pytest.fail("AlignScore default path should use tri_label_logits, not a generic logits sigmoid")
+
+
+def _make_fake_alignscore_runtime():
+    tokenizer_load_calls: list[dict[str, object]] = []
+    tokenizer_encode_calls: list[dict[str, object]] = []
+    model_load_calls: list[dict[str, object]] = []
+
+    class FakeTokenizer:
+        @classmethod
+        def from_pretrained(cls, model_name_or_path: str, **kwargs: object) -> "FakeTokenizer":
+            tokenizer_load_calls.append({"model_name_or_path": model_name_or_path, **kwargs})
+            return cls()
+
+        def __call__(
+            self,
+            contexts: list[str],
+            claims: list[str],
+            **kwargs: object,
+        ) -> dict[str, FakeAlignScoreTensor]:
+            tokenizer_encode_calls.append({"contexts": contexts, "claims": claims, **kwargs})
+            return {"input_ids": FakeAlignScoreTensor([[1, 2], [3, 4]])}
+
+    class FakeModel:
+        def __init__(self) -> None:
+            self.config = SimpleNamespace(
+                model_type="alignscore",
+                id2label={0: "entailment", 1: "neutral", 2: "contradiction"},
+            )
+
+        @classmethod
+        def from_pretrained(cls, model_name_or_path: str, **kwargs: object) -> "FakeModel":
+            model_load_calls.append({"model_name_or_path": model_name_or_path, **kwargs})
+            return cls()
+
+        def eval(self) -> None:
+            return None
+
+        def to(self, _device: str) -> None:
+            return None
+
+        def __call__(self, **_encoded: FakeAlignScoreTensor) -> SimpleNamespace:
+            return SimpleNamespace(tri_label_logits=FakeAlignScoreTensor([[2.0, 0.0, 0.0], [0.0, 2.0, 0.0]]))
+
+    return (
+        FakeAlignScoreTorch,
+        FakeModel,
+        FakeTokenizer,
+        model_load_calls,
+        tokenizer_load_calls,
+        tokenizer_encode_calls,
+    )
+
+
 def test_align_score_scores_sentence_claims_against_retrieved_context():
     scorer = DummyAlignScoreScorer(responses=[0.25, 0.75])
 
@@ -705,7 +812,45 @@ def test_align_score_config_exposes_metric_function_and_kwargs():
         "device": "cpu",
         "cache_dir": "custom-cache",
         "aggregation": "min",
+        "trust_remote_code": True,
     }
+
+
+def test_align_score_default_huggingface_scorer_uses_alignscore_remote_contract(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import autorag_research.evaluation.metrics.generation as generation_module
+
+    fake_torch, fake_model, fake_tokenizer, model_load_calls, tokenizer_load_calls, tokenizer_encode_calls = (
+        _make_fake_alignscore_runtime()
+    )
+
+    monkeypatch.setattr(
+        generation_module,
+        "_import_alignscore_runtime",
+        lambda: (fake_torch, fake_model, fake_tokenizer),
+    )
+
+    scorer = generation_module.HuggingFaceAlignScoreScorer(model_name_or_path="liuyanyi/AlignScore-large-hf")
+    scores = scorer.score(["context 1", "context 2"], ["claim 1", "claim 2"], batch_size=2)
+
+    assert model_load_calls == [
+        {"model_name_or_path": "liuyanyi/AlignScore-large-hf", "cache_dir": None, "trust_remote_code": True}
+    ]
+    assert tokenizer_load_calls == [
+        {"model_name_or_path": "liuyanyi/AlignScore-large-hf", "cache_dir": None, "trust_remote_code": True}
+    ]
+    assert tokenizer_encode_calls == [
+        {
+            "contexts": ["context 1", "context 2"],
+            "claims": ["claim 1", "claim 2"],
+            "max_length": 1024,
+            "truncation": "only_first",
+            "padding": "max_length",
+            "return_tensors": "pt",
+        }
+    ]
+    assert scores == [pytest.approx(0.786986), pytest.approx(0.106507)]
 
 
 def test_align_score_runtime_guard_points_to_optional_dependencies(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
<!-- dani:stage=implementation;job=d54ba47c387361e88905fc86f915d232;issue=335 -->

## Summary
- add a configurable AlignScore generation metric for factual consistency against retrieved context
- split generated answers into sentence-level claims, score each claim against individual retrieved passages / sentence windows, take the max support score per claim, and aggregate by mean or min
- expose the metric through exports, YAML discovery, lazy optional model loading, and focused offline tests
- make the shipped remote-code AlignScore checkpoint explicit and auditable by pinning its Hugging Face revision in YAML and requiring explicit `trust_remote_code: true`
- keep custom AlignScore model paths unconstrained by default while rejecting the built-in checkpoint when trust or an immutable revision pin is missing

## Verification
- `uv run pytest tests/autorag_research/evaluation/metrics/test_generation.py::test_align_score_uses_later_retrieved_passage_when_it_best_supports_claim tests/autorag_research/evaluation/metrics/test_generation.py::test_align_score_uses_later_sentence_window_when_passage_is_long -q`
- `uv run pytest tests/autorag_research/evaluation/metrics/test_generation.py -q -k 'align_score'`
- `uv run pytest tests/autorag_research/evaluation/metrics/test_generation.py -q tests/autorag_research/cli/test_utils.py::TestDiscoverMetrics::test_discover_metrics_finds_real_generation_configs -q`
- `uv run ty check tests/autorag_research/evaluation/metrics/test_generation.py`
- `uv run ty check autorag_research/evaluation/metrics/generation.py`
- mocked runtime smoke script calling `align_score()` through the default cached scorer path with pinned revision
- mocked runtime smoke script confirming later retrieved evidence wins via max support per claim
- `make check`

## Notes
- the default scorer uses a Hugging Face-format AlignScore checkpoint and keeps `torch`/`transformers` imports lazy so environments without GPU extras can still import core metrics
- the shipped YAML pins `liuyanyi/AlignScore-large-hf` to revision `cc13dc572fce8aa32778a437fb66a02d39a5b8e3` and explicitly opts into remote code
- claim/window scoring increases scorer calls as `claims × windows`, but prevents tokenizer truncation of later retrieved evidence
- real checkpoint inference was not run locally because it would require model download/runtime resources
- full Docker-backed `make test` was not run for this follow-up; no DB-backed paths changed
