### PR TITLE
Add INTERACT-RAG generation pipeline

### DIFF
--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -7,6 +7,7 @@ from autorag_research.pipelines.generation.et2rag import (
     ET2RAGPipelineConfig,
     OrganizationStrategy,
 )
+from autorag_research.pipelines.generation.interact_rag import InteractRAGPipeline, InteractRAGPipelineConfig
 from autorag_research.pipelines.generation.ircot import IRCoTGenerationPipeline, IRCoTGenerationPipelineConfig
 from autorag_research.pipelines.generation.main_rag import MAINRAGPipeline
 from autorag_research.pipelines.generation.question_decomposition import (
@@ -34,6 +35,8 @@ __all__ = [
     "ET2RAGPipelineConfig",
     "IRCoTGenerationPipeline",
     "IRCoTGenerationPipelineConfig",
+    "InteractRAGPipeline",
+    "InteractRAGPipelineConfig",
     "MAINRAGPipeline",
     "OrganizationStrategy",
     "QuestionDecompositionPipeline",

--- a/autorag_research/pipelines/generation/interact_rag.py
+++ b/autorag_research/pipelines/generation/interact_rag.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -38,13 +39,14 @@ InteractActionKind = Literal[
 ]
 
 DEFAULT_INTERACT_RAG_STEP_PROMPT = """You are an INTERACT-RAG agent that can reason and interact with the retrieval corpus.
-Use exactly one XML-like action per step:
-- <semantic_search>query</semantic_search>: dense/semantic evidence search
-- <exact_search>keywords</exact_search>: lexical/exact evidence search
-- <weighted_fusion semantic="0.6" exact="0.4">query</weighted_fusion>: combine semantic and exact intent
-- <entity_match>entity name</entity_match>: focus retrieval around an entity
-- <include_docs>1, 2</include_docs>: force known useful doc IDs into context
-- <exclude_docs>3, 4</exclude_docs>: remove noisy doc IDs from future context
+Use exactly one XML-like action per step. Retrieval actions are prompt-simulated through the configured
+retrieval pipeline unless that retriever advertises richer native capabilities:
+- <semantic_search>query</semantic_search>: evidence search
+- <exact_search>keywords</exact_search>: prompt-simulated lexical/exact intent search
+- <weighted_fusion semantic="0.6" exact="0.4">query</weighted_fusion>: prompt-simulated semantic/exact intent
+- <entity_match>entity name</entity_match>: prompt-simulated entity-focused retrieval
+- <include_docs>chunk_id</include_docs>: force known useful chunk IDs from displayed evidence into context
+- <exclude_docs>chunk_id</exclude_docs>: remove noisy chunk IDs from displayed evidence and future context
 - <adjust_scale>8</adjust_scale>: change retrieval scale for later searches
 - <answer>final answer</answer>: finish
 
@@ -75,7 +77,10 @@ _ACTION_PATTERNS: tuple[tuple[InteractActionKind, re.Pattern[str]], ...] = (
     ("answer", re.compile(r"<answer>\s*(.*?)\s*</answer>", re.IGNORECASE | re.DOTALL)),
     ("semantic_search", re.compile(r"<semantic_search>\s*(.*?)\s*</semantic_search>", re.IGNORECASE | re.DOTALL)),
     ("exact_search", re.compile(r"<exact_search>\s*(.*?)\s*</exact_search>", re.IGNORECASE | re.DOTALL)),
-    ("weighted_fusion", re.compile(r"<weighted_fusion(?:\s+[^>]*)?>\s*(.*?)\s*</weighted_fusion>", re.IGNORECASE | re.DOTALL)),
+    (
+        "weighted_fusion",
+        re.compile(r"<weighted_fusion(?:\s+[^>]*)?>\s*(.*?)\s*</weighted_fusion>", re.IGNORECASE | re.DOTALL),
+    ),
     ("entity_match", re.compile(r"<entity_match>\s*(.*?)\s*</entity_match>", re.IGNORECASE | re.DOTALL)),
     ("include_docs", re.compile(r"<include_docs>\s*(.*?)\s*</include_docs>", re.IGNORECASE | re.DOTALL)),
     ("exclude_docs", re.compile(r"<exclude_docs>\s*(.*?)\s*</exclude_docs>", re.IGNORECASE | re.DOTALL)),
@@ -242,13 +247,28 @@ class InteractRAGPipeline(BaseGenerationPipeline):
         return ", ".join(str(doc_id) for doc_id in doc_ids) if doc_ids else "(none)"
 
     @staticmethod
-    def _format_scratchpad(trace: list[str], evidence: list[str]) -> str:
+    def _format_evidence_item(item: str | dict[str, Any]) -> str:
+        """Format one evidence item with exposed chunk IDs when available."""
+        if not isinstance(item, dict):
+            return item
+
+        doc_id = item.get("doc_id")
+        content = str(item.get("content", ""))
+        if doc_id is None:
+            return content
+
+        score = item.get("score")
+        score_label = "" if score is None else f" score={score}"
+        return f"[chunk_id={doc_id}{score_label}] {content}"
+
+    @classmethod
+    def _format_scratchpad(cls, trace: list[str], evidence: Sequence[str | dict[str, Any]]) -> str:
         """Format trace and evidence for prompting."""
         sections: list[str] = []
         if trace:
             sections.append("Trace:\n" + "\n".join(trace))
         if evidence:
-            sections.append("Evidence:\n" + "\n\n".join(f"[{i + 1}] {item}" for i, item in enumerate(evidence)))
+            sections.append("Evidence:\n" + "\n\n".join(cls._format_evidence_item(item) for item in evidence))
         return "\n\n".join(sections) if sections else "(empty)"
 
     def _build_step_prompt(
@@ -256,7 +276,7 @@ class InteractRAGPipeline(BaseGenerationPipeline):
         query: str,
         state: InteractRAGState,
         trace: list[str],
-        evidence: list[str],
+        evidence: list[dict[str, Any]],
         steps_used: int,
     ) -> str:
         """Build one interaction prompt."""
@@ -270,21 +290,23 @@ class InteractRAGPipeline(BaseGenerationPipeline):
             excluded_doc_ids=self._format_doc_ids(state.excluded_doc_ids),
         )
 
-    def _build_final_prompt(self, query: str, trace: list[str], evidence: list[str]) -> str:
+    def _build_final_prompt(self, query: str, trace: list[str], evidence: list[dict[str, Any]]) -> str:
         """Build fallback answer prompt."""
         return self.final_prompt_template.format(query=query, scratchpad=self._format_scratchpad(trace, evidence))
 
-    def _contents_from_results(self, retrieval_results: list[dict[str, Any]]) -> tuple[list[int | str], list[str]]:
-        """Extract IDs and contents from retrieval results, backfilling when needed."""
+    def _evidence_from_results(self, retrieval_results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Extract displayable evidence snippets from retrieval results, backfilling missing content when needed."""
         doc_ids: list[int | str] = []
         contents: list[str | None] = []
         missing_positions: list[int] = []
         missing_ids: list[int | str] = []
+        scores: list[Any] = []
         for result in retrieval_results:
             doc_id = result.get("doc_id")
             if doc_id is None:
                 continue
             doc_ids.append(doc_id)
+            scores.append(result.get("score"))
             content = result.get("content")
             if content:
                 contents.append(str(content))
@@ -297,33 +319,72 @@ class InteractRAGPipeline(BaseGenerationPipeline):
             fetched_contents = self._service.get_chunk_contents(missing_ids)
             for position, fetched_content in zip(missing_positions, fetched_contents, strict=False):
                 contents[position] = fetched_content
-        return doc_ids, [content or "" for content in contents]
+        return [
+            {"doc_id": doc_id, "score": score, "content": content or ""}
+            for doc_id, score, content in zip(doc_ids, scores, contents, strict=False)
+        ]
 
-    def _apply_state_action(self, action: InteractRAGAction, state: InteractRAGState, trace: list[str]) -> bool:
+    @staticmethod
+    def _known_doc_ids(exposed_doc_ids: set[int | str]) -> set[int | str]:
+        """Return exposed IDs plus their string forms for tolerant matching."""
+        return exposed_doc_ids | {str(doc_id) for doc_id in exposed_doc_ids}
+
+    def _apply_doc_id_action(
+        self,
+        action: InteractRAGAction,
+        state: InteractRAGState,
+        trace: list[str],
+        exposed_doc_ids: set[int | str],
+    ) -> bool:
+        """Apply include/exclude actions only to IDs shown to the model."""
+        target_list = state.included_doc_ids if action.kind == "include_docs" else state.excluded_doc_ids
+        known_doc_ids = self._known_doc_ids(exposed_doc_ids)
+        requested_doc_ids = parse_doc_ids(action.text)
+        accepted_doc_ids = [doc_id for doc_id in requested_doc_ids if doc_id in known_doc_ids]
+        ignored_doc_ids = [doc_id for doc_id in requested_doc_ids if doc_id not in known_doc_ids]
+
+        for doc_id in accepted_doc_ids:
+            if doc_id not in target_list:
+                target_list.append(doc_id)
+
+        if accepted_doc_ids:
+            trace.append(f"{action.kind}: {self._format_doc_ids(target_list)}")
+        if ignored_doc_ids:
+            trace.append(f"{action.kind} ignored unknown IDs: {self._format_doc_ids(ignored_doc_ids)}")
+        if not accepted_doc_ids and not ignored_doc_ids:
+            trace.append(f"{action.kind}: (none)")
+        return True
+
+    def _apply_scale_action(self, action: InteractRAGAction, state: InteractRAGState, trace: list[str]) -> bool:
+        """Apply retrieval scale changes."""
+        parsed_values = parse_doc_ids(action.text)
+        if parsed_values:
+            state.current_scale = min(max(parsed_values[0], 1), self.max_scale)
+        trace.append(f"adjust_scale: {state.current_scale}")
+        return True
+
+    @staticmethod
+    def _apply_weight_action(action: InteractRAGAction, state: InteractRAGState) -> bool:
+        """Store weighted-fusion hint values for metadata."""
+        if action.semantic_weight is not None and action.exact_weight is not None:
+            state.semantic_weight = action.semantic_weight
+            state.exact_weight = action.exact_weight
+        return False
+
+    def _apply_state_action(
+        self,
+        action: InteractRAGAction,
+        state: InteractRAGState,
+        trace: list[str],
+        exposed_doc_ids: set[int | str],
+    ) -> bool:
         """Apply non-search context-shaping actions. Return True if handled."""
-        if action.kind == "include_docs":
-            for doc_id in parse_doc_ids(action.text):
-                if doc_id not in state.included_doc_ids:
-                    state.included_doc_ids.append(doc_id)
-            trace.append(f"include_docs: {self._format_doc_ids(state.included_doc_ids)}")
-            return True
-        if action.kind == "exclude_docs":
-            for doc_id in parse_doc_ids(action.text):
-                if doc_id not in state.excluded_doc_ids:
-                    state.excluded_doc_ids.append(doc_id)
-            trace.append(f"exclude_docs: {self._format_doc_ids(state.excluded_doc_ids)}")
-            return True
+        if action.kind in {"include_docs", "exclude_docs"}:
+            return self._apply_doc_id_action(action, state, trace, exposed_doc_ids)
         if action.kind == "adjust_scale":
-            parsed_values = parse_doc_ids(action.text)
-            if parsed_values:
-                state.current_scale = min(max(parsed_values[0], 1), self.max_scale)
-            trace.append(f"adjust_scale: {state.current_scale}")
-            return True
+            return self._apply_scale_action(action, state, trace)
         if action.kind == "weighted_fusion":
-            if action.semantic_weight is not None and action.exact_weight is not None:
-                state.semantic_weight = action.semantic_weight
-                state.exact_weight = action.exact_weight
-            return False
+            return self._apply_weight_action(action, state)
         return False
 
     def _build_retrieval_query(self, action: InteractRAGAction) -> str:
@@ -353,32 +414,60 @@ class InteractRAGPipeline(BaseGenerationPipeline):
         ]
         return [*included, *filtered_results]
 
-    def _append_evidence(self, evidence: list[str], new_contents: list[str]) -> list[str]:
+    def _append_evidence(
+        self,
+        evidence: list[dict[str, Any]],
+        new_evidence: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         """Append deduplicated evidence while respecting evidence_budget."""
         updated = list(evidence)
-        for content in new_contents:
-            if content and content not in updated:
-                updated.append(content)
+        existing_contents = {item.get("content") for item in updated}
+        for item in new_evidence:
+            content = item.get("content")
+            if content and content not in existing_contents:
+                updated.append(item)
+                existing_contents.add(content)
         return updated[-self.evidence_budget :]
+
+    @staticmethod
+    def _is_prompt_simulated_action(action: InteractRAGAction) -> bool:
+        """Return True when an action is represented as a query hint over the base retrieval boundary."""
+        return action.kind in {"exact_search", "weighted_fusion", "entity_match"}
+
+    @staticmethod
+    def _drop_excluded_docs(
+        evidence: list[dict[str, Any]],
+        retrieved_doc_ids: list[int | str],
+        state: InteractRAGState,
+    ) -> list[dict[str, Any]]:
+        """Remove excluded chunks from the active evidence context and metadata."""
+        excluded_doc_ids = set(state.excluded_doc_ids)
+        retrieved_doc_ids[:] = [doc_id for doc_id in retrieved_doc_ids if doc_id not in excluded_doc_ids]
+        return [item for item in evidence if item.get("doc_id") not in excluded_doc_ids]
 
     async def _execute_retrieval_action(
         self,
         action: InteractRAGAction,
         state: InteractRAGState,
         trace: list[str],
-        evidence: list[str],
+        evidence: list[dict[str, Any]],
         retrieved_doc_ids: list[int | str],
-    ) -> list[str]:
+        degraded_actions: list[str],
+    ) -> list[dict[str, Any]]:
         """Run one retrieval-like action and update evidence."""
         retrieval_query = self._build_retrieval_query(action)
+        if self._is_prompt_simulated_action(action) and action.kind not in degraded_actions:
+            degraded_actions.append(action.kind)
+            trace.append(f"degraded {action.kind}: prompt-simulated via retrieval query")
         retrieval_results = await self._retrieval_pipeline.retrieve(retrieval_query, state.current_scale)
         filtered_results = self._filter_results(retrieval_results, state)
-        doc_ids, contents = self._contents_from_results(filtered_results)
+        new_evidence = self._evidence_from_results(filtered_results)
+        doc_ids = [item["doc_id"] for item in new_evidence]
         for doc_id in doc_ids:
             if doc_id not in retrieved_doc_ids:
                 retrieved_doc_ids.append(doc_id)
         trace.append(f"{action.kind}: {action.text}")
-        return self._append_evidence(evidence, contents)
+        return self._append_evidence(evidence, new_evidence)
 
     async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
         """Generate an answer through INTERACT-RAG corpus interaction primitives."""
@@ -386,8 +475,9 @@ class InteractRAGPipeline(BaseGenerationPipeline):
         state = InteractRAGState(current_scale=min(max(top_k, self.initial_scale), self.max_scale))
         tracker = TokenUsageTracker()
         trace: list[str] = []
-        evidence: list[str] = []
+        evidence: list[dict[str, Any]] = []
         retrieved_doc_ids: list[int | str] = []
+        degraded_actions: list[str] = []
         final_answer = ""
         terminated_by = "max_steps"
 
@@ -401,9 +491,18 @@ class InteractRAGPipeline(BaseGenerationPipeline):
                 trace.append(f"answer: {final_answer}")
                 terminated_by = "answer"
                 break
-            if self._apply_state_action(action, state, trace):
+            if self._apply_state_action(action, state, trace, set(retrieved_doc_ids)):
+                if action.kind == "exclude_docs":
+                    evidence = self._drop_excluded_docs(evidence, retrieved_doc_ids, state)
                 continue
-            evidence = await self._execute_retrieval_action(action, state, trace, evidence, retrieved_doc_ids)
+            evidence = await self._execute_retrieval_action(
+                action,
+                state,
+                trace,
+                evidence,
+                retrieved_doc_ids,
+                degraded_actions,
+            )
 
         if not final_answer and self.fallback_to_final_prompt:
             final_prompt = self._build_final_prompt(query_text, trace, evidence)
@@ -417,13 +516,15 @@ class InteractRAGPipeline(BaseGenerationPipeline):
             token_usage=tracker.total,
             metadata={
                 "trace": trace,
-                "evidence": evidence,
+                "evidence": [item.get("content", "") for item in evidence],
                 "retrieved_chunk_ids": retrieved_doc_ids,
                 "included_doc_ids": state.included_doc_ids,
                 "excluded_doc_ids": state.excluded_doc_ids,
                 "current_scale": state.current_scale,
                 "semantic_weight": state.semantic_weight,
                 "exact_weight": state.exact_weight,
+                "retrieval_action_mode": "prompt_simulated",
+                "degraded_actions": degraded_actions,
                 "terminated_by": terminated_by,
             },
         )

