### PR TITLE
Fix DuplicateRetrievalGTError in RAGBench ingestion

### DIFF
--- a/autorag_research/data/ragbench.py
+++ b/autorag_research/data/ragbench.py
@@ -128,6 +128,7 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
 
         seen_chunk_ids: set[str] = set()
         relation_chunk_ids_by_query: dict[str, set[str]] = {}
+        query_metadata_by_query: dict[str, tuple[str, str | None]] = {}
         batch: list[dict[str, Any]] = []
         total_processed = 0
 
@@ -136,7 +137,14 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
             batch.append(example_dict)
 
             if len(batch) >= self.batch_size:
-                self._process_batch(config, split, batch, seen_chunk_ids, relation_chunk_ids_by_query)
+                self._process_batch(
+                    config,
+                    split,
+                    batch,
+                    seen_chunk_ids,
+                    relation_chunk_ids_by_query,
+                    query_metadata_by_query,
+                )
                 total_processed += len(batch)
                 logger.info(f"[{config}] Processed {total_processed} examples...")
                 batch = []
@@ -147,7 +155,14 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
                 break
 
         if batch:
-            self._process_batch(config, split, batch, seen_chunk_ids, relation_chunk_ids_by_query)
+            self._process_batch(
+                config,
+                split,
+                batch,
+                seen_chunk_ids,
+                relation_chunk_ids_by_query,
+                query_metadata_by_query,
+            )
             total_processed += len(batch)
 
         logger.info(f"[{config}] Total examples processed: {total_processed}")
@@ -160,10 +175,41 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
         examples: list[dict[str, Any]],
         seen_chunk_ids: set[str],
         relation_chunk_ids_by_query: dict[str, set[str]],
+        query_metadata_by_query: dict[str, tuple[str, str | None]] | None = None,
     ) -> None:
+        if query_metadata_by_query is not None:
+            self._record_query_metadata_and_warn_on_mismatch(config, split, examples, query_metadata_by_query)
         row_doc_to_chunk_mapping = self._ingest_chunks(config, examples, seen_chunk_ids)
         self._ingest_queries(config, split, examples)
         self._ingest_relations(config, split, examples, row_doc_to_chunk_mapping, relation_chunk_ids_by_query)
+
+    def _record_query_metadata_and_warn_on_mismatch(
+        self,
+        config: str,
+        split: str,
+        examples: list[dict[str, Any]],
+        query_metadata_by_query: dict[str, tuple[str, str | None]],
+    ) -> None:
+        for example in examples:
+            example_id = str(example["id"])
+            query_id = _make_query_id(config, split, example_id)
+            question = str(example["question"])
+            response = example.get("response")
+            response_text = str(response) if response is not None else None
+            current_metadata = (question, response_text)
+            first_metadata = query_metadata_by_query.setdefault(query_id, current_metadata)
+
+            if first_metadata != current_metadata:
+                logger.warning(
+                    "Duplicate RAGBench query id %s has different question/response metadata; "
+                    "keeping first query metadata while unioning retrieval ground truth. "
+                    "first_question=%r duplicate_question=%r first_response=%r duplicate_response=%r",
+                    query_id,
+                    first_metadata[0],
+                    question,
+                    first_metadata[1],
+                    response_text,
+                )
 
     def _ingest_chunks(
         self,

--- a/autorag_research/data/ragbench.py
+++ b/autorag_research/data/ragbench.py
@@ -161,23 +161,23 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
         seen_chunk_ids: set[str],
         relation_chunk_ids_by_query: dict[str, set[str]],
     ) -> None:
-        doc_to_chunk_mapping = self._ingest_chunks(config, examples, seen_chunk_ids)
+        row_doc_to_chunk_mapping = self._ingest_chunks(config, examples, seen_chunk_ids)
         self._ingest_queries(config, split, examples)
