### PR TITLE
Add inference-only Search-R1 generation pipeline

### DIFF
--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -14,6 +14,7 @@ from autorag_research.pipelines.generation.question_decomposition import (
     QuestionDecompositionPipelineConfig,
 )
 from autorag_research.pipelines.generation.rag_critic import RAGCriticPipeline, RAGCriticPipelineConfig
+from autorag_research.pipelines.generation.search_r1 import SearchR1GenerationPipeline, SearchR1GenerationPipelineConfig
 from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline, SelfRAGPipelineConfig
 from autorag_research.pipelines.generation.spd_rag import SPDRAGPipeline, SPDRAGPipelineConfig
 from autorag_research.pipelines.generation.visrag_gen import (
@@ -42,6 +43,8 @@ __all__ = [
     "RAGCriticPipelineConfig",
     "SPDRAGPipeline",
     "SPDRAGPipelineConfig",
+    "SearchR1GenerationPipeline",
+    "SearchR1GenerationPipelineConfig",
     "SelfRAGPipeline",
     "SelfRAGPipelineConfig",
     "VisRAGGenerationPipeline",

--- a/autorag_research/pipelines/generation/search_r1.py
+++ b/autorag_research/pipelines/generation/search_r1.py
@@ -1,0 +1,337 @@
+"""Search-R1-style inference pipeline for AutoRAG-Research.
+
+Search-R1 is a training framework for reasoning-and-search interleaved agents.
+This module implements the inference/evaluation slice that fits AutoRAG: an LLM
+iteratively decides when to search, observes retrieved evidence from an existing
+retrieval pipeline, and eventually emits an answer. RL training from the
+upstream project is intentionally out of scope.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker
+
+logger = logging.getLogger("AutoRAG-Research")
+
+DEFAULT_SEARCH_R1_STEP_PROMPT = """You are a Search-R1-style question answering agent.
+You may interleave reasoning with retrieval. At each step, choose exactly one action:
+- Search for more evidence by writing <search>your search query</search>
+- Finish with an answer by writing <answer>your final answer</answer>
+
+Question:
+{query}
+
+Search budget: {searches_used}/{max_searches} used, {remaining_searches} remaining.
+
+Scratchpad and observations:
+{scratchpad}
+
+Next action:"""
+
+DEFAULT_SEARCH_R1_FINAL_PROMPT = """Answer the question using the gathered Search-R1 evidence.
+
+Question:
+{query}
+
+Scratchpad and observations:
+{scratchpad}
+
+Return only the final answer."""
+
+_SEARCH_PATTERN = re.compile(r"<search>\s*(.*?)\s*</search>", re.IGNORECASE | re.DOTALL)
+_ANSWER_PATTERN = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass(frozen=True)
+class SearchR1Action:
+    """Parsed Search-R1 agent action."""
+
+    kind: str
+    text: str
+
+
+def parse_search_r1_action(response_text: str) -> SearchR1Action:
+    """Parse a Search-R1 action from an LLM response.
+
+    ``<answer>`` is preferred over ``<search>`` when both are present because an
+    explicit final answer should stop the loop.
+    """
+    answer_match = _ANSWER_PATTERN.search(response_text)
+    if answer_match is not None:
+        return SearchR1Action(kind="answer", text=answer_match.group(1).strip())
+
+    search_match = _SEARCH_PATTERN.search(response_text)
+    if search_match is not None:
+        return SearchR1Action(kind="search", text=search_match.group(1).strip())
+
+    stripped_response = response_text.strip()
+    if stripped_response.lower().startswith("answer:"):
+        return SearchR1Action(kind="answer", text=stripped_response.split(":", 1)[1].strip())
+
+    return SearchR1Action(kind="answer", text=stripped_response)
+
+
+@dataclass(kw_only=True)
+class SearchR1GenerationPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for the inference-only Search-R1 generation pipeline."""
+
+    step_prompt_template: str = field(default=DEFAULT_SEARCH_R1_STEP_PROMPT)
+    final_prompt_template: str = field(default=DEFAULT_SEARCH_R1_FINAL_PROMPT)
+    max_searches: int = 3
+    k_per_search: int = 5
+    observation_budget: int = 12
+    fallback_to_final_prompt: bool = True
+
+    def get_pipeline_class(self) -> type[SearchR1GenerationPipeline]:
+        """Return the SearchR1GenerationPipeline class."""
+        return SearchR1GenerationPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for SearchR1GenerationPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "step_prompt_template": self.step_prompt_template,
+            "final_prompt_template": self.final_prompt_template,
+            "max_searches": self.max_searches,
+            "k_per_search": self.k_per_search,
+            "observation_budget": self.observation_budget,
+            "fallback_to_final_prompt": self.fallback_to_final_prompt,
+        }
+
+
+class SearchR1GenerationPipeline(BaseGenerationPipeline):
+    """Inference-time Search-R1-style reason/search/answer generation pipeline."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        step_prompt_template: str = DEFAULT_SEARCH_R1_STEP_PROMPT,
+        final_prompt_template: str = DEFAULT_SEARCH_R1_FINAL_PROMPT,
+        max_searches: int = 3,
+        k_per_search: int = 5,
+        observation_budget: int = 12,
+        fallback_to_final_prompt: bool = True,
+        schema: Any | None = None,
+    ):
+        """Initialize the Search-R1 inference pipeline."""
+        self._validate_prompt_templates(step_prompt_template, final_prompt_template)
+        if max_searches < 1:
+            msg = "max_searches must be >= 1"
+            raise ValueError(msg)
+        if k_per_search < 1:
+            msg = "k_per_search must be >= 1"
+            raise ValueError(msg)
+        if observation_budget < 1:
+            msg = "observation_budget must be >= 1"
+            raise ValueError(msg)
+
+        self.step_prompt_template = step_prompt_template
+        self.final_prompt_template = final_prompt_template
+        self.max_searches = max_searches
+        self.k_per_search = k_per_search
+        self.observation_budget = observation_budget
+        self.fallback_to_final_prompt = fallback_to_final_prompt
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    @staticmethod
+    def _validate_prompt_templates(step_prompt_template: str, final_prompt_template: str) -> None:
+        """Validate required prompt placeholders."""
+        for placeholder in ("{query}", "{scratchpad}", "{max_searches}", "{remaining_searches}", "{searches_used}"):
+            if placeholder not in step_prompt_template:
+                msg = f"step_prompt_template must contain {placeholder}"
+                raise ValueError(msg)
+        for placeholder in ("{query}", "{scratchpad}"):
+            if placeholder not in final_prompt_template:
+                msg = f"final_prompt_template must contain {placeholder}"
+                raise ValueError(msg)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return Search-R1 pipeline configuration."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+
+        return {
+            "type": "search_r1",
+            "step_prompt_template": self.step_prompt_template,
+            "final_prompt_template": self.final_prompt_template,
+            "max_searches": self.max_searches,
+            "k_per_search": self.k_per_search,
+            "observation_budget": self.observation_budget,
+            "fallback_to_final_prompt": self.fallback_to_final_prompt,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_response_content(response: Any) -> str:
+        """Extract string content from a LangChain response."""
+        if hasattr(response, "content"):
+            return str(response.content)
+        return str(response)
+
+    @staticmethod
+    def _format_scratchpad(steps: list[str], observations: list[str]) -> str:
+        """Format reasoning/search steps and observations for the next prompt."""
+        sections: list[str] = []
+        if steps:
+            sections.append("Previous actions:\n" + "\n".join(steps))
+        if observations:
+            numbered_observations = "\n\n".join(
+                f"[Observation {index + 1}] {observation}" for index, observation in enumerate(observations)
+            )
+            sections.append("Retrieved evidence:\n" + numbered_observations)
+        return "\n\n".join(sections) if sections else "(empty)"
+
+    def _build_step_prompt(
+        self,
+        query: str,
+        steps: list[str],
+        observations: list[str],
+        searches_used: int,
+    ) -> str:
+        """Build one Search-R1 agent-step prompt."""
+        remaining_searches = max(self.max_searches - searches_used, 0)
+        return self.step_prompt_template.format(
+            query=query,
+            scratchpad=self._format_scratchpad(steps, observations),
+            max_searches=self.max_searches,
+            searches_used=searches_used,
+            remaining_searches=remaining_searches,
+        )
+
+    def _build_final_prompt(self, query: str, steps: list[str], observations: list[str]) -> str:
+        """Build fallback final-answer prompt after search budget exhaustion."""
+        return self.final_prompt_template.format(
+            query=query,
+            scratchpad=self._format_scratchpad(steps, observations),
+        )
+
+    def _contents_from_results(self, retrieval_results: list[dict[str, Any]]) -> tuple[list[int | str], list[str]]:
+        """Extract contents from retrieval results, backfilling from DB when needed."""
+        chunk_ids: list[int | str] = []
+        contents: list[str | None] = []
+        missing_positions: list[int] = []
+        missing_ids: list[int | str] = []
+
+        for result in retrieval_results:
+            doc_id = result.get("doc_id")
+            if doc_id is None:
+                continue
+            chunk_ids.append(doc_id)
+            content = result.get("content")
+            if content:
+                contents.append(str(content))
+            else:
+                missing_positions.append(len(contents))
+                missing_ids.append(doc_id)
+                contents.append(None)
+
+        if missing_ids:
+            fetched_contents = self._service.get_chunk_contents(missing_ids)
+            for position, fetched_content in zip(missing_positions, fetched_contents, strict=False):
+                contents[position] = fetched_content
+
+        return chunk_ids, [content or "" for content in contents]
+
+    def _append_observations(
+        self,
+        observations: list[str],
+        new_contents: list[str],
+    ) -> list[str]:
+        """Append non-empty, deduplicated observations within the observation budget."""
+        updated_observations = list(observations)
+        for content in new_contents:
+            if content and content not in updated_observations:
+                updated_observations.append(content)
+        return updated_observations[-self.observation_budget :]
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate an answer with interleaved Search-R1-style search actions."""
+        query_text = self._service.get_query_text(query_id)
+        search_k = min(top_k, self.k_per_search) if top_k > 0 else self.k_per_search
+        search_k = max(search_k, 1)
+        tracker = TokenUsageTracker()
+        steps: list[str] = []
+        observations: list[str] = []
+        retrieved_chunk_ids: list[int | str] = []
+        search_queries: list[str] = []
+        final_answer = ""
+        terminated_by = "max_searches"
+
+        for search_index in range(self.max_searches):
+            prompt = self._build_step_prompt(query_text, steps, observations, search_index)
+            response = await self._llm.ainvoke(prompt)
+            tracker.record(response)
+            response_text = self._extract_response_content(response)
+            action = parse_search_r1_action(response_text)
+
+            if action.kind == "answer":
+                final_answer = action.text
+                steps.append(f"Answer: {final_answer}")
+                terminated_by = "answer"
+                break
+
+            if not action.text:
+                logger.debug("Search-R1 emitted an empty search action; stopping with fallback answer")
+                terminated_by = "empty_search"
+                break
+
+            search_queries.append(action.text)
+            steps.append(f"Search: {action.text}")
+            retrieval_results = await self._retrieval_pipeline.retrieve(action.text, search_k)
+            chunk_ids, contents = self._contents_from_results(retrieval_results)
+            for chunk_id in chunk_ids:
+                if chunk_id not in retrieved_chunk_ids:
+                    retrieved_chunk_ids.append(chunk_id)
+            observations = self._append_observations(observations, contents)
+
+        if not final_answer and self.fallback_to_final_prompt:
+            final_prompt = self._build_final_prompt(query_text, steps, observations)
+            final_response = await self._llm.ainvoke(final_prompt)
+            tracker.record(final_response)
+            final_answer = self._extract_response_content(final_response)
+            terminated_by = f"{terminated_by}_fallback"
+
+        return GenerationResult(
+            text=final_answer,
+            token_usage=tracker.total,
+            metadata={
+                "search_queries": search_queries,
+                "retrieved_chunk_ids": retrieved_chunk_ids,
+                "observations": observations,
+                "steps": steps,
+                "terminated_by": terminated_by,
+            },
+        )
+
+
+__all__ = [
+    "DEFAULT_SEARCH_R1_FINAL_PROMPT",
+    "DEFAULT_SEARCH_R1_STEP_PROMPT",
+    "SearchR1Action",
+    "SearchR1GenerationPipeline",
+    "SearchR1GenerationPipelineConfig",
+    "parse_search_r1_action",
+]

--- a/configs/pipelines/generation/search_r1.yaml
+++ b/configs/pipelines/generation/search_r1.yaml
@@ -1,0 +1,14 @@
+_target_: autorag_research.pipelines.generation.search_r1.SearchR1GenerationPipelineConfig
+description: "Inference-only Search-R1-style reason/search/answer generation pipeline"
+name: search_r1
+retrieval_pipeline_name: bm25
+llm: openai-gpt4o-mini
+max_searches: 3
+k_per_search: 5
+observation_budget: 12
+fallback_to_final_prompt: true
+top_k: 5
+batch_size: 32
+max_concurrency: 4
+max_retries: 3
+retry_delay: 1.0

--- a/configs/pipelines/generation/search_r1.yaml
+++ b/configs/pipelines/generation/search_r1.yaml
@@ -2,7 +2,7 @@ _target_: autorag_research.pipelines.generation.search_r1.SearchR1GenerationPipe
 description: "Inference-only Search-R1-style reason/search/answer generation pipeline"
 name: search_r1
 retrieval_pipeline_name: bm25
-llm: openai-gpt4o-mini
+llm: openai-gpt5-mini
 max_searches: 3
 k_per_search: 5
 observation_budget: 12

--- a/tests/autorag_research/pipelines/generation/test_search_r1_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_search_r1_pipeline.py
@@ -1,0 +1,211 @@
+"""Tests for the inference-only Search-R1 generation pipeline."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from autorag_research.pipelines.generation.search_r1 import (
+    SearchR1GenerationPipeline,
+    SearchR1GenerationPipelineConfig,
+    parse_search_r1_action,
+)
+from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_retrieval_pipeline
+
+
+def _mock_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
+    return response
+
+
+def _build_unit_pipeline(
+    llm: Any,
+    retrieval_pipeline: Any,
+    service: Any,
+    **kwargs: Any,
+) -> SearchR1GenerationPipeline:
+    with patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None):
+        pipeline = SearchR1GenerationPipeline(
+            session_factory=MagicMock(),
+            name="search_r1_unit",
+            llm=llm,
+            retrieval_pipeline=retrieval_pipeline,
+            **kwargs,
+        )
+    pipeline._llm = llm
+    pipeline._retrieval_pipeline = retrieval_pipeline
+    pipeline._service = service
+    pipeline.pipeline_id = 1
+    return pipeline
+
+
+class TestSearchR1ActionParsing:
+    """Tests for Search-R1 action parsing."""
+
+    def test_parse_search_action(self):
+        action = parse_search_r1_action("Need evidence. <search>latest mars mission</search>")
+
+        assert action.kind == "search"
+        assert action.text == "latest mars mission"
+
+    def test_parse_answer_action(self):
+        action = parse_search_r1_action("<answer>Mars is the fourth planet.</answer>")
+
+        assert action.kind == "answer"
+        assert action.text == "Mars is the fourth planet."
+
+    def test_parse_prefers_answer_over_search(self):
+        action = parse_search_r1_action("<search>mars</search><answer>final</answer>")
+
+        assert action.kind == "answer"
+        assert action.text == "final"
+
+    def test_parse_plain_response_as_answer(self):
+        action = parse_search_r1_action("Plain final answer")
+
+        assert action.kind == "answer"
+        assert action.text == "Plain final answer"
+
+
+class TestSearchR1GenerationPipelineConfig:
+    """Tests for SearchR1GenerationPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        config = SearchR1GenerationPipelineConfig(
+            name="search_r1",
+            llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+            retrieval_pipeline_name="bm25",
+        )
+
+        assert config.get_pipeline_class() == SearchR1GenerationPipeline
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        config = SearchR1GenerationPipelineConfig(
+            name="search_r1",
+            llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+            retrieval_pipeline_name="bm25",
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        wrapped_retrieval = create_mock_retrieval_pipeline(pipeline_id=77)
+        llm = FakeListLLM(responses=["<answer>ok</answer>"])
+        config = SearchR1GenerationPipelineConfig(
+            name="search_r1",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+            max_searches=4,
+            k_per_search=3,
+        )
+
+        config.inject_retrieval_pipeline(wrapped_retrieval)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is wrapped_retrieval
+        assert kwargs["max_searches"] == 4
+        assert kwargs["k_per_search"] == 3
+
+
+class TestSearchR1GenerationPipeline:
+    """Tests for SearchR1GenerationPipeline behavior."""
+
+    def test_initialization_rejects_invalid_search_budget(self):
+        with (
+            patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="max_searches must be >= 1"),
+        ):
+            SearchR1GenerationPipeline(
+                session_factory=MagicMock(),
+                name="invalid_search_r1",
+                llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                max_searches=0,
+            )
+
+    def test_prompt_template_requires_search_budget_placeholders(self):
+        with (
+            patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="step_prompt_template must contain"),
+        ):
+            SearchR1GenerationPipeline(
+                session_factory=MagicMock(),
+                name="invalid_prompt_search_r1",
+                llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                step_prompt_template="Question: {query}\n{scratchpad}",
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_searches_then_answers(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("We need evidence. <search>mars moons</search>"),
+                _mock_response("<answer>Mars has two moons.</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 10, "score": 0.9, "content": "Mars has Phobos and Deimos."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "How many moons does Mars have?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_searches=3, k_per_search=2)
+
+        result = await pipeline._generate(1, top_k=5)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("mars moons", 2)
+        assert result.text == "Mars has two moons."
+        assert result.metadata["search_queries"] == ["mars moons"]
+        assert result.metadata["retrieved_chunk_ids"] == [10]
+        assert result.metadata["observations"] == ["Mars has Phobos and Deimos."]
+        assert result.metadata["terminated_by"] == "answer"
+        assert result.token_usage == {"prompt_tokens": 4, "completion_tokens": 6, "total_tokens": 10}
+
+    @pytest.mark.asyncio
+    async def test_generate_falls_back_after_search_budget(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<search>first query</search>"),
+                _mock_response("Fallback final answer."),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 1, "score": 0.8, "content": "Evidence."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_searches=1, k_per_search=4)
+
+        result = await pipeline._generate(1, top_k=2)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("first query", 2)
+        assert result.text == "Fallback final answer."
+        assert result.metadata["terminated_by"] == "max_searches_fallback"
+        assert llm.ainvoke.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_generate_backfills_missing_result_contents(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<search>missing content query</search>"),
+                _mock_response("<answer>Done.</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(default_results=[{"doc_id": 5, "score": 0.8}])
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        service.get_chunk_contents.return_value = ["Fetched evidence."]
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_searches=2, k_per_search=1)
+
+        result = await pipeline._generate(1, top_k=1)
+
+        service.get_chunk_contents.assert_called_once_with([5])
+        assert result.metadata["observations"] == ["Fetched evidence."]


### PR DESCRIPTION
## Summary
- Adds an inference-only Search-R1-style generation pipeline that alternates LLM search actions with existing AutoRAG retrieval pipelines, then emits an answer or falls back to a final answer prompt.
- Adds YAML config and exports for SearchR1GenerationPipeline.
- Adds focused tests for action parsing, config injection, search/answer loops, fallback behavior, content backfill, and token usage aggregation.

## Scope
- Implements the Search-R1 inference/evaluation slice that fits AutoRAG-Research.
- Does not port upstream RL training/PPO/GRPO infrastructure or online search services.

## Validation
- uv run pytest tests/autorag_research/pipelines/generation/test_search_r1_pipeline.py -q
- make check

Closes #185

<!-- dani:stage=implementation;job=9d6374541facac3d11805238ba940d48;issue=185 -->