--- a/autorag_research/pipelines/generation/interact_rag.py
+++ b/autorag_research/pipelines/generation/interact_rag.py
@@ -90,7 +90,7 @@ _WEIGHTED_FUSION_ATTR_RE = re.compile(
     r"<weighted_fusion\s+semantic=['\"]?([0-9.]+)['\"]?\s+exact=['\"]?([0-9.]+)['\"]?",
     re.IGNORECASE,
 )
-_DOC_ID_RE = re.compile(r"-?\d+")
+_DOC_ID_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 
 
 @dataclass(frozen=True)
@@ -133,9 +133,18 @@ def parse_interact_rag_action(response_text: str) -> InteractRAGAction:
     return InteractRAGAction(kind="answer", text=stripped_response)
 
 
-def parse_doc_ids(text: str) -> list[int]:
-    """Parse document IDs from comma/space/free-form text."""
-    return [int(match.group(0)) for match in _DOC_ID_RE.finditer(text)]
+def parse_doc_ids(text: str) -> list[int | str]:
+    """Parse document IDs from comma/space/free-form text without splitting string IDs."""
+    doc_ids: list[int | str] = []
+    for token_match in _DOC_ID_TOKEN_RE.finditer(text):
+        token = token_match.group(0).strip(".,;:")
+        if not token or token.lower() in {"id", "ids", "and"}:
+            continue
+        if re.fullmatch(r"-?\d+", token):
+            doc_ids.append(int(token))
+        else:
+            doc_ids.append(token)
+    return doc_ids
 
 
 @dataclass