-        self._ingest_relations(config, split, examples, doc_to_chunk_mapping, relation_chunk_ids_by_query)
+        self._ingest_relations(config, split, examples, row_doc_to_chunk_mapping, relation_chunk_ids_by_query)
 
     def _ingest_chunks(
         self,
         config: str,
         examples: list[dict[str, Any]],
         seen_chunk_ids: set[str],
-    ) -> dict[tuple[str, int], str]:
+    ) -> dict[tuple[int, int], str]:
         if self.service is None:
             raise ServiceNotSetError
 
         chunks_to_add: list[dict[str, str | int | None]] = []
-        doc_to_chunk_mapping: dict[tuple[str, int], str] = {}
+        row_doc_to_chunk_mapping: dict[tuple[int, int], str] = {}
 
-        for example in examples:
+        for row_idx, example in enumerate(examples):
             example_id = str(example["id"])
             documents = example.get("documents", [])
 
@@ -187,7 +187,7 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
                     continue
 
                 chunk_id = compute_chunk_id(doc_text, config)
-                doc_to_chunk_mapping[(example_id, doc_idx)] = chunk_id
+                row_doc_to_chunk_mapping[(row_idx, doc_idx)] = chunk_id
 
                 if chunk_id not in seen_chunk_ids:
                     seen_chunk_ids.add(chunk_id)
@@ -199,7 +199,7 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
         if chunks_to_add:
             self.service.add_chunks(chunks_to_add)
 
-        return doc_to_chunk_mapping
+        return row_doc_to_chunk_mapping
 
     def _ingest_queries(
         self,
@@ -217,6 +217,8 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
             query_id = _make_query_id(config, split, example_id)
             response = example.get("response")
 
+            # RAGBench duplicate IDs are expected to repeat the same query/response metadata. Query insertion remains
+            # first-wins via the ingestion service's default duplicate-skip behavior, while retrieval GT is unioned.
             queries.append({
                 "id": query_id,
                 "contents": example["question"],
@@ -231,13 +233,13 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
         config: str,
         split: str,
         examples: list[dict[str, Any]],
-        doc_to_chunk_mapping: dict[tuple[str, int], str],
+        row_doc_to_chunk_mapping: dict[tuple[int, int], str],
         relation_chunk_ids_by_query: dict[str, set[str]] | None = None,
     ) -> None:
         if self.service is None:
             raise ServiceNotSetError
 
-        for example in examples:
+        for row_idx, example in enumerate(examples):
             example_id = str(example["id"])
             query_id = _make_query_id(config, split, example_id)
 
@@ -256,9 +258,9 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
                 logger.warning(f"Some sentence keys reference non-existent documents for example {example_id}")
 
             chunk_ids = [
-                doc_to_chunk_mapping[(example_id, idx)]
+                row_doc_to_chunk_mapping[(row_idx, idx)]
                 for idx in sorted(valid_indices)
-                if (example_id, idx) in doc_to_chunk_mapping
+                if (row_idx, idx) in row_doc_to_chunk_mapping
             ]
 
             if chunk_ids:

--- a/autorag_research/data/ragbench.py
+++ b/autorag_research/data/ragbench.py
@@ -257,10 +257,15 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
             raise ServiceNotSetError
 
         queries: list[dict[str, str | list[str] | None]] = []
+        seen_query_ids: set[str] = set()
 
         for example in examples:
             example_id = str(example["id"])
             query_id = _make_query_id(config, split, example_id)
+            if query_id in seen_query_ids:
+                continue
+            seen_query_ids.add(query_id)
+
             response = example.get("response")
 
             # RAGBench duplicate IDs are expected to repeat the same query/response metadata. Query insertion remains

--- a/autorag_research/data/ragbench.py
+++ b/autorag_research/data/ragbench.py
@@ -127,6 +127,7 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
         )
 
         seen_chunk_ids: set[str] = set()
+        relation_chunk_ids_by_query: dict[str, set[str]] = {}
         batch: list[dict[str, Any]] = []
         total_processed = 0
 
@@ -135,7 +136,7 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
             batch.append(example_dict)
 
             if len(batch) >= self.batch_size:
-                self._process_batch(config, split, batch, seen_chunk_ids)
+                self._process_batch(config, split, batch, seen_chunk_ids, relation_chunk_ids_by_query)
                 total_processed += len(batch)
                 logger.info(f"[{config}] Processed {total_processed} examples...")
                 batch = []
@@ -146,7 +147,7 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
                 break
 
         if batch:
-            self._process_batch(config, split, batch, seen_chunk_ids)
+            self._process_batch(config, split, batch, seen_chunk_ids, relation_chunk_ids_by_query)
             total_processed += len(batch)
 
         logger.info(f"[{config}] Total examples processed: {total_processed}")
@@ -158,10 +159,11 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
         split: str,
         examples: list[dict[str, Any]],
         seen_chunk_ids: set[str],
+        relation_chunk_ids_by_query: dict[str, set[str]],
     ) -> None:
         doc_to_chunk_mapping = self._ingest_chunks(config, examples, seen_chunk_ids)
         self._ingest_queries(config, split, examples)