@@ -333,6 +342,23 @@ class InteractRAGPipeline(BaseGenerationPipeline):
         """Return exposed IDs plus their string forms for tolerant matching."""
         return exposed_doc_ids | {str(doc_id) for doc_id in exposed_doc_ids}
 
+    @staticmethod
+    def _resolve_requested_doc_ids(
+        requested_doc_ids: list[int | str],
+        exposed_doc_ids: set[int | str],
+    ) -> tuple[list[int | str], list[int | str]]:
+        """Resolve requested document IDs to exposed IDs while preserving their stored type."""
+        exposed_by_label = {str(doc_id): doc_id for doc_id in exposed_doc_ids}
+        accepted_doc_ids: list[int | str] = []
+        ignored_doc_ids: list[int | str] = []
+        for requested_doc_id in requested_doc_ids:
+            resolved_doc_id = exposed_by_label.get(str(requested_doc_id))
+            if resolved_doc_id is None:
+                ignored_doc_ids.append(requested_doc_id)
+            else:
+                accepted_doc_ids.append(resolved_doc_id)
+        return accepted_doc_ids, ignored_doc_ids
+
     def _apply_doc_id_action(
         self,
         action: InteractRAGAction,
@@ -342,10 +368,8 @@ class InteractRAGPipeline(BaseGenerationPipeline):
     ) -> bool:
         """Apply include/exclude actions only to IDs shown to the model."""
         target_list = state.included_doc_ids if action.kind == "include_docs" else state.excluded_doc_ids
-        known_doc_ids = self._known_doc_ids(exposed_doc_ids)
         requested_doc_ids = parse_doc_ids(action.text)
-        accepted_doc_ids = [doc_id for doc_id in requested_doc_ids if doc_id in known_doc_ids]
-        ignored_doc_ids = [doc_id for doc_id in requested_doc_ids if doc_id not in known_doc_ids]
+        accepted_doc_ids, ignored_doc_ids = self._resolve_requested_doc_ids(requested_doc_ids, exposed_doc_ids)
 
         for doc_id in accepted_doc_ids:
             if doc_id not in target_list:
@@ -362,8 +386,9 @@ class InteractRAGPipeline(BaseGenerationPipeline):
     def _apply_scale_action(self, action: InteractRAGAction, state: InteractRAGState, trace: list[str]) -> bool:
         """Apply retrieval scale changes."""
         parsed_values = parse_doc_ids(action.text)
-        if parsed_values:
-            state.current_scale = min(max(parsed_values[0], 1), self.max_scale)
+        parsed_scale = next((value for value in parsed_values if isinstance(value, int)), None)
+        if parsed_scale is not None:
+            state.current_scale = min(max(parsed_scale, 1), self.max_scale)
         trace.append(f"adjust_scale: {state.current_scale}")
         return True
 