-        self._ingest_relations(config, split, examples, doc_to_chunk_mapping)
+        self._ingest_relations(config, split, examples, doc_to_chunk_mapping, relation_chunk_ids_by_query)
 
     def _ingest_chunks(
         self,
@@ -230,6 +232,7 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
         split: str,
         examples: list[dict[str, Any]],
         doc_to_chunk_mapping: dict[tuple[str, int], str],
+        relation_chunk_ids_by_query: dict[str, set[str]] | None = None,
     ) -> None:
         if self.service is None:
             raise ServiceNotSetError
@@ -259,4 +262,11 @@ class RAGBenchIngestor(TextEmbeddingDataIngestor):
             ]
 
             if chunk_ids:
-                self.service.add_retrieval_gt(query_id, or_all(chunk_ids), chunk_type="text")
+                stored_chunk_ids = (
+                    relation_chunk_ids_by_query.setdefault(query_id, set())
+                    if relation_chunk_ids_by_query is not None
+                    else set()
+                )
+                stored_chunk_ids.update(chunk_ids)
+                gt_chunk_ids = sorted(stored_chunk_ids) if relation_chunk_ids_by_query is not None else chunk_ids
+                self.service.add_retrieval_gt(query_id, or_all(gt_chunk_ids), chunk_type="text", upsert=True)