--- a/autorag_research/pipelines/generation/interact_rag.py
+++ b/autorag_research/pipelines/generation/interact_rag.py
@@ -1,0 +1,441 @@
+"""INTERACT-RAG-style inference pipeline for AutoRAG-Research.
+
+The ICLR 2026 INTERACT-RAG paper equips an agent with corpus-interaction
+primitives beyond black-box query issuing: semantic/exact search, weighted
+fusion, entity matching, include/exclude document controls, and retrieval-scale
+adjustment. This module implements the training-free inference slice that fits
+AutoRAG-Research by mapping those primitives onto an existing retrieval pipeline
+and preserving rich interaction traces for evaluation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker
+
+logger = logging.getLogger("AutoRAG-Research")
+
+InteractActionKind = Literal[
+    "semantic_search",
+    "exact_search",
+    "weighted_fusion",
+    "entity_match",
+    "include_docs",
+    "exclude_docs",
+    "adjust_scale",
+    "answer",
+]
+
+DEFAULT_INTERACT_RAG_STEP_PROMPT = """You are an INTERACT-RAG agent that can reason and interact with the retrieval corpus.
+Use exactly one XML-like action per step:
+- <semantic_search>query</semantic_search>: dense/semantic evidence search
+- <exact_search>keywords</exact_search>: lexical/exact evidence search
+- <weighted_fusion semantic="0.6" exact="0.4">query</weighted_fusion>: combine semantic and exact intent
+- <entity_match>entity name</entity_match>: focus retrieval around an entity
+- <include_docs>1, 2</include_docs>: force known useful doc IDs into context
+- <exclude_docs>3, 4</exclude_docs>: remove noisy doc IDs from future context
+- <adjust_scale>8</adjust_scale>: change retrieval scale for later searches
+- <answer>final answer</answer>: finish
+
+Question:
+{query}
+
+Interaction budget: {steps_used}/{max_steps} steps used.
+Current retrieval scale: {current_scale}
+Included doc IDs: {included_doc_ids}
+Excluded doc IDs: {excluded_doc_ids}
+
+Interaction trace and evidence:
+{scratchpad}
+
+Next action:"""
+
+DEFAULT_INTERACT_RAG_FINAL_PROMPT = """Answer the question using the INTERACT-RAG interaction trace and gathered evidence.
+
+Question:
+{query}
+
+Interaction trace and evidence:
+{scratchpad}
+
+Return only the final answer."""
+
+_ACTION_PATTERNS: tuple[tuple[InteractActionKind, re.Pattern[str]], ...] = (
+    ("answer", re.compile(r"<answer>\s*(.*?)\s*</answer>", re.IGNORECASE | re.DOTALL)),
+    ("semantic_search", re.compile(r"<semantic_search>\s*(.*?)\s*</semantic_search>", re.IGNORECASE | re.DOTALL)),
+    ("exact_search", re.compile(r"<exact_search>\s*(.*?)\s*</exact_search>", re.IGNORECASE | re.DOTALL)),
+    ("weighted_fusion", re.compile(r"<weighted_fusion(?:\s+[^>]*)?>\s*(.*?)\s*</weighted_fusion>", re.IGNORECASE | re.DOTALL)),
+    ("entity_match", re.compile(r"<entity_match>\s*(.*?)\s*</entity_match>", re.IGNORECASE | re.DOTALL)),
+    ("include_docs", re.compile(r"<include_docs>\s*(.*?)\s*</include_docs>", re.IGNORECASE | re.DOTALL)),
+    ("exclude_docs", re.compile(r"<exclude_docs>\s*(.*?)\s*</exclude_docs>", re.IGNORECASE | re.DOTALL)),
+    ("adjust_scale", re.compile(r"<adjust_scale>\s*(.*?)\s*</adjust_scale>", re.IGNORECASE | re.DOTALL)),
+)
+_WEIGHTED_FUSION_ATTR_RE = re.compile(
+    r"<weighted_fusion\s+semantic=['\"]?([0-9.]+)['\"]?\s+exact=['\"]?([0-9.]+)['\"]?",
+    re.IGNORECASE,
+)
+_DOC_ID_RE = re.compile(r"-?\d+")
+
+
+@dataclass(frozen=True)
+class InteractRAGAction:
+    """Parsed INTERACT-RAG action."""
+
+    kind: InteractActionKind
+    text: str
+    semantic_weight: float | None = None
+    exact_weight: float | None = None
+
+
+def parse_interact_rag_action(response_text: str) -> InteractRAGAction:
+    """Parse the first supported INTERACT-RAG action from an LLM response."""
+    for action_kind, pattern in _ACTION_PATTERNS:
+        match = pattern.search(response_text)
+        if match is None:
+            continue
+        semantic_weight = None
+        exact_weight = None
+        if action_kind == "weighted_fusion":
+            weight_match = _WEIGHTED_FUSION_ATTR_RE.search(response_text)
+            if weight_match is not None:
+                semantic_weight = float(weight_match.group(1))
+                exact_weight = float(weight_match.group(2))
+        return InteractRAGAction(
+            kind=action_kind,
+            text=match.group(1).strip(),
+            semantic_weight=semantic_weight,
+            exact_weight=exact_weight,
+        )
+
+    stripped_response = response_text.strip()
+    if stripped_response.lower().startswith("answer:"):
+        return InteractRAGAction(kind="answer", text=stripped_response.split(":", 1)[1].strip())
+    return InteractRAGAction(kind="answer", text=stripped_response)
+
+
+def parse_doc_ids(text: str) -> list[int]:
+    """Parse document IDs from comma/space/free-form text."""
+    return [int(match.group(0)) for match in _DOC_ID_RE.finditer(text)]
+
+
+@dataclass
+class InteractRAGState:
+    """Mutable retrieval interaction state."""
+
+    included_doc_ids: list[int | str] = field(default_factory=list)
+    excluded_doc_ids: list[int | str] = field(default_factory=list)
+    current_scale: int = 5
+    semantic_weight: float = 0.5
+    exact_weight: float = 0.5
+
+
+@dataclass(kw_only=True)
+class InteractRAGPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for the INTERACT-RAG inference pipeline."""
+
+    step_prompt_template: str = field(default=DEFAULT_INTERACT_RAG_STEP_PROMPT)
+    final_prompt_template: str = field(default=DEFAULT_INTERACT_RAG_FINAL_PROMPT)
+    max_steps: int = 6
+    initial_scale: int = 5
+    max_scale: int = 20
+    evidence_budget: int = 12
+    fallback_to_final_prompt: bool = True
+
+    def get_pipeline_class(self) -> type[InteractRAGPipeline]:
+        """Return the InteractRAGPipeline class."""
+        return InteractRAGPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for InteractRAGPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "step_prompt_template": self.step_prompt_template,
+            "final_prompt_template": self.final_prompt_template,
+            "max_steps": self.max_steps,
+            "initial_scale": self.initial_scale,
+            "max_scale": self.max_scale,
+            "evidence_budget": self.evidence_budget,
+            "fallback_to_final_prompt": self.fallback_to_final_prompt,
+        }
+
+
+class InteractRAGPipeline(BaseGenerationPipeline):
+    """Training-free INTERACT-RAG generation pipeline."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        step_prompt_template: str = DEFAULT_INTERACT_RAG_STEP_PROMPT,
+        final_prompt_template: str = DEFAULT_INTERACT_RAG_FINAL_PROMPT,
+        max_steps: int = 6,
+        initial_scale: int = 5,
+        max_scale: int = 20,
+        evidence_budget: int = 12,
+        fallback_to_final_prompt: bool = True,
+        schema: Any | None = None,
+    ):
+        """Initialize the INTERACT-RAG pipeline."""
+        if max_steps < 1:
+            msg = "max_steps must be >= 1"
+            raise ValueError(msg)
+        if initial_scale < 1 or max_scale < 1:
+            msg = "initial_scale and max_scale must be >= 1"
+            raise ValueError(msg)
+        if evidence_budget < 1:
+            msg = "evidence_budget must be >= 1"
+            raise ValueError(msg)
+
+        self.step_prompt_template = step_prompt_template
+        self.final_prompt_template = final_prompt_template
+        self.max_steps = max_steps
+        self.initial_scale = min(initial_scale, max_scale)
+        self.max_scale = max_scale
+        self.evidence_budget = evidence_budget
+        self.fallback_to_final_prompt = fallback_to_final_prompt
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return INTERACT-RAG pipeline configuration."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+        return {
+            "type": "interact_rag",
+            "step_prompt_template": self.step_prompt_template,
+            "final_prompt_template": self.final_prompt_template,
+            "max_steps": self.max_steps,
+            "initial_scale": self.initial_scale,
+            "max_scale": self.max_scale,
+            "evidence_budget": self.evidence_budget,
+            "fallback_to_final_prompt": self.fallback_to_final_prompt,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract text content from an LLM response."""
+        return response.content if hasattr(response, "content") else str(response)
+
+    @staticmethod
+    def _format_doc_ids(doc_ids: list[int | str]) -> str:
+        """Format doc IDs for prompts."""
+        return ", ".join(str(doc_id) for doc_id in doc_ids) if doc_ids else "(none)"
+
+    @staticmethod
+    def _format_scratchpad(trace: list[str], evidence: list[str]) -> str:
+        """Format trace and evidence for prompting."""
+        sections: list[str] = []
+        if trace:
+            sections.append("Trace:\n" + "\n".join(trace))
+        if evidence:
+            sections.append("Evidence:\n" + "\n\n".join(f"[{i + 1}] {item}" for i, item in enumerate(evidence)))
+        return "\n\n".join(sections) if sections else "(empty)"
+
+    def _build_step_prompt(
+        self,
+        query: str,
+        state: InteractRAGState,
+        trace: list[str],
+        evidence: list[str],
+        steps_used: int,
+    ) -> str:
+        """Build one interaction prompt."""
+        return self.step_prompt_template.format(
+            query=query,
+            scratchpad=self._format_scratchpad(trace, evidence),
+            steps_used=steps_used,
+            max_steps=self.max_steps,
+            current_scale=state.current_scale,
+            included_doc_ids=self._format_doc_ids(state.included_doc_ids),
+            excluded_doc_ids=self._format_doc_ids(state.excluded_doc_ids),
+        )
+
+    def _build_final_prompt(self, query: str, trace: list[str], evidence: list[str]) -> str:
+        """Build fallback answer prompt."""
+        return self.final_prompt_template.format(query=query, scratchpad=self._format_scratchpad(trace, evidence))
+
+    def _contents_from_results(self, retrieval_results: list[dict[str, Any]]) -> tuple[list[int | str], list[str]]:
+        """Extract IDs and contents from retrieval results, backfilling when needed."""
+        doc_ids: list[int | str] = []
+        contents: list[str | None] = []
+        missing_positions: list[int] = []
+        missing_ids: list[int | str] = []
+        for result in retrieval_results:
+            doc_id = result.get("doc_id")
+            if doc_id is None:
+                continue
+            doc_ids.append(doc_id)
+            content = result.get("content")
+            if content:
+                contents.append(str(content))
+            else:
+                missing_positions.append(len(contents))
+                missing_ids.append(doc_id)
+                contents.append(None)
+
+        if missing_ids:
+            fetched_contents = self._service.get_chunk_contents(missing_ids)
+            for position, fetched_content in zip(missing_positions, fetched_contents, strict=False):
+                contents[position] = fetched_content
+        return doc_ids, [content or "" for content in contents]
+
+    def _apply_state_action(self, action: InteractRAGAction, state: InteractRAGState, trace: list[str]) -> bool:
+        """Apply non-search context-shaping actions. Return True if handled."""
+        if action.kind == "include_docs":
+            for doc_id in parse_doc_ids(action.text):
+                if doc_id not in state.included_doc_ids:
+                    state.included_doc_ids.append(doc_id)
+            trace.append(f"include_docs: {self._format_doc_ids(state.included_doc_ids)}")
+            return True
+        if action.kind == "exclude_docs":
+            for doc_id in parse_doc_ids(action.text):
+                if doc_id not in state.excluded_doc_ids:
+                    state.excluded_doc_ids.append(doc_id)
+            trace.append(f"exclude_docs: {self._format_doc_ids(state.excluded_doc_ids)}")
+            return True
+        if action.kind == "adjust_scale":
+            parsed_values = parse_doc_ids(action.text)
+            if parsed_values:
+                state.current_scale = min(max(parsed_values[0], 1), self.max_scale)
+            trace.append(f"adjust_scale: {state.current_scale}")
+            return True
+        if action.kind == "weighted_fusion":
+            if action.semantic_weight is not None and action.exact_weight is not None:
+                state.semantic_weight = action.semantic_weight
+                state.exact_weight = action.exact_weight
+            return False
+        return False
+
+    def _build_retrieval_query(self, action: InteractRAGAction) -> str:
+        """Translate an interaction primitive into a retrieval query string."""
+        if action.kind == "entity_match":
+            return f"entity: {action.text}"
+        if action.kind == "exact_search":
+            return f"exact: {action.text}"
+        if action.kind == "weighted_fusion":
+            semantic_weight = action.semantic_weight if action.semantic_weight is not None else 0.5
+            exact_weight = action.exact_weight if action.exact_weight is not None else 0.5
+            return f"semantic weight {semantic_weight:.2f}; exact weight {exact_weight:.2f}; query: {action.text}"
+        return action.text
+
+    def _filter_results(
+        self,
+        retrieval_results: list[dict[str, Any]],
+        state: InteractRAGState,
+    ) -> list[dict[str, Any]]:
+        """Apply include/exclude state to retrieval results."""
+        excluded = set(state.excluded_doc_ids)
+        filtered_results = [result for result in retrieval_results if result.get("doc_id") not in excluded]
+        included = [
+            {"doc_id": doc_id, "score": float("inf")}
+            for doc_id in state.included_doc_ids
+            if doc_id not in excluded and all(result.get("doc_id") != doc_id for result in filtered_results)
+        ]
+        return [*included, *filtered_results]
+
+    def _append_evidence(self, evidence: list[str], new_contents: list[str]) -> list[str]:
+        """Append deduplicated evidence while respecting evidence_budget."""
+        updated = list(evidence)
+        for content in new_contents:
+            if content and content not in updated:
+                updated.append(content)
+        return updated[-self.evidence_budget :]
+
+    async def _execute_retrieval_action(
+        self,
+        action: InteractRAGAction,
+        state: InteractRAGState,
+        trace: list[str],
+        evidence: list[str],
+        retrieved_doc_ids: list[int | str],
+    ) -> list[str]:
+        """Run one retrieval-like action and update evidence."""
+        retrieval_query = self._build_retrieval_query(action)
+        retrieval_results = await self._retrieval_pipeline.retrieve(retrieval_query, state.current_scale)
+        filtered_results = self._filter_results(retrieval_results, state)
+        doc_ids, contents = self._contents_from_results(filtered_results)
+        for doc_id in doc_ids:
+            if doc_id not in retrieved_doc_ids:
+                retrieved_doc_ids.append(doc_id)
+        trace.append(f"{action.kind}: {action.text}")
+        return self._append_evidence(evidence, contents)
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate an answer through INTERACT-RAG corpus interaction primitives."""
+        query_text = self._service.get_query_text(query_id)
+        state = InteractRAGState(current_scale=min(max(top_k, self.initial_scale), self.max_scale))
+        tracker = TokenUsageTracker()
+        trace: list[str] = []
+        evidence: list[str] = []
+        retrieved_doc_ids: list[int | str] = []
+        final_answer = ""
+        terminated_by = "max_steps"
+
+        for step_index in range(self.max_steps):
+            prompt = self._build_step_prompt(query_text, state, trace, evidence, step_index)
+            response = await self._llm.ainvoke(prompt)
+            tracker.record(response)
+            action = parse_interact_rag_action(self._extract_text(response))
+            if action.kind == "answer":
+                final_answer = action.text
+                trace.append(f"answer: {final_answer}")
+                terminated_by = "answer"
+                break
+            if self._apply_state_action(action, state, trace):
+                continue
+            evidence = await self._execute_retrieval_action(action, state, trace, evidence, retrieved_doc_ids)
+
+        if not final_answer and self.fallback_to_final_prompt:
+            final_prompt = self._build_final_prompt(query_text, trace, evidence)
+            final_response = await self._llm.ainvoke(final_prompt)
+            tracker.record(final_response)
+            final_answer = self._extract_text(final_response)
+            terminated_by = f"{terminated_by}_fallback"
+
+        return GenerationResult(
+            text=final_answer,
+            token_usage=tracker.total,
+            metadata={
+                "trace": trace,
+                "evidence": evidence,
+                "retrieved_chunk_ids": retrieved_doc_ids,
+                "included_doc_ids": state.included_doc_ids,
+                "excluded_doc_ids": state.excluded_doc_ids,
+                "current_scale": state.current_scale,
+                "semantic_weight": state.semantic_weight,
+                "exact_weight": state.exact_weight,
+                "terminated_by": terminated_by,
+            },
+        )
+
+
+__all__ = [
+    "DEFAULT_INTERACT_RAG_FINAL_PROMPT",
+    "DEFAULT_INTERACT_RAG_STEP_PROMPT",
+    "InteractRAGAction",
+    "InteractRAGPipeline",
+    "InteractRAGPipelineConfig",
+    "InteractRAGState",
+    "parse_doc_ids",
+    "parse_interact_rag_action",
+]

--- a/autorag_research/pipelines/generation/interact_rag.py
+++ b/autorag_research/pipelines/generation/interact_rag.py
@@ -40,7 +40,7 @@ InteractActionKind = Literal[
 
 DEFAULT_INTERACT_RAG_STEP_PROMPT = """You are an INTERACT-RAG agent that can reason and interact with the retrieval corpus.
 Use exactly one XML-like action per step. Retrieval actions are prompt-simulated through the configured
-retrieval pipeline unless that retriever advertises richer native capabilities:
+retrieval pipeline query boundary:
 - <semantic_search>query</semantic_search>: evidence search
 - <exact_search>keywords</exact_search>: prompt-simulated lexical/exact intent search
 - <weighted_fusion semantic="0.6" exact="0.4">query</weighted_fusion>: prompt-simulated semantic/exact intent
@@ -114,8 +114,12 @@ def parse_interact_rag_action(response_text: str) -> InteractRAGAction:
         if action_kind == "weighted_fusion":
             weight_match = _WEIGHTED_FUSION_ATTR_RE.search(response_text)
             if weight_match is not None:
-                semantic_weight = float(weight_match.group(1))
-                exact_weight = float(weight_match.group(2))
+                try:
+                    semantic_weight = float(weight_match.group(1))
+                    exact_weight = float(weight_match.group(2))
+                except ValueError:
+                    semantic_weight = None
+                    exact_weight = None
         return InteractRAGAction(
             kind=action_kind,
             text=match.group(1).strip(),
@@ -418,6 +422,7 @@ class InteractRAGPipeline(BaseGenerationPipeline):
         self,
         evidence: list[dict[str, Any]],
         new_evidence: list[dict[str, Any]],
+        state: InteractRAGState,
     ) -> list[dict[str, Any]]:
         """Append deduplicated evidence while respecting evidence_budget."""
         updated = list(evidence)