--- a/tests/autorag_research/data/test_ragbench.py
+++ b/tests/autorag_research/data/test_ragbench.py
@@ -4,6 +4,8 @@ Unit tests for helper functions (TDD - tests written before implementation).
 Integration tests use real data subsets against PostgreSQL.
 """
 
+import logging
+
 import pytest
 from langchain_core.embeddings.fake import FakeEmbeddings
 
@@ -213,6 +215,106 @@ def test_process_batch_upserts_duplicate_ragbench_query_relations_across_batches
         second_chunk_id,
         shared_chunk_id,
     ])
+
+
+def test_process_batch_warns_on_duplicate_ragbench_query_metadata_mismatch_across_batches(
+    mock_embedding_model,
+    caplog,
+):
+    service = FakeRAGBenchService()
+    ingestor = RAGBenchIngestor(mock_embedding_model, config="covidqa", batch_size=1)
+    ingestor.set_service(service)  # ty: ignore[invalid-argument-type]
+    seen_chunk_ids: set[str] = set()
+    relation_chunk_ids_by_query: dict[str, set[str]] = {}
+    query_metadata_by_query: dict[str, tuple[str, str | None]] = {}
+
+    first_example = {
+        "id": "dup",
+        "question": "What is duplicated?",
+        "response": "First response",
+        "documents": ["First supporting document."],
+        "all_relevant_sentence_keys": ["0a"],
+    }
+    second_example = {
+        "id": "dup",
+        "question": "What changed?",
+        "response": "Different response",
+        "documents": ["Second supporting document."],
+        "all_relevant_sentence_keys": ["0a"],
+    }
+
+    with caplog.at_level(logging.WARNING, logger="AutoRAG-Research"):
+        ingestor._process_batch(
+            "covidqa",
+            "test",
+            [first_example],
+            seen_chunk_ids,
+            relation_chunk_ids_by_query,
+            query_metadata_by_query,
+        )
+        ingestor._process_batch(
+            "covidqa",
+            "test",
+            [second_example],
+            seen_chunk_ids,
+            relation_chunk_ids_by_query,
+            query_metadata_by_query,
+        )
+
+    query_id = _make_query_id("covidqa", "test", "dup")
+    assert query_metadata_by_query[query_id] == ("What is duplicated?", "First response")
+    assert any(
+        "Duplicate RAGBench query id" in record.message
+        and query_id in record.message
+        and "different question/response metadata" in record.message
+        for record in caplog.records
+    )
+
+
+def test_process_batch_warns_on_duplicate_ragbench_query_metadata_mismatch_within_same_batch(
+    mock_embedding_model,
+    caplog,
+):
+    service = FakeRAGBenchService()
+    ingestor = RAGBenchIngestor(mock_embedding_model, config="covidqa")
+    ingestor.set_service(service)  # ty: ignore[invalid-argument-type]
+    seen_chunk_ids: set[str] = set()
+    relation_chunk_ids_by_query: dict[str, set[str]] = {}
+    query_metadata_by_query: dict[str, tuple[str, str | None]] = {}
+
+    first_example = {
+        "id": "dup",
+        "question": "What is duplicated?",
+        "response": "Same response",
+        "documents": ["First supporting document."],
+        "all_relevant_sentence_keys": ["0a"],
+    }
+    second_example = {
+        "id": "dup",
+        "question": "What is duplicated?",
+        "response": "Changed response",
+        "documents": ["Second supporting document."],
+        "all_relevant_sentence_keys": ["0a"],
+    }
+
+    with caplog.at_level(logging.WARNING, logger="AutoRAG-Research"):
+        ingestor._process_batch(
+            "covidqa",
+            "test",
+            [first_example, second_example],
+            seen_chunk_ids,
+            relation_chunk_ids_by_query,
+            query_metadata_by_query,
+        )
+
+    query_id = _make_query_id("covidqa", "test", "dup")
+    assert query_metadata_by_query[query_id] == ("What is duplicated?", "Same response")
+    assert any(
+        "Duplicate RAGBench query id" in record.message
+        and query_id in record.message
+        and "different question/response metadata" in record.message
+        for record in caplog.records
+    )
 
 
 def test_process_batch_preserves_duplicate_ragbench_query_relations_within_same_batch(mock_embedding_model):

--- a/tests/autorag_research/data/test_ragbench.py
+++ b/tests/autorag_research/data/test_ragbench.py
@@ -13,6 +13,7 @@ from autorag_research.data.ragbench import (
     compute_chunk_id,
     extract_relevant_doc_indices,
 )
+from autorag_research.orm.models.retrieval_gt import RetrievalGT, normalize_gt
 from autorag_research.orm.service.text_ingestion import TextDataIngestionService
 from tests.autorag_research.data.ingestor_test_utils import (
     IngestorTestConfig,
@@ -135,7 +136,7 @@ RAGBENCH_INTEGRATION_CONFIG = IngestorTestConfig(
 class TestRAGBenchIngestorIntegration:
     def test_ingest_covidqa_subset(self, mock_embedding_model):
         with create_test_database(RAGBENCH_INTEGRATION_CONFIG) as db:
-            service = TextDataIngestionService(db.session_factory, schema=db.schema)
+            service = TextDataIngestionService(db.session_factory, schema=db.schema)  # ty: ignore[invalid-argument-type]
 
             ingestor = RAGBenchIngestor(
                 mock_embedding_model,
@@ -155,7 +156,7 @@ class FakeRAGBenchService:
     def __init__(self):
         self.chunks: list[list[dict[str, str | int | None]]] = []
         self.queries: list[list[dict[str, str | list[str] | None]]] = []
-        self.retrieval_gt_calls: list[tuple[str, object, str, bool]] = []
+        self.retrieval_gt_calls: list[tuple[str, RetrievalGT, str, bool]] = []
 
     def add_chunks(self, chunks: list[dict[str, str | int | None]]) -> None:
         self.chunks.append(chunks)
@@ -163,16 +164,14 @@ class FakeRAGBenchService:
     def add_queries(self, queries: list[dict[str, str | list[str] | None]]) -> None:
         self.queries.append(queries)
 
-    def add_retrieval_gt(self, query_id: str, gt: object, chunk_type: str = "mixed", upsert: bool = False) -> None:
+    def add_retrieval_gt(self, query_id: str, gt: RetrievalGT, chunk_type: str = "mixed", upsert: bool = False) -> None:
         self.retrieval_gt_calls.append((query_id, gt, chunk_type, upsert))
 
 
-def _extract_or_gt_ids(gt: object) -> list[str]:
-    if hasattr(gt, "items"):
-        return [str(item.id) for item in gt.items]
-    if hasattr(gt, "value"):
-        return [str(gt.value)]
-    raise AssertionError
+def _extract_or_gt_ids(gt: RetrievalGT) -> list[str]:
+    normalized_gt = normalize_gt(gt, chunk_type="text")
+    assert len(normalized_gt.groups) == 1
+    return [str(item.id) for item in normalized_gt.groups[0].items]
 
 
 def test_process_batch_upserts_duplicate_ragbench_query_relations_across_batches(mock_embedding_model):

--- a/tests/autorag_research/data/test_ragbench.py
+++ b/tests/autorag_research/data/test_ragbench.py
@@ -192,13 +192,59 @@ def test_process_batch_upserts_duplicate_ragbench_query_relations_across_batches
     second_example = {
         "id": "dup",
         "question": "What is duplicated?",
-        "response": "Second response",
+        "response": "First response",
         "documents": ["Second supporting document.", "Shared supporting document."],
         "all_relevant_sentence_keys": ["0a", "1b"],
     }
 
     ingestor._process_batch("covidqa", "test", [first_example], seen_chunk_ids, relation_chunk_ids_by_query)
     ingestor._process_batch("covidqa", "test", [second_example], seen_chunk_ids, relation_chunk_ids_by_query)
+
+    query_id = _make_query_id("covidqa", "test", "dup")
+    first_chunk_id = compute_chunk_id("First supporting document.", "covidqa")
+    second_chunk_id = compute_chunk_id("Second supporting document.", "covidqa")
+    shared_chunk_id = compute_chunk_id("Shared supporting document.", "covidqa")
+
+    assert [call[0] for call in service.retrieval_gt_calls] == [query_id, query_id]
+    assert [call[2] for call in service.retrieval_gt_calls] == ["text", "text"]
+    assert [call[3] for call in service.retrieval_gt_calls] == [True, True]
+    assert _extract_or_gt_ids(service.retrieval_gt_calls[0][1]) == [first_chunk_id]
+    assert _extract_or_gt_ids(service.retrieval_gt_calls[1][1]) == sorted([
+        first_chunk_id,
+        second_chunk_id,
+        shared_chunk_id,
+    ])
+
+
+def test_process_batch_preserves_duplicate_ragbench_query_relations_within_same_batch(mock_embedding_model):
+    service = FakeRAGBenchService()
+    ingestor = RAGBenchIngestor(mock_embedding_model, config="covidqa")
+    ingestor.set_service(service)  # ty: ignore[invalid-argument-type]
+    seen_chunk_ids: set[str] = set()
+    relation_chunk_ids_by_query: dict[str, set[str]] = {}
+
+    first_example = {
+        "id": "dup",
+        "question": "What is duplicated?",
+        "response": "Same response",
+        "documents": ["First supporting document."],
+        "all_relevant_sentence_keys": ["0a"],
+    }
+    second_example = {
+        "id": "dup",
+        "question": "What is duplicated?",
+        "response": "Same response",
+        "documents": ["Second supporting document.", "Shared supporting document."],
+        "all_relevant_sentence_keys": ["0a", "1b"],
+    }
+
+    ingestor._process_batch(
+        "covidqa",
+        "test",
+        [first_example, second_example],
+        seen_chunk_ids,
+        relation_chunk_ids_by_query,
+    )
 
     query_id = _make_query_id("covidqa", "test", "dup")
     first_chunk_id = compute_chunk_id("First supporting document.", "covidqa")

--- a/tests/autorag_research/data/test_ragbench.py
+++ b/tests/autorag_research/data/test_ragbench.py
@@ -158,6 +158,7 @@ class FakeRAGBenchService:
     def __init__(self):
         self.chunks: list[list[dict[str, str | int | None]]] = []
         self.queries: list[list[dict[str, str | list[str] | None]]] = []
+        self.persisted_queries: dict[str, tuple[str, list[str] | None]] = {}
         self.retrieval_gt_calls: list[tuple[str, RetrievalGT, str, bool]] = []
 
     def add_chunks(self, chunks: list[dict[str, str | int | None]]) -> None:
@@ -165,6 +166,12 @@ class FakeRAGBenchService:
 
     def add_queries(self, queries: list[dict[str, str | list[str] | None]]) -> None:
         self.queries.append(queries)
+        for query in queries:
+            query_id = str(query["id"])
+            if query_id not in self.persisted_queries:
+                generation_gt = query["generation_gt"]
+                assert generation_gt is None or isinstance(generation_gt, list)
+                self.persisted_queries[query_id] = (str(query["contents"]), generation_gt)
 
     def add_retrieval_gt(self, query_id: str, gt: RetrievalGT, chunk_type: str = "mixed", upsert: bool = False) -> None:
         self.retrieval_gt_calls.append((query_id, gt, chunk_type, upsert))
@@ -263,6 +270,7 @@ def test_process_batch_warns_on_duplicate_ragbench_query_metadata_mismatch_acros
 
     query_id = _make_query_id("covidqa", "test", "dup")
     assert query_metadata_by_query[query_id] == ("What is duplicated?", "First response")
+    assert service.persisted_queries[query_id] == ("What is duplicated?", ["First response"])
     assert any(
         "Duplicate RAGBench query id" in record.message
         and query_id in record.message
@@ -309,6 +317,7 @@ def test_process_batch_warns_on_duplicate_ragbench_query_metadata_mismatch_withi
 
     query_id = _make_query_id("covidqa", "test", "dup")
     assert query_metadata_by_query[query_id] == ("What is duplicated?", "Same response")
+    assert service.persisted_queries[query_id] == ("What is duplicated?", ["Same response"])
     assert any(
         "Duplicate RAGBench query id" in record.message
         and query_id in record.message

--- a/tests/autorag_research/data/test_ragbench.py
+++ b/tests/autorag_research/data/test_ragbench.py
@@ -139,7 +139,7 @@ class TestRAGBenchIngestorIntegration:
 
             ingestor = RAGBenchIngestor(
                 mock_embedding_model,
-                configs=["covidqa"],
+                config="covidqa",
             )
             ingestor.set_service(service)
             ingestor.ingest(
@@ -149,3 +149,68 @@ class TestRAGBenchIngestorIntegration:
 
             verifier = IngestorTestVerifier(service, db.schema, RAGBENCH_INTEGRATION_CONFIG)
             verifier.verify_all()
+
+
+class FakeRAGBenchService:
+    def __init__(self):
+        self.chunks: list[list[dict[str, str | int | None]]] = []
+        self.queries: list[list[dict[str, str | list[str] | None]]] = []
+        self.retrieval_gt_calls: list[tuple[str, object, str, bool]] = []
+
+    def add_chunks(self, chunks: list[dict[str, str | int | None]]) -> None:
+        self.chunks.append(chunks)
+
+    def add_queries(self, queries: list[dict[str, str | list[str] | None]]) -> None:
+        self.queries.append(queries)
+
+    def add_retrieval_gt(self, query_id: str, gt: object, chunk_type: str = "mixed", upsert: bool = False) -> None:
+        self.retrieval_gt_calls.append((query_id, gt, chunk_type, upsert))
+
+
+def _extract_or_gt_ids(gt: object) -> list[str]:
+    if hasattr(gt, "items"):
+        return [str(item.id) for item in gt.items]
+    if hasattr(gt, "value"):
+        return [str(gt.value)]
+    raise AssertionError
+
+
+def test_process_batch_upserts_duplicate_ragbench_query_relations_across_batches(mock_embedding_model):
+    service = FakeRAGBenchService()
+    ingestor = RAGBenchIngestor(mock_embedding_model, config="covidqa", batch_size=1)
+    ingestor.set_service(service)  # ty: ignore[invalid-argument-type]
+    seen_chunk_ids: set[str] = set()
+    relation_chunk_ids_by_query: dict[str, set[str]] = {}
+
+    first_example = {
+        "id": "dup",
+        "question": "What is duplicated?",
+        "response": "First response",
+        "documents": ["First supporting document."],
+        "all_relevant_sentence_keys": ["0a"],
+    }
+    second_example = {
+        "id": "dup",
+        "question": "What is duplicated?",
+        "response": "Second response",
+        "documents": ["Second supporting document.", "Shared supporting document."],
+        "all_relevant_sentence_keys": ["0a", "1b"],
+    }
+
+    ingestor._process_batch("covidqa", "test", [first_example], seen_chunk_ids, relation_chunk_ids_by_query)
+    ingestor._process_batch("covidqa", "test", [second_example], seen_chunk_ids, relation_chunk_ids_by_query)
+
+    query_id = _make_query_id("covidqa", "test", "dup")
+    first_chunk_id = compute_chunk_id("First supporting document.", "covidqa")
+    second_chunk_id = compute_chunk_id("Second supporting document.", "covidqa")
+    shared_chunk_id = compute_chunk_id("Shared supporting document.", "covidqa")
+
+    assert [call[0] for call in service.retrieval_gt_calls] == [query_id, query_id]
+    assert [call[2] for call in service.retrieval_gt_calls] == ["text", "text"]
+    assert [call[3] for call in service.retrieval_gt_calls] == [True, True]
+    assert _extract_or_gt_ids(service.retrieval_gt_calls[0][1]) == [first_chunk_id]
+    assert _extract_or_gt_ids(service.retrieval_gt_calls[1][1]) == sorted([
+        first_chunk_id,
+        second_chunk_id,
+        shared_chunk_id,
+    ])


### PR DESCRIPTION
<!-- dani:stage=implementation;job=08f26735a34d28be9156596926e52068;issue=233 -->

## Summary
- make RAGBench retrieval-GT writes duplicate-tolerant by using upsert semantics for query relations
- accumulate relevant chunk IDs per RAGBench query across batches and within a single batch before rewriting relations, preserving additional evidence from repeated source rows
- add focused regression coverage for repeated RAGBench example IDs across batches and within the same batch
- warn when repeated RAGBench IDs carry different question/response metadata, keeping first-wins query metadata while unioning retrieval evidence
- skip duplicate query rows within a single RAGBench batch so first-wins metadata is enforced before relation evidence is unioned/upserted

## Verification
- `uv run pytest tests/autorag_research/data/test_ragbench.py -q -m 'not data'`
- `uv run ty check tests/autorag_research/data/test_ragbench.py autorag_research/data/ragbench.py`
- `git diff --check origin/dev...HEAD && uv run ruff check autorag_research/data/ragbench.py tests/autorag_research/data/test_ragbench.py`
- `make check`

## Notes
- the shared ingestion service remains duplicate-strict by default; this change scopes the tolerant behavior to RAGBench, where query insertion already tolerates duplicates and source rows/reruns can otherwise trip relation uniqueness
- full external RAGBench ingestion was not run locally because it requires dataset streaming plus PostgreSQL integration resources