@@ -427,7 +432,25 @@ class InteractRAGPipeline(BaseGenerationPipeline):
             if content and content not in existing_contents:
                 updated.append(item)
                 existing_contents.add(content)
-        return updated[-self.evidence_budget :]
+        return self._trim_evidence_to_budget(updated, state)
+
+    def _trim_evidence_to_budget(
+        self,
+        evidence: list[dict[str, Any]],
+        state: InteractRAGState,
+    ) -> list[dict[str, Any]]:
+        """Trim evidence while preserving explicitly included chunks."""
+        included_doc_ids = self._known_doc_ids(set(state.included_doc_ids))
+        included_evidence = [item for item in evidence if item.get("doc_id") in included_doc_ids]
+        if not included_evidence:
+            return evidence[-self.evidence_budget :]
+
+        remaining_budget = self.evidence_budget - len(included_evidence)
+        if remaining_budget <= 0:
+            return included_evidence
+
+        non_included_evidence = [item for item in evidence if item.get("doc_id") not in included_doc_ids]
+        return [*included_evidence, *non_included_evidence[-remaining_budget:]]
 
     @staticmethod
     def _is_prompt_simulated_action(action: InteractRAGAction) -> bool:
@@ -467,7 +490,7 @@ class InteractRAGPipeline(BaseGenerationPipeline):
             if doc_id not in retrieved_doc_ids:
                 retrieved_doc_ids.append(doc_id)
         trace.append(f"{action.kind}: {action.text}")
-        return self._append_evidence(evidence, new_evidence)
+        return self._append_evidence(evidence, new_evidence, state)
 
     async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
         """Generate an answer through INTERACT-RAG corpus interaction primitives."""

--- a/configs/pipelines/generation/interact_rag.yaml
+++ b/configs/pipelines/generation/interact_rag.yaml
@@ -1,0 +1,15 @@
+_target_: autorag_research.pipelines.generation.interact_rag.InteractRAGPipelineConfig
+description: "Training-free INTERACT-RAG inference pipeline with corpus interaction primitives"
+name: interact_rag
+retrieval_pipeline_name: hybrid_rrf
+llm: openai-gpt4o-mini
+max_steps: 6
+initial_scale: 5
+max_scale: 20
+evidence_budget: 12
+fallback_to_final_prompt: true
+top_k: 5
+batch_size: 32
+max_concurrency: 4
+max_retries: 3
+retry_delay: 1.0

--- a/configs/pipelines/generation/interact_rag.yaml
+++ b/configs/pipelines/generation/interact_rag.yaml
@@ -1,8 +1,8 @@
 _target_: autorag_research.pipelines.generation.interact_rag.InteractRAGPipelineConfig
-description: "Training-free INTERACT-RAG inference pipeline with corpus interaction primitives"
+description: "Training-free INTERACT-RAG inference pipeline with prompt-simulated corpus interaction primitives"
 name: interact_rag
 retrieval_pipeline_name: hybrid_rrf
-llm: openai-gpt4o-mini
+llm: mock
 max_steps: 6
 initial_scale: 5
 max_scale: 20

--- a/tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py
@@ -1,14 +1,17 @@
 """Tests for the INTERACT-RAG generation pipeline."""
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.language_models.fake import FakeListLLM
+from omegaconf import OmegaConf
 
 from autorag_research.pipelines.generation.interact_rag import (
     InteractRAGPipeline,
     InteractRAGPipelineConfig,
+    InteractRAGState,
     parse_doc_ids,
     parse_interact_rag_action,
 )
@@ -53,7 +56,7 @@ class TestInteractRAGParsing:
         assert action.text == "moon landing timeline"
 
     def test_parse_weighted_fusion_with_weights(self):
-        action = parse_interact_rag_action("<weighted_fusion semantic=\"0.7\" exact=\"0.3\">apollo 11</weighted_fusion>")
+        action = parse_interact_rag_action('<weighted_fusion semantic="0.7" exact="0.3">apollo 11</weighted_fusion>')
 
         assert action.kind == "weighted_fusion"
         assert action.text == "apollo 11"
@@ -72,6 +75,12 @@ class TestInteractRAGParsing:
 
 class TestInteractRAGPipelineConfig:
     """Tests for InteractRAGPipelineConfig."""
+
+    def test_shipped_yaml_uses_existing_llm_config(self):
+        config = OmegaConf.load(Path("configs/pipelines/generation/interact_rag.yaml"))
+        llm_name = str(config.llm)
+
+        assert (Path("configs/llm") / f"{llm_name}.yaml").exists() or (Path("configs/llm") / f"{llm_name}.yml").exists()
 
     def test_get_pipeline_class(self):
         config = InteractRAGPipelineConfig(
@@ -114,6 +123,55 @@ class TestInteractRAGPipelineConfig:
 
 class TestInteractRAGPipeline:
     """Tests for INTERACT-RAG generation behavior."""
+
+    def test_format_scratchpad_exposes_real_chunk_ids_and_scores(self):
+        scratchpad = InteractRAGPipeline._format_scratchpad(
+            ["semantic_search: apollo"],
+            [{"doc_id": 42, "score": 0.75, "content": "Apollo evidence."}],
+        )
+
+        assert "[chunk_id=42 score=0.75] Apollo evidence." in scratchpad
+        assert "[1]" not in scratchpad
+
+    def test_apply_include_docs_rejects_unexposed_ordinal_ids(self):
+        pipeline = _build_unit_pipeline(
+            FakeListLLM(responses=["<answer>ok</answer>"]),
+            create_mock_retrieval_pipeline(),
+            MagicMock(),
+        )
+        state = InteractRAGState()
+        trace: list[str] = []
+
+        handled = pipeline._apply_state_action(
+            parse_interact_rag_action("<include_docs>1</include_docs>"),
+            state,
+            trace,
+            exposed_doc_ids={42},
+        )
+
+        assert handled is True
+        assert state.included_doc_ids == []
+        assert trace == ["include_docs ignored unknown IDs: 1"]
+
+    def test_apply_include_docs_accepts_exposed_chunk_ids(self):
+        pipeline = _build_unit_pipeline(
+            FakeListLLM(responses=["<answer>ok</answer>"]),
+            create_mock_retrieval_pipeline(),
+            MagicMock(),
+        )
+        state = InteractRAGState()
+        trace: list[str] = []
+
+        handled = pipeline._apply_state_action(
+            parse_interact_rag_action("<include_docs>42</include_docs>"),
+            state,
+            trace,
+            exposed_doc_ids={42},
+        )
+
+        assert handled is True
+        assert state.included_doc_ids == [42]
+        assert trace == ["include_docs: 42"]
 
     def test_initialization_rejects_invalid_steps(self):
         with (
@@ -159,6 +217,7 @@ class TestInteractRAGPipeline:
         llm.ainvoke = AsyncMock(
             side_effect=[
                 _mock_response("<adjust_scale>4</adjust_scale>"),
+                _mock_response("<exact_search>target terms</exact_search>"),
                 _mock_response("<exclude_docs>2</exclude_docs>"),
                 _mock_response("<exact_search>target terms</exact_search>"),
                 _mock_response("fallback answer"),
@@ -176,39 +235,71 @@ class TestInteractRAGPipeline:
             llm,
             retrieval_pipeline,
             service,
-            max_steps=3,
+            max_steps=4,
             initial_scale=1,
             max_scale=5,
         )
 
         result = await pipeline._generate(1, top_k=1)
 
-        retrieval_pipeline.retrieve.assert_awaited_once_with("exact: target terms", 4)
+        assert retrieval_pipeline.retrieve.await_args_list[0].args == ("exact: target terms", 4)
+        assert retrieval_pipeline.retrieve.await_args_list[1].args == ("exact: target terms", 4)
         assert result.metadata["excluded_doc_ids"] == [2]
         assert result.metadata["retrieved_chunk_ids"] == [3]
         assert result.metadata["evidence"] == ["kept"]
         assert result.metadata["terminated_by"] == "max_steps_fallback"
 
     @pytest.mark.asyncio
-    async def test_generate_applies_include_docs_and_backfills_content(self):
+    async def test_generate_applies_include_docs_for_exposed_ids_and_backfills_content(self):
         llm = MagicMock()
         llm.ainvoke = AsyncMock(
             side_effect=[
+                _mock_response("<semantic_search>Curie</semantic_search>"),
                 _mock_response("<include_docs>5</include_docs>"),
                 _mock_response("<entity_match>Curie</entity_match>"),
                 _mock_response("<answer>Curie answer.</answer>"),
             ]
         )
-        retrieval_pipeline = create_mock_retrieval_pipeline(default_results=[{"doc_id": 6, "score": 0.8}])
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 5, "score": 0.9}, {"doc_id": 6, "score": 0.8}]
+        )
         service = MagicMock()
         service.get_query_text.return_value = "Question?"
         service.get_chunk_contents.return_value = ["Forced evidence.", "Fetched evidence."]
-        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=3, initial_scale=2)
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=4, initial_scale=2)
 
         result = await pipeline._generate(1, top_k=2)
 
-        retrieval_pipeline.retrieve.assert_awaited_once_with("entity: Curie", 2)
-        service.get_chunk_contents.assert_called_once_with([5, 6])
+        assert retrieval_pipeline.retrieve.await_args_list[0].args == ("Curie", 2)
+        assert retrieval_pipeline.retrieve.await_args_list[1].args == ("entity: Curie", 2)
+        service.get_chunk_contents.assert_any_call([5, 6])
         assert result.metadata["included_doc_ids"] == [5]
         assert result.metadata["retrieved_chunk_ids"] == [5, 6]
         assert result.metadata["evidence"] == ["Forced evidence.", "Fetched evidence."]
+        second_prompt = llm.ainvoke.await_args_list[1].args[0]
+        assert "[chunk_id=5 score=0.9] Forced evidence." in second_prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_records_prompt_simulated_degradation_for_weighted_fusion(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response('<weighted_fusion semantic="0.8" exact="0.2">apollo</weighted_fusion>'),
+                _mock_response("<answer>done</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 10, "score": 0.9, "content": "Apollo evidence."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=2, initial_scale=2)
+
+        result = await pipeline._generate(1, top_k=2)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with(
+            "semantic weight 0.80; exact weight 0.20; query: apollo", 2
+        )
+        assert result.metadata["retrieval_action_mode"] == "prompt_simulated"
+        assert result.metadata["degraded_actions"] == ["weighted_fusion"]
+        assert "degraded weighted_fusion" in result.metadata["trace"][0]

--- a/tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py
@@ -63,6 +63,14 @@ class TestInteractRAGParsing:
         assert action.semantic_weight == 0.7
         assert action.exact_weight == 0.3
 
+    def test_parse_weighted_fusion_malformed_weights_falls_back_to_defaults(self):
+        action = parse_interact_rag_action('<weighted_fusion semantic="." exact="0.2">apollo 11</weighted_fusion>')
+
+        assert action.kind == "weighted_fusion"
+        assert action.text == "apollo 11"
+        assert action.semantic_weight is None
+        assert action.exact_weight is None
+
     def test_parse_answer_preferred(self):
         action = parse_interact_rag_action("<semantic_search>x</semantic_search><answer>final</answer>")
 
@@ -205,6 +213,7 @@ class TestInteractRAGPipeline:
         result = await pipeline._generate(1, top_k=2)
 
         retrieval_pipeline.retrieve.assert_awaited_once_with("apollo 11 landing", 2)
+        assert result.metadata is not None
         assert result.text == "Apollo 11 landed in 1969."
         assert result.metadata["retrieved_chunk_ids"] == [10]
         assert result.metadata["evidence"] == ["Apollo 11 landed in July 1969."]
@@ -242,6 +251,7 @@ class TestInteractRAGPipeline:
 
         result = await pipeline._generate(1, top_k=1)
 
+        assert result.metadata is not None
         assert retrieval_pipeline.retrieve.await_args_list[0].args == ("exact: target terms", 4)
         assert retrieval_pipeline.retrieve.await_args_list[1].args == ("exact: target terms", 4)
         assert result.metadata["excluded_doc_ids"] == [2]
@@ -270,6 +280,7 @@ class TestInteractRAGPipeline:
 
         result = await pipeline._generate(1, top_k=2)
 
+        assert result.metadata is not None
         assert retrieval_pipeline.retrieve.await_args_list[0].args == ("Curie", 2)
         assert retrieval_pipeline.retrieve.await_args_list[1].args == ("entity: Curie", 2)
         service.get_chunk_contents.assert_any_call([5, 6])
@@ -297,9 +308,44 @@ class TestInteractRAGPipeline:
 
         result = await pipeline._generate(1, top_k=2)
 
+        assert result.metadata is not None
         retrieval_pipeline.retrieve.assert_awaited_once_with(
             "semantic weight 0.80; exact weight 0.20; query: apollo", 2
         )
         assert result.metadata["retrieval_action_mode"] == "prompt_simulated"
         assert result.metadata["degraded_actions"] == ["weighted_fusion"]
         assert "degraded weighted_fusion" in result.metadata["trace"][0]
+
+    @pytest.mark.asyncio
+    async def test_generate_keeps_included_doc_within_evidence_budget(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<semantic_search>first</semantic_search>"),
+                _mock_response("<include_docs>5</include_docs>"),
+                _mock_response("<semantic_search>second</semantic_search>"),
+                _mock_response("<answer>done</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline.retrieve = AsyncMock(
+            side_effect=[
+                [{"doc_id": 5, "score": 0.9, "content": "pinned"}],
+                [
+                    {"doc_id": 6, "score": 0.8, "content": "new6"},
+                    {"doc_id": 7, "score": 0.7, "content": "new7"},
+                    {"doc_id": 8, "score": 0.6, "content": "new8"},
+                ],
+            ]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(
+            llm, retrieval_pipeline, service, max_steps=4, initial_scale=3, evidence_budget=2
+        )
+
+        result = await pipeline._generate(1, top_k=3)
+
+        assert result.metadata is not None
+        assert result.metadata["included_doc_ids"] == [5]
+        assert result.metadata["evidence"] == ["pinned", "new8"]

--- a/tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py
@@ -80,6 +80,9 @@ class TestInteractRAGParsing:
     def test_parse_doc_ids(self):
         assert parse_doc_ids("IDs: 3, 7 and 12") == [3, 7, 12]
 
+    def test_parse_doc_ids_preserves_string_chunk_ids(self):
+        assert parse_doc_ids("chunk-alpha, abc-123, alpha") == ["chunk-alpha", "abc-123", "alpha"]
+
 
 class TestInteractRAGPipelineConfig:
     """Tests for InteractRAGPipelineConfig."""
@@ -180,6 +183,26 @@ class TestInteractRAGPipeline:
         assert handled is True
         assert state.included_doc_ids == [42]
         assert trace == ["include_docs: 42"]
+
+    def test_apply_include_docs_accepts_exposed_string_chunk_ids(self):
+        pipeline = _build_unit_pipeline(
+            FakeListLLM(responses=["<answer>ok</answer>"]),
+            create_mock_retrieval_pipeline(),
+            MagicMock(),
+        )
+        state = InteractRAGState()
+        trace: list[str] = []
+
+        handled = pipeline._apply_state_action(
+            parse_interact_rag_action("<include_docs>chunk-alpha, abc-123, alpha</include_docs>"),
+            state,
+            trace,
+            exposed_doc_ids={"chunk-alpha", "abc-123", "alpha"},
+        )
+
+        assert handled is True
+        assert state.included_doc_ids == ["chunk-alpha", "abc-123", "alpha"]
+        assert trace == ["include_docs: chunk-alpha, abc-123, alpha"]
 
     def test_initialization_rejects_invalid_steps(self):
         with (
@@ -349,3 +372,33 @@ class TestInteractRAGPipeline:
         assert result.metadata is not None
         assert result.metadata["included_doc_ids"] == [5]
         assert result.metadata["evidence"] == ["pinned", "new8"]
+
+    @pytest.mark.asyncio
+    async def test_generate_applies_string_include_and_exclude_controls(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<semantic_search>first</semantic_search>"),
+                _mock_response("<include_docs>chunk-alpha</include_docs>"),
+                _mock_response("<exclude_docs>abc-123</exclude_docs>"),
+                _mock_response("<semantic_search>second</semantic_search>"),
+                _mock_response("<answer>done</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": "chunk-alpha", "score": 0.9, "content": "included"},
+                {"doc_id": "abc-123", "score": 0.8, "content": "excluded"},
+            ]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=5, initial_scale=2)
+
+        result = await pipeline._generate("query-alpha", top_k=2)
+
+        assert result.metadata is not None
+        assert result.metadata["included_doc_ids"] == ["chunk-alpha"]
+        assert result.metadata["excluded_doc_ids"] == ["abc-123"]
+        assert result.metadata["retrieved_chunk_ids"] == ["chunk-alpha"]
+        assert result.metadata["evidence"] == ["included"]

--- a/tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py
@@ -1,0 +1,214 @@
+"""Tests for the INTERACT-RAG generation pipeline."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from autorag_research.pipelines.generation.interact_rag import (
+    InteractRAGPipeline,
+    InteractRAGPipelineConfig,
+    parse_doc_ids,
+    parse_interact_rag_action,
+)
+from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_retrieval_pipeline
+
+
+def _mock_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
+    return response
+
+
+def _build_unit_pipeline(
+    llm: Any,
+    retrieval_pipeline: Any,
+    service: Any,
+    **kwargs: Any,
+) -> InteractRAGPipeline:
+    with patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None):
+        pipeline = InteractRAGPipeline(
+            session_factory=MagicMock(),
+            name="interact_rag_unit",
+            llm=llm,
+            retrieval_pipeline=retrieval_pipeline,
+            **kwargs,
+        )
+    pipeline._llm = llm
+    pipeline._retrieval_pipeline = retrieval_pipeline
+    pipeline._service = service
+    pipeline.pipeline_id = 1
+    return pipeline
+
+
+class TestInteractRAGParsing:
+    """Tests for action parsing helpers."""
+
+    def test_parse_semantic_search(self):
+        action = parse_interact_rag_action("<semantic_search>moon landing timeline</semantic_search>")
+
+        assert action.kind == "semantic_search"
+        assert action.text == "moon landing timeline"
+
+    def test_parse_weighted_fusion_with_weights(self):
+        action = parse_interact_rag_action("<weighted_fusion semantic=\"0.7\" exact=\"0.3\">apollo 11</weighted_fusion>")
+
+        assert action.kind == "weighted_fusion"
+        assert action.text == "apollo 11"
+        assert action.semantic_weight == 0.7
+        assert action.exact_weight == 0.3
+
+    def test_parse_answer_preferred(self):
+        action = parse_interact_rag_action("<semantic_search>x</semantic_search><answer>final</answer>")
+
+        assert action.kind == "answer"
+        assert action.text == "final"
+
+    def test_parse_doc_ids(self):
+        assert parse_doc_ids("IDs: 3, 7 and 12") == [3, 7, 12]
+
+
+class TestInteractRAGPipelineConfig:
+    """Tests for InteractRAGPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        config = InteractRAGPipelineConfig(
+            name="interact_rag",
+            llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+            retrieval_pipeline_name="hybrid_rrf",
+        )
+
+        assert config.get_pipeline_class() == InteractRAGPipeline
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        config = InteractRAGPipelineConfig(
+            name="interact_rag",
+            llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+            retrieval_pipeline_name="hybrid_rrf",
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        retrieval_pipeline = create_mock_retrieval_pipeline(pipeline_id=77)
+        llm = FakeListLLM(responses=["<answer>ok</answer>"])
+        config = InteractRAGPipelineConfig(
+            name="interact_rag",
+            llm=llm,
+            retrieval_pipeline_name="hybrid_rrf",
+            max_steps=4,
+            initial_scale=6,
+        )
+
+        config.inject_retrieval_pipeline(retrieval_pipeline)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is retrieval_pipeline
+        assert kwargs["max_steps"] == 4
+        assert kwargs["initial_scale"] == 6
+
+
+class TestInteractRAGPipeline:
+    """Tests for INTERACT-RAG generation behavior."""
+
+    def test_initialization_rejects_invalid_steps(self):
+        with (
+            patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="max_steps must be >= 1"),
+        ):
+            InteractRAGPipeline(
+                session_factory=MagicMock(),
+                name="invalid_interact_rag",
+                llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                max_steps=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_runs_search_action_then_answer(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<semantic_search>apollo 11 landing</semantic_search>"),
+                _mock_response("<answer>Apollo 11 landed in 1969.</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 10, "score": 0.9, "content": "Apollo 11 landed in July 1969."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "When did Apollo 11 land?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=3, initial_scale=2)
+
+        result = await pipeline._generate(1, top_k=2)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("apollo 11 landing", 2)
+        assert result.text == "Apollo 11 landed in 1969."
+        assert result.metadata["retrieved_chunk_ids"] == [10]
+        assert result.metadata["evidence"] == ["Apollo 11 landed in July 1969."]
+        assert result.metadata["terminated_by"] == "answer"
+        assert result.token_usage == {"prompt_tokens": 4, "completion_tokens": 6, "total_tokens": 10}
+
+    @pytest.mark.asyncio
+    async def test_generate_applies_scale_and_exclude_controls(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<adjust_scale>4</adjust_scale>"),
+                _mock_response("<exclude_docs>2</exclude_docs>"),
+                _mock_response("<exact_search>target terms</exact_search>"),
+                _mock_response("fallback answer"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 2, "score": 0.9, "content": "excluded"},
+                {"doc_id": 3, "score": 0.8, "content": "kept"},
+            ]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(
+            llm,
+            retrieval_pipeline,
+            service,
+            max_steps=3,
+            initial_scale=1,
+            max_scale=5,
+        )
+
+        result = await pipeline._generate(1, top_k=1)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("exact: target terms", 4)
+        assert result.metadata["excluded_doc_ids"] == [2]
+        assert result.metadata["retrieved_chunk_ids"] == [3]
+        assert result.metadata["evidence"] == ["kept"]
+        assert result.metadata["terminated_by"] == "max_steps_fallback"
+
+    @pytest.mark.asyncio
+    async def test_generate_applies_include_docs_and_backfills_content(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<include_docs>5</include_docs>"),
+                _mock_response("<entity_match>Curie</entity_match>"),
+                _mock_response("<answer>Curie answer.</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(default_results=[{"doc_id": 6, "score": 0.8}])
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        service.get_chunk_contents.return_value = ["Forced evidence.", "Fetched evidence."]
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=3, initial_scale=2)
+
+        result = await pipeline._generate(1, top_k=2)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("entity: Curie", 2)
+        service.get_chunk_contents.assert_called_once_with([5, 6])
+        assert result.metadata["included_doc_ids"] == [5]
+        assert result.metadata["retrieved_chunk_ids"] == [5, 6]
+        assert result.metadata["evidence"] == ["Forced evidence.", "Fetched evidence."]


### PR DESCRIPTION
## Summary
- Adds a training-free INTERACT-RAG generation pipeline with corpus-interaction primitives: semantic/exact/weighted/entity retrieval actions, include/exclude document controls, retrieval scale adjustment, and final answer emission.
- Maps interaction primitives onto existing AutoRAG retrieval pipelines without adding new dependencies.
- Exports the pipeline, adds YAML config, and covers action parsing/config/interaction-state behavior in tests.

## Scope
- Implements the inference/evaluation workflow suitable for AutoRAG-Research.
- Does not add paper-scale SFT/RL trajectory training or a separate retrieval interaction service.

## Validation
- uv run pytest tests/autorag_research/pipelines/generation/test_interact_rag_pipeline.py -q
- uv sync --all-extras --all-groups
- make check

Closes #179

<!-- dani:stage=implementation;job=80e0e3a57f4470c21a5d6dd77fe0e06e;issue=179 -->
