### PR TITLE
Add Hybrid Deep Searcher generation pipeline

### DIFF
--- a/autorag_research/orm/repository/base.py
+++ b/autorag_research/orm/repository/base.py
@@ -569,17 +569,25 @@ class BaseEmbeddingRepository(GenericRepository[T]):
             stmt = stmt.limit(limit)
         return list(self.session.execute(stmt).scalars().all())
 
-    def get_without_embeddings(self, limit: int | None = None, offset: int | None = None) -> list[T]:
+    def get_without_embeddings(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        excluded_ids: set[int | str] | None = None,
+    ) -> list[T]:
         """Retrieve entities that do not have embeddings.
 
         Args:
             limit: Maximum number of results to return.
             offset: Number of results to skip.
+            excluded_ids: Entity IDs to exclude from the result set.
 
         Returns:
             List of entities without embeddings.
         """
         stmt = select(self.model_cls).where(self.model_cls.embedding.is_(None))  # ty: ignore[possibly-missing-attribute]
+        if excluded_ids:
+            stmt = stmt.where(self.model_cls.id.notin_(excluded_ids))  # ty: ignore[possibly-missing-attribute]
         return self._execute_with_offset_limit(stmt, limit, offset)
 
     def get_with_embeddings(self, limit: int | None = None, offset: int | None = None) -> list[T]:
@@ -595,17 +603,25 @@ class BaseEmbeddingRepository(GenericRepository[T]):
         stmt = select(self.model_cls).where(self.model_cls.embedding.is_not(None))  # ty: ignore[possibly-missing-attribute]
         return self._execute_with_offset_limit(stmt, limit, offset)
 
-    def get_without_multi_embeddings(self, limit: int | None = None, offset: int | None = None) -> list[T]:
+    def get_without_multi_embeddings(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        excluded_ids: set[int | str] | None = None,
+    ) -> list[T]:
         """Retrieve entities that do not have multi-vector embeddings.
 
         Args:
             limit: Maximum number of results to return.
             offset: Number of results to skip.
+            excluded_ids: Entity IDs to exclude from the result set.
 
         Returns:
             List of entities without multi-vector embeddings.
         """
         stmt = select(self.model_cls).where(self.model_cls.embeddings.is_(None))  # ty: ignore[possibly-missing-attribute]
+        if excluded_ids:
+            stmt = stmt.where(self.model_cls.id.notin_(excluded_ids))  # ty: ignore[possibly-missing-attribute]
         return self._execute_with_offset_limit(stmt, limit, offset)
 
     def get_with_multi_embeddings(self, limit: int | None = None, offset: int | None = None) -> list[T]:

--- a/autorag_research/orm/service/base_ingestion.py
+++ b/autorag_research/orm/service/base_ingestion.py
@@ -447,18 +447,16 @@ class BaseIngestionService(BaseService, ABC):
     ) -> list[tuple[int | str, Any]]:
         """Fetch the next batch of entities without embeddings, excluding `failed_ids`.
 
-        Over-fetches by `len(failed_ids)` so already-failed rows do not starve
-        the batch when they appear at the head of the database ordering.
+        Exclusion is pushed into the repository query so permanently failing
+        rows do not force an expanding over-fetch prefix on later iterations.
         """
         with self._create_uow() as uow:
             repository = getattr(uow, repo_attr, None)
             if repository is None:
                 raise RepositoryNotSupportedError(repo_attr, type(uow).__name__)
             fetch_method = getattr(repository, fetch_method_name)
-            entities = fetch_method(limit=batch_size + len(failed_ids))
-            if not entities:
-                return []
-            return [(e.id, getattr(e, data_attr)) for e in entities if e.id not in failed_ids]
+            entities = fetch_method(limit=batch_size, excluded_ids=failed_ids)
+            return [(e.id, getattr(e, data_attr)) for e in entities]
 
     def _embed_batch(
         self,

--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -7,6 +7,10 @@ from autorag_research.pipelines.generation.et2rag import (
     ET2RAGPipelineConfig,
     OrganizationStrategy,
 )
+from autorag_research.pipelines.generation.hybrid_deep_searcher import (
+    HybridDeepSearcherPipeline,
+    HybridDeepSearcherPipelineConfig,
+)
 from autorag_research.pipelines.generation.ircot import IRCoTGenerationPipeline, IRCoTGenerationPipelineConfig
 from autorag_research.pipelines.generation.main_rag import MAINRAGPipeline
 from autorag_research.pipelines.generation.question_decomposition import (
@@ -32,6 +36,8 @@ __all__ = [
     "BasicRAGPipelineConfig",
     "ET2RAGPipeline",
     "ET2RAGPipelineConfig",
+    "HybridDeepSearcherPipeline",
+    "HybridDeepSearcherPipelineConfig",
     "IRCoTGenerationPipeline",
     "IRCoTGenerationPipelineConfig",
     "MAINRAGPipeline",

--- a/autorag_research/pipelines/generation/hybrid_deep_searcher.py
+++ b/autorag_research/pipelines/generation/hybrid_deep_searcher.py
@@ -1,0 +1,347 @@
+"""Hybrid Deep Searcher generation pipeline for AutoRAG-Research.
+
+This pipeline implements a practical inference-only Hybrid Deep Searcher (HDS)
+baseline: an LLM alternates sequential reasoning with parallel fan-out query
+proposal, retrieves evidence for those subqueries through an existing retrieval
+pipeline, merges/deduplicates evidence, and either refines the search or emits a
+final answer.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker, run_with_concurrency_limit
+
+logger = logging.getLogger("AutoRAG-Research")
+
+DEFAULT_HDS_PLAN_PROMPT = """You are a Hybrid Deep Searcher agent.
+Combine parallel exploration with sequential reasoning. At each turn, either:
+- propose multiple parallel search queries inside <queries>...</queries>, one query per line, or
+- finish with <answer>final answer</answer>.
+
+Question:
+{query}
+
+Turn: {turn}/{max_turns}
+Evidence gathered so far:
+{evidence}
+
+Reasoning trace:
+{trace}
+
+Next action:"""
+
+DEFAULT_HDS_FINAL_PROMPT = """Answer the question using the Hybrid Deep Searcher evidence and reasoning trace.
+
+Question:
+{query}
+
+Evidence:
+{evidence}
+
+Reasoning trace:
+{trace}
+
+Final answer:"""
+
+_ANSWER_RE = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.IGNORECASE | re.DOTALL)
+_QUERIES_RE = re.compile(r"<queries>\s*(.*?)\s*</queries>", re.IGNORECASE | re.DOTALL)
+_QUERY_PREFIX_RE = re.compile(r"^\s*(?:[-*•]|\d+[.)]|query\s*\d*\s*:|[A-Za-z][.)])\s*", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class HybridDeepSearchAction:
+    """Parsed Hybrid Deep Searcher action."""
+
+    kind: str
+    text: str = ""
+    queries: tuple[str, ...] = ()
+
+
+def parse_hybrid_deep_search_action(response_text: str, max_queries: int) -> HybridDeepSearchAction:
+    """Parse an HDS answer or parallel-query action."""
+    answer_match = _ANSWER_RE.search(response_text)
+    if answer_match is not None:
+        return HybridDeepSearchAction(kind="answer", text=answer_match.group(1).strip())
+
+    queries_match = _QUERIES_RE.search(response_text)
+    query_block = queries_match.group(1) if queries_match is not None else response_text
+    queries: list[str] = []
+    for line in query_block.splitlines():
+        cleaned = _QUERY_PREFIX_RE.sub("", line).strip()
+        if cleaned and cleaned not in queries:
+            queries.append(cleaned)
+        if len(queries) >= max_queries:
+            break
+
+    if queries:
+        return HybridDeepSearchAction(kind="queries", queries=tuple(queries))
+
+    return HybridDeepSearchAction(kind="answer", text=response_text.strip())
+
+
+@dataclass(kw_only=True)
+class HybridDeepSearcherPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for the Hybrid Deep Searcher generation pipeline."""
+
+    plan_prompt_template: str = field(default=DEFAULT_HDS_PLAN_PROMPT)
+    final_prompt_template: str = field(default=DEFAULT_HDS_FINAL_PROMPT)
+    max_turns: int = 3
+    max_parallel_queries: int = 4
+    k_per_query: int = 3
+    evidence_budget: int = 12
+    retrieval_concurrency: int = 4
+    fallback_to_final_prompt: bool = True
+
+    def get_pipeline_class(self) -> type[HybridDeepSearcherPipeline]:
+        """Return the HybridDeepSearcherPipeline class."""
+        return HybridDeepSearcherPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for HybridDeepSearcherPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "plan_prompt_template": self.plan_prompt_template,
+            "final_prompt_template": self.final_prompt_template,
+            "max_turns": self.max_turns,
+            "max_parallel_queries": self.max_parallel_queries,
+            "k_per_query": self.k_per_query,
+            "evidence_budget": self.evidence_budget,
+            "retrieval_concurrency": self.retrieval_concurrency,
+            "fallback_to_final_prompt": self.fallback_to_final_prompt,
+        }
+
+
+class HybridDeepSearcherPipeline(BaseGenerationPipeline):
+    """Generation pipeline that mixes parallel fan-out search with sequential reasoning."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        plan_prompt_template: str = DEFAULT_HDS_PLAN_PROMPT,
+        final_prompt_template: str = DEFAULT_HDS_FINAL_PROMPT,
+        max_turns: int = 3,
+        max_parallel_queries: int = 4,
+        k_per_query: int = 3,
+        evidence_budget: int = 12,
+        retrieval_concurrency: int = 4,
+        fallback_to_final_prompt: bool = True,
+        schema: Any | None = None,
+    ):
+        """Initialize Hybrid Deep Searcher."""
+        if max_turns < 1:
+            msg = "max_turns must be >= 1"
+            raise ValueError(msg)
+        if max_parallel_queries < 1:
+            msg = "max_parallel_queries must be >= 1"
+            raise ValueError(msg)
+        if k_per_query < 1:
+            msg = "k_per_query must be >= 1"
+            raise ValueError(msg)
+        if evidence_budget < 1 or retrieval_concurrency < 1:
+            msg = "evidence_budget and retrieval_concurrency must be >= 1"
+            raise ValueError(msg)
+
+        self.plan_prompt_template = plan_prompt_template
+        self.final_prompt_template = final_prompt_template
+        self.max_turns = max_turns
+        self.max_parallel_queries = max_parallel_queries
+        self.k_per_query = k_per_query
+        self.evidence_budget = evidence_budget
+        self.retrieval_concurrency = retrieval_concurrency
+        self.fallback_to_final_prompt = fallback_to_final_prompt
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return HDS pipeline configuration."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+        return {
+            "type": "hybrid_deep_searcher",
+            "plan_prompt_template": self.plan_prompt_template,
+            "final_prompt_template": self.final_prompt_template,
+            "max_turns": self.max_turns,
+            "max_parallel_queries": self.max_parallel_queries,
+            "k_per_query": self.k_per_query,
+            "evidence_budget": self.evidence_budget,
+            "retrieval_concurrency": self.retrieval_concurrency,
+            "fallback_to_final_prompt": self.fallback_to_final_prompt,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract response text."""
+        return response.content if hasattr(response, "content") else str(response)
+
+    @staticmethod
+    def _format_evidence(evidence: list[str]) -> str:
+        """Format evidence list for prompts."""
+        if not evidence:
+            return "(none)"
+        return "\n\n".join(f"[{index + 1}] {item}" for index, item in enumerate(evidence))
+
+    @staticmethod
+    def _format_trace(trace: list[str]) -> str:
+        """Format search trace for prompts."""
+        return "\n".join(trace) if trace else "(none)"
+
+    def _build_plan_prompt(self, query: str, evidence: list[str], trace: list[str], turn: int) -> str:
+        """Build one sequential HDS planning prompt."""
+        return self.plan_prompt_template.format(
+            query=query,
+            evidence=self._format_evidence(evidence),
+            trace=self._format_trace(trace),
+            turn=turn,
+            max_turns=self.max_turns,
+        )
+
+    def _build_final_prompt(self, query: str, evidence: list[str], trace: list[str]) -> str:
+        """Build fallback final-answer prompt."""
+        return self.final_prompt_template.format(
+            query=query,
+            evidence=self._format_evidence(evidence),
+            trace=self._format_trace(trace),
+        )
+
+    def _contents_from_results(self, results: list[dict[str, Any]]) -> tuple[list[int | str], list[str]]:
+        """Extract IDs and contents, backfilling missing chunk text."""
+        doc_ids: list[int | str] = []
+        contents: list[str | None] = []
+        missing_positions: list[int] = []
+        missing_ids: list[int | str] = []
+        for result in results:
+            doc_id = result.get("doc_id")
+            if doc_id is None:
+                continue
+            doc_ids.append(doc_id)
+            content = result.get("content")
+            if content:
+                contents.append(str(content))
+            else:
+                missing_positions.append(len(contents))
+                missing_ids.append(doc_id)
+                contents.append(None)
+        if missing_ids:
+            fetched_contents = self._service.get_chunk_contents(missing_ids)
+            for position, fetched_content in zip(missing_positions, fetched_contents, strict=False):
+                contents[position] = fetched_content
+        return doc_ids, [content or "" for content in contents]
+
+    async def _retrieve_query(self, query_and_k: tuple[str, int]) -> list[dict[str, Any]]:
+        """Retrieve evidence for one fan-out query."""
+        query, top_k = query_and_k
+        return await self._retrieval_pipeline.retrieve(query, top_k)
+
+    async def _retrieve_parallel(self, queries: tuple[str, ...], top_k: int) -> list[list[dict[str, Any]]]:
+        """Retrieve multiple fan-out queries with bounded concurrency."""
+        results = await run_with_concurrency_limit(
+            [(query, top_k) for query in queries],
+            self._retrieve_query,
+            max_concurrency=min(self.retrieval_concurrency, len(queries)),
+            error_message="Hybrid Deep Searcher retrieval failed",
+        )
+        return [result for result in results if result is not None]
+
+    @staticmethod
+    def _merge_results(result_sets: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+        """Merge retrieval results by doc_id, keeping the highest score."""
+        merged: dict[int | str, dict[str, Any]] = {}
+        for result_set in result_sets:
+            for result in result_set:
+                doc_id = result.get("doc_id")
+                if doc_id is None:
+                    continue
+                score = result.get("score", 0.0)
+                score_value = float(score) if isinstance(score, (int, float)) else 0.0
+                existing = merged.get(doc_id)
+                if existing is None or score_value > float(existing.get("score", 0.0)):
+                    merged[doc_id] = {**result, "score": score_value}
+        return sorted(merged.values(), key=lambda item: (-float(item.get("score", 0.0)), str(item.get("doc_id"))))
+
+    def _append_evidence(self, evidence: list[str], new_contents: list[str]) -> list[str]:
+        """Append deduplicated evidence within evidence budget."""
+        updated = list(evidence)
+        for content in new_contents:
+            if content and content not in updated:
+                updated.append(content)
+        return updated[-self.evidence_budget :]
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate an answer with parallel fan-out search and sequential refinement."""
+        query_text = self._service.get_query_text(query_id)
+        tracker = TokenUsageTracker()
+        evidence: list[str] = []
+        trace: list[str] = []
+        retrieved_doc_ids: list[int | str] = []
+        final_answer = ""
+        terminated_by = "max_turns"
+        for turn in range(1, self.max_turns + 1):
+            plan_prompt = self._build_plan_prompt(query_text, evidence, trace, turn)
+            response = await self._llm.ainvoke(plan_prompt)
+            tracker.record(response)
+            action = parse_hybrid_deep_search_action(self._extract_text(response), self.max_parallel_queries)
+            if action.kind == "answer":
+                final_answer = action.text
+                trace.append(f"answer: {final_answer}")
+                terminated_by = "answer"
+                break
+
+            trace.append(f"turn {turn} queries: {' | '.join(action.queries)}")
+            effective_k = max(1, min(top_k, self.k_per_query)) if top_k > 0 else self.k_per_query
+            result_sets = await self._retrieve_parallel(action.queries, effective_k)
+            merged_results = self._merge_results(result_sets)
+            doc_ids, contents = self._contents_from_results(merged_results)
+            for doc_id in doc_ids:
+                if doc_id not in retrieved_doc_ids:
+                    retrieved_doc_ids.append(doc_id)
+            evidence = self._append_evidence(evidence, contents)
+
+        if not final_answer and self.fallback_to_final_prompt:
+            final_prompt = self._build_final_prompt(query_text, evidence, trace)
+            final_response = await self._llm.ainvoke(final_prompt)
+            tracker.record(final_response)
+            final_answer = self._extract_text(final_response)
+            terminated_by = f"{terminated_by}_fallback"
+
+        return GenerationResult(
+            text=final_answer,
+            token_usage=tracker.total,
+            metadata={
+                "trace": trace,
+                "evidence": evidence,
+                "retrieved_chunk_ids": retrieved_doc_ids,
+                "terminated_by": terminated_by,
+            },
+        )
+
+
+__all__ = [
+    "DEFAULT_HDS_FINAL_PROMPT",
+    "DEFAULT_HDS_PLAN_PROMPT",
+    "HybridDeepSearchAction",
+    "HybridDeepSearcherPipeline",
+    "HybridDeepSearcherPipelineConfig",
+    "parse_hybrid_deep_search_action",
+]

--- a/autorag_research/pipelines/generation/hybrid_deep_searcher.py
+++ b/autorag_research/pipelines/generation/hybrid_deep_searcher.py
@@ -86,6 +86,16 @@ class HybridDeepSearchRetrievalResult:
     failure: HybridDeepSearchRetrievalFailure | None = None
 
 
+def _sanitize_retrieval_error(exc: Exception) -> str:
+    """Return a persistence-safe retrieval error summary.
+
+    Full backend exceptions remain available in logs via ``logger.exception``.
+    Result metadata is durable and user-visible, so it stores only the exception
+    type plus a controlled message instead of raw DSNs, SQL, payloads, or keys.
+    """
+    return f"{type(exc).__name__}: retrieval failed"
+
+
 def parse_hybrid_deep_search_action(response_text: str, max_queries: int) -> HybridDeepSearchAction:
     """Parse an HDS answer or parallel-query action."""
     answer_match = _ANSWER_RE.search(response_text)
@@ -283,7 +293,7 @@ class HybridDeepSearcherPipeline(BaseGenerationPipeline):
             logger.exception("Hybrid Deep Searcher retrieval failed for generated query: %s", query)
             return HybridDeepSearchRetrievalResult(
                 query=query,
-                failure=HybridDeepSearchRetrievalFailure(query=query, error=str(exc)),
+                failure=HybridDeepSearchRetrievalFailure(query=query, error=_sanitize_retrieval_error(exc)),
             )
 
     async def _retrieve_parallel(

--- a/autorag_research/pipelines/generation/hybrid_deep_searcher.py
+++ b/autorag_research/pipelines/generation/hybrid_deep_searcher.py
@@ -69,6 +69,23 @@ class HybridDeepSearchAction:
     queries: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class HybridDeepSearchRetrievalFailure:
+    """Failure details for one fan-out retrieval query."""
+
+    query: str
+    error: str
+
+
+@dataclass(frozen=True)
+class HybridDeepSearchRetrievalResult:
+    """Result envelope for one fan-out retrieval query."""
+
+    query: str
+    results: list[dict[str, Any]] = field(default_factory=list)
+    failure: HybridDeepSearchRetrievalFailure | None = None
+
+
 def parse_hybrid_deep_search_action(response_text: str, max_queries: int) -> HybridDeepSearchAction:
     """Parse an HDS answer or parallel-query action."""
     answer_match = _ANSWER_RE.search(response_text)
@@ -103,6 +120,7 @@ class HybridDeepSearcherPipelineConfig(BaseGenerationPipelineConfig):
     evidence_budget: int = 12
     retrieval_concurrency: int = 4
     fallback_to_final_prompt: bool = True
+    allow_partial_retrieval_failures: bool = False
 
     def get_pipeline_class(self) -> type[HybridDeepSearcherPipeline]:
         """Return the HybridDeepSearcherPipeline class."""
@@ -124,6 +142,7 @@ class HybridDeepSearcherPipelineConfig(BaseGenerationPipelineConfig):
             "evidence_budget": self.evidence_budget,
             "retrieval_concurrency": self.retrieval_concurrency,
             "fallback_to_final_prompt": self.fallback_to_final_prompt,
+            "allow_partial_retrieval_failures": self.allow_partial_retrieval_failures,
         }
 
 
@@ -144,6 +163,7 @@ class HybridDeepSearcherPipeline(BaseGenerationPipeline):
         evidence_budget: int = 12,
         retrieval_concurrency: int = 4,
         fallback_to_final_prompt: bool = True,
+        allow_partial_retrieval_failures: bool = False,
         schema: Any | None = None,
     ):
         """Initialize Hybrid Deep Searcher."""
@@ -168,6 +188,7 @@ class HybridDeepSearcherPipeline(BaseGenerationPipeline):
         self.evidence_budget = evidence_budget
         self.retrieval_concurrency = retrieval_concurrency
         self.fallback_to_final_prompt = fallback_to_final_prompt
+        self.allow_partial_retrieval_failures = allow_partial_retrieval_failures
 
         super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
 
@@ -186,6 +207,7 @@ class HybridDeepSearcherPipeline(BaseGenerationPipeline):
             "evidence_budget": self.evidence_budget,
             "retrieval_concurrency": self.retrieval_concurrency,
             "fallback_to_final_prompt": self.fallback_to_final_prompt,
+            "allow_partial_retrieval_failures": self.allow_partial_retrieval_failures,
             "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
             "llm_model": model_name,
         }
@@ -249,20 +271,49 @@ class HybridDeepSearcherPipeline(BaseGenerationPipeline):
                 contents[position] = fetched_content
         return doc_ids, [content or "" for content in contents]
 
-    async def _retrieve_query(self, query_and_k: tuple[str, int]) -> list[dict[str, Any]]:
+    async def _retrieve_query(self, query_and_k: tuple[str, int]) -> HybridDeepSearchRetrievalResult:
         """Retrieve evidence for one fan-out query."""
         query, top_k = query_and_k
-        return await self._retrieval_pipeline.retrieve(query, top_k)
+        try:
+            return HybridDeepSearchRetrievalResult(
+                query=query,
+                results=await self._retrieval_pipeline.retrieve(query, top_k),
+            )
+        except Exception as exc:
+            logger.exception("Hybrid Deep Searcher retrieval failed for generated query: %s", query)
+            return HybridDeepSearchRetrievalResult(
+                query=query,
+                failure=HybridDeepSearchRetrievalFailure(query=query, error=str(exc)),
+            )
 
-    async def _retrieve_parallel(self, queries: tuple[str, ...], top_k: int) -> list[list[dict[str, Any]]]:
+    async def _retrieve_parallel(
+        self,
+        queries: tuple[str, ...],
+        top_k: int,
+    ) -> tuple[list[list[dict[str, Any]]], list[HybridDeepSearchRetrievalFailure]]:
         """Retrieve multiple fan-out queries with bounded concurrency."""
-        results = await run_with_concurrency_limit(
+        outcomes = await run_with_concurrency_limit(
             [(query, top_k) for query in queries],
             self._retrieve_query,
             max_concurrency=min(self.retrieval_concurrency, len(queries)),
             error_message="Hybrid Deep Searcher retrieval failed",
         )
-        return [result for result in results if result is not None]
+        result_sets: list[list[dict[str, Any]]] = []
+        failures: list[HybridDeepSearchRetrievalFailure] = []
+        for query, outcome in zip(queries, outcomes, strict=False):
+            if outcome is None:
+                failures.append(HybridDeepSearchRetrievalFailure(query=query, error="unknown retrieval error"))
+            elif outcome.failure is not None:
+                failures.append(outcome.failure)
+            else:
+                result_sets.append(outcome.results)
+
+        if failures and not self.allow_partial_retrieval_failures:
+            failure_summary = "; ".join(f"{failure.query}: {failure.error}" for failure in failures)
+            msg = f"Hybrid Deep Searcher retrieval failed for {len(failures)} fan-out query(s): {failure_summary}"
+            raise RuntimeError(msg)
+
+        return result_sets, failures
 
     @staticmethod
     def _merge_results(result_sets: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
@@ -295,6 +346,7 @@ class HybridDeepSearcherPipeline(BaseGenerationPipeline):
         evidence: list[str] = []
         trace: list[str] = []
         retrieved_doc_ids: list[int | str] = []
+        retrieval_failures: list[HybridDeepSearchRetrievalFailure] = []
         final_answer = ""
         terminated_by = "max_turns"
         for turn in range(1, self.max_turns + 1):
@@ -310,7 +362,8 @@ class HybridDeepSearcherPipeline(BaseGenerationPipeline):
 
             trace.append(f"turn {turn} queries: {' | '.join(action.queries)}")
             effective_k = max(1, min(top_k, self.k_per_query)) if top_k > 0 else self.k_per_query
-            result_sets = await self._retrieve_parallel(action.queries, effective_k)
+            result_sets, failures = await self._retrieve_parallel(action.queries, effective_k)
+            retrieval_failures.extend(failures)
             merged_results = self._merge_results(result_sets)
             doc_ids, contents = self._contents_from_results(merged_results)
             for doc_id in doc_ids:
@@ -332,6 +385,9 @@ class HybridDeepSearcherPipeline(BaseGenerationPipeline):
                 "trace": trace,
                 "evidence": evidence,
                 "retrieved_chunk_ids": retrieved_doc_ids,
+                "retrieval_failures": [
+                    {"query": failure.query, "error": failure.error} for failure in retrieval_failures
+                ],
                 "terminated_by": terminated_by,
             },
         )
@@ -341,6 +397,8 @@ __all__ = [
     "DEFAULT_HDS_FINAL_PROMPT",
     "DEFAULT_HDS_PLAN_PROMPT",
     "HybridDeepSearchAction",
+    "HybridDeepSearchRetrievalFailure",
+    "HybridDeepSearchRetrievalResult",
     "HybridDeepSearcherPipeline",
     "HybridDeepSearcherPipelineConfig",
     "parse_hybrid_deep_search_action",

--- a/configs/llm/openai-gpt4o-mini.yaml
+++ b/configs/llm/openai-gpt4o-mini.yaml
@@ -1,0 +1,5 @@
+# OpenAI GPT-4o Mini
+# pip install langchain-openai
+_target_: langchain_openai.ChatOpenAI
+model: gpt-4o-mini
+api_key: ${oc.env:OPENAI_API_KEY}

--- a/configs/pipelines/generation/hybrid_deep_searcher.yaml
+++ b/configs/pipelines/generation/hybrid_deep_searcher.yaml
@@ -1,7 +1,7 @@
 _target_: autorag_research.pipelines.generation.hybrid_deep_searcher.HybridDeepSearcherPipelineConfig
 description: "Hybrid Deep Searcher generation pipeline with parallel fan-out and sequential refinement"
 name: hybrid_deep_searcher
-retrieval_pipeline_name: hybrid_rrf
+retrieval_pipeline_name: bm25
 llm: openai-gpt4o-mini
 max_turns: 3
 max_parallel_queries: 4
@@ -9,6 +9,7 @@ k_per_query: 3
 evidence_budget: 12
 retrieval_concurrency: 4
 fallback_to_final_prompt: true
+allow_partial_retrieval_failures: false
 top_k: 3
 batch_size: 32
 max_concurrency: 4

--- a/configs/pipelines/generation/hybrid_deep_searcher.yaml
+++ b/configs/pipelines/generation/hybrid_deep_searcher.yaml
@@ -1,0 +1,16 @@
+_target_: autorag_research.pipelines.generation.hybrid_deep_searcher.HybridDeepSearcherPipelineConfig
+description: "Hybrid Deep Searcher generation pipeline with parallel fan-out and sequential refinement"
+name: hybrid_deep_searcher
+retrieval_pipeline_name: hybrid_rrf
+llm: openai-gpt4o-mini
+max_turns: 3
+max_parallel_queries: 4
+k_per_query: 3
+evidence_budget: 12
+retrieval_concurrency: 4
+fallback_to_final_prompt: true
+top_k: 3
+batch_size: 32
+max_concurrency: 4
+max_retries: 3
+retry_delay: 1.0

--- a/docs/pipelines/generation/hybrid-deep-searcher.md
+++ b/docs/pipelines/generation/hybrid-deep-searcher.md
@@ -1,0 +1,36 @@
+# Hybrid Deep Searcher
+
+Hybrid Deep Searcher (HDS) is an inference-only generation baseline that alternates sequential LLM planning with
+parallel fan-out retrieval. At each turn, the LLM proposes subqueries, the configured retrieval pipeline gathers
+evidence for those subqueries, and HDS merges/deduplicates evidence before either continuing or producing an answer.
+
+```yaml
+_target_: autorag_research.pipelines.generation.hybrid_deep_searcher.HybridDeepSearcherPipelineConfig
+name: hybrid_deep_searcher
+retrieval_pipeline_name: bm25
+llm: openai-gpt4o-mini
+max_turns: 3
+max_parallel_queries: 4
+retrieval_concurrency: 4
+```
+
+## Retrieval backend expectations
+
+HDS sends LLM-generated subqueries directly to `retrieval_pipeline.retrieve(...)`. The retriever must therefore be
+text-query-capable for strings that are not already rows in the query table. The shipped example uses `bm25` because it
+can retrieve from generated text without an embedding model. If you switch to vector or hybrid retrieval, configure an
+embedding-capable text path first.
+
+## Concurrency
+
+HDS has bounded logical fan-out. Effective retrieval pressure is approximately:
+
+`generation max_concurrency x retrieval_concurrency`
+
+Retriever-internal fan-out can multiply that further. Start with conservative values for larger datasets or shared
+databases, then raise the limits only after observing database and provider capacity.
+
+## Scope
+
+This pipeline is meant for inference/evaluation comparisons with other generation baselines such as IRCoT and question
+decomposition. It does not implement HDS-specific training infrastructure or paper-scale benchmark reproduction.

--- a/docs/pipelines/generation/index.md
+++ b/docs/pipelines/generation/index.md
@@ -7,6 +7,7 @@ Algorithms that take a query and retrieved documents to generate an answer.
 | Pipeline | Algorithm |
 |----------|-----------|
 | [BasicRAG](basic-rag.md) | Single retrieve + generate |
+| [HybridDeepSearcher](hybrid-deep-searcher.md) | Sequential planning with parallel fan-out retrieval |
 | [IRCoT](ircot.md) | Iterative retrieve + chain-of-thought reasoning |
 | [SelfRAG](self-rag.md) | Draft, critique, retrieve, and revise adaptively |
 

--- a/tests/autorag_research/orm/service/test_base_ingestion.py
+++ b/tests/autorag_research/orm/service/test_base_ingestion.py
@@ -21,6 +21,47 @@ class ConcreteTestIngestionService(BaseIngestionService):
         }
 
 
+class _FakeEntity:
+    def __init__(self, entity_id: int, contents: str):
+        self.id = entity_id
+        self.contents = contents
+
+
+class _FakeEmbeddingRepository:
+    def __init__(self):
+        self.calls: list[dict[str, object]] = []
+
+    def get_without_embeddings(self, *, limit: int, excluded_ids: set[int | str]):
+        self.calls.append({"limit": limit, "excluded_ids": set(excluded_ids)})
+        return [
+            _FakeEntity(entity_id, f"content {entity_id}")
+            for entity_id in range(1, 101)
+            if entity_id not in excluded_ids
+        ][:limit]
+
+
+class _FakeUow:
+    def __init__(self, repository: _FakeEmbeddingRepository):
+        self.queries = repository
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class _FakeIngestionService(BaseIngestionService):
+    def __init__(self, repository: _FakeEmbeddingRepository):
+        self.repository = repository
+
+    def _create_uow(self):
+        return _FakeUow(self.repository)
+
+    def _get_schema_classes(self) -> dict[str, type]:
+        return {}
+
+
 class TestBaseIngestionService:
     @pytest.fixture
     def service(self, session_factory):
@@ -342,6 +383,28 @@ class TestBaseIngestionService:
                         uow.queries.delete(entity)
                 uow.commit()
             _restore_unembedded_queries(service, snapshots)
+
+    def test_fetch_unembedded_batch_excludes_failed_ids_without_overfetching(self):
+        """Failed embedding IDs should be excluded by the repository inside a bounded batch query."""
+        repository = _FakeEmbeddingRepository()
+        service = _FakeIngestionService(repository)
+
+        items = service._fetch_unembedded_batch(
+            repo_attr="queries",
+            fetch_method_name="get_without_embeddings",
+            data_attr="contents",
+            batch_size=5,
+            failed_ids=set(range(1, 51)),
+        )
+
+        assert items == [
+            (51, "content 51"),
+            (52, "content 52"),
+            (53, "content 53"),
+            (54, "content 54"),
+            (55, "content 55"),
+        ]
+        assert repository.calls == [{"limit": 5, "excluded_ids": set(range(1, 51))}]
 
 
 def _snapshot_unembedded_queries(service: BaseIngestionService) -> list[int]:

--- a/tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py
@@ -1,11 +1,15 @@
 """Tests for Hybrid Deep Searcher generation pipeline."""
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from hydra.utils import instantiate
 from langchain_core.language_models.fake import FakeListLLM
+from omegaconf import OmegaConf
 
+from autorag_research.orm.service.generation_pipeline import GenerationResult
 from autorag_research.pipelines.generation.hybrid_deep_searcher import (
     HybridDeepSearcherPipeline,
     HybridDeepSearcherPipelineConfig,
@@ -35,6 +39,11 @@ def _build_unit_pipeline(llm: Any, retrieval_pipeline: Any, service: Any, **kwar
     pipeline._service = service
     pipeline.pipeline_id = 1
     return pipeline
+
+
+def _metadata(result: GenerationResult) -> dict[str, Any]:
+    assert result.metadata is not None
+    return result.metadata
 
 
 class TestHybridDeepSearchActionParsing:
@@ -99,6 +108,20 @@ class TestHybridDeepSearcherPipelineConfig:
         assert kwargs["max_turns"] == 4
         assert kwargs["max_parallel_queries"] == 3
 
+    def test_default_yaml_config_uses_text_query_capable_retriever(self):
+        config_path = Path("configs/pipelines/generation/hybrid_deep_searcher.yaml")
+        with patch("autorag_research.injection.load_llm", return_value=FakeListLLM(responses=["<answer>ok</answer>"])):
+            config = instantiate(OmegaConf.load(config_path))
+
+        assert isinstance(config, HybridDeepSearcherPipelineConfig)
+        assert config.retrieval_pipeline_name == "bm25"
+
+        retrieval_pipeline = create_mock_retrieval_pipeline(pipeline_id=89)
+        config.inject_retrieval_pipeline(retrieval_pipeline)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["retrieval_pipeline"] is retrieval_pipeline
+
 
 class TestHybridDeepSearcherPipeline:
     """Tests for HDS generation behavior."""
@@ -141,8 +164,9 @@ class TestHybridDeepSearcherPipeline:
         retrieval_pipeline.retrieve.assert_any_await("moon origin", 2)
         retrieval_pipeline.retrieve.assert_any_await("moon composition", 2)
         assert result.text == "The Moon likely formed from giant-impact debris."
-        assert result.metadata["retrieved_chunk_ids"] == [1, 2]
-        assert result.metadata["terminated_by"] == "answer"
+        metadata = _metadata(result)
+        assert metadata["retrieved_chunk_ids"] == [1, 2]
+        assert metadata["terminated_by"] == "answer"
         assert result.token_usage == {"prompt_tokens": 4, "completion_tokens": 6, "total_tokens": 10}
 
     @pytest.mark.asyncio
@@ -168,9 +192,10 @@ class TestHybridDeepSearcherPipeline:
         result = await pipeline._generate(1, top_k=3)
 
         assert result.text == "fallback answer"
-        assert result.metadata["retrieved_chunk_ids"] == [1]
-        assert result.metadata["evidence"] == ["high"]
-        assert result.metadata["terminated_by"] == "max_turns_fallback"
+        metadata = _metadata(result)
+        assert metadata["retrieved_chunk_ids"] == [1]
+        assert metadata["evidence"] == ["high"]
+        assert metadata["terminated_by"] == "max_turns_fallback"
 
     @pytest.mark.asyncio
     async def test_generate_backfills_missing_contents(self):
@@ -190,4 +215,53 @@ class TestHybridDeepSearcherPipeline:
         result = await pipeline._generate(1, top_k=1)
 
         service.get_chunk_contents.assert_called_once_with([7])
-        assert result.metadata["evidence"] == ["Fetched content."]
+        metadata = _metadata(result)
+        assert metadata["evidence"] == ["Fetched content."]
+
+    @pytest.mark.asyncio
+    async def test_generate_raises_when_fanout_retrieval_fails_by_default(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(return_value=_mock_response("<queries>\nbroken generated subquery\n</queries>"))
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline.retrieve = AsyncMock(side_effect=RuntimeError("retriever unavailable"))
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_turns=1)
+
+        with pytest.raises(RuntimeError, match="Hybrid Deep Searcher retrieval failed"):
+            await pipeline._generate(1, top_k=1)
+
+    @pytest.mark.asyncio
+    async def test_generate_records_partial_retrieval_failures_when_allowed(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<queries>\nok generated subquery\nbroken generated subquery\n</queries>"),
+                _mock_response("fallback with partial evidence"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline.retrieve = AsyncMock(
+            side_effect=[
+                [{"doc_id": 11, "score": 0.7, "content": "usable evidence"}],
+                RuntimeError("retriever unavailable"),
+            ]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(
+            llm,
+            retrieval_pipeline,
+            service,
+            max_turns=1,
+            allow_partial_retrieval_failures=True,
+        )
+
+        result = await pipeline._generate(1, top_k=1)
+
+        assert result.text == "fallback with partial evidence"
+        metadata = _metadata(result)
+        assert metadata["evidence"] == ["usable evidence"]
+        assert metadata["retrieval_failures"] == [
+            {"query": "broken generated subquery", "error": "retriever unavailable"}
+        ]

--- a/tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py
@@ -1,0 +1,193 @@
+"""Tests for Hybrid Deep Searcher generation pipeline."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from autorag_research.pipelines.generation.hybrid_deep_searcher import (
+    HybridDeepSearcherPipeline,
+    HybridDeepSearcherPipelineConfig,
+    parse_hybrid_deep_search_action,
+)
+from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_retrieval_pipeline
+
+
+def _mock_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
+    return response
+
+
+def _build_unit_pipeline(llm: Any, retrieval_pipeline: Any, service: Any, **kwargs: Any) -> HybridDeepSearcherPipeline:
+    with patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None):
+        pipeline = HybridDeepSearcherPipeline(
+            session_factory=MagicMock(),
+            name="hds_unit",
+            llm=llm,
+            retrieval_pipeline=retrieval_pipeline,
+            **kwargs,
+        )
+    pipeline._llm = llm
+    pipeline._retrieval_pipeline = retrieval_pipeline
+    pipeline._service = service
+    pipeline.pipeline_id = 1
+    return pipeline
+
+
+class TestHybridDeepSearchActionParsing:
+    """Tests for action parsing."""
+
+    def test_parse_parallel_queries(self):
+        action = parse_hybrid_deep_search_action("<queries>\n1. alpha\n- beta\n</queries>", max_queries=4)
+
+        assert action.kind == "queries"
+        assert action.queries == ("alpha", "beta")
+
+    def test_parse_limits_queries(self):
+        action = parse_hybrid_deep_search_action("<queries>\na\nb\nc\n</queries>", max_queries=2)
+
+        assert action.queries == ("a", "b")
+
+    def test_parse_answer(self):
+        action = parse_hybrid_deep_search_action("<answer>done</answer>", max_queries=2)
+
+        assert action.kind == "answer"
+        assert action.text == "done"
+
+
+class TestHybridDeepSearcherPipelineConfig:
+    """Tests for HybridDeepSearcherPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        config = HybridDeepSearcherPipelineConfig(
+            name="hybrid_deep_searcher",
+            llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+            retrieval_pipeline_name="hybrid_rrf",
+        )
+
+        assert config.get_pipeline_class() == HybridDeepSearcherPipeline
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        config = HybridDeepSearcherPipelineConfig(
+            name="hybrid_deep_searcher",
+            llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+            retrieval_pipeline_name="hybrid_rrf",
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        retrieval_pipeline = create_mock_retrieval_pipeline(pipeline_id=88)
+        llm = FakeListLLM(responses=["<answer>ok</answer>"])
+        config = HybridDeepSearcherPipelineConfig(
+            name="hybrid_deep_searcher",
+            llm=llm,
+            retrieval_pipeline_name="hybrid_rrf",
+            max_turns=4,
+            max_parallel_queries=3,
+        )
+
+        config.inject_retrieval_pipeline(retrieval_pipeline)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is retrieval_pipeline
+        assert kwargs["max_turns"] == 4
+        assert kwargs["max_parallel_queries"] == 3
+
+
+class TestHybridDeepSearcherPipeline:
+    """Tests for HDS generation behavior."""
+
+    def test_initialization_rejects_invalid_turns(self):
+        with (
+            patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="max_turns must be >= 1"),
+        ):
+            HybridDeepSearcherPipeline(
+                session_factory=MagicMock(),
+                name="invalid_hds",
+                llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                max_turns=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_parallel_search_then_answer(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<queries>\nmoon origin\nmoon composition\n</queries>"),
+                _mock_response("<answer>The Moon likely formed from giant-impact debris.</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline.retrieve = AsyncMock(
+            side_effect=[
+                [{"doc_id": 1, "score": 0.9, "content": "Giant impact evidence."}],
+                [{"doc_id": 2, "score": 0.8, "content": "Moon composition evidence."}],
+            ]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "How did the Moon form?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_turns=3, k_per_query=4)
+
+        result = await pipeline._generate(1, top_k=2)
+
+        retrieval_pipeline.retrieve.assert_any_await("moon origin", 2)
+        retrieval_pipeline.retrieve.assert_any_await("moon composition", 2)
+        assert result.text == "The Moon likely formed from giant-impact debris."
+        assert result.metadata["retrieved_chunk_ids"] == [1, 2]
+        assert result.metadata["terminated_by"] == "answer"
+        assert result.token_usage == {"prompt_tokens": 4, "completion_tokens": 6, "total_tokens": 10}
+
+    @pytest.mark.asyncio
+    async def test_generate_merges_duplicate_results_and_falls_back(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<queries>\na\nb\n</queries>"),
+                _mock_response("fallback answer"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline.retrieve = AsyncMock(
+            side_effect=[
+                [{"doc_id": 1, "score": 0.2, "content": "low"}],
+                [{"doc_id": 1, "score": 0.9, "content": "high"}],
+            ]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_turns=1, k_per_query=3)
+
+        result = await pipeline._generate(1, top_k=3)
+
+        assert result.text == "fallback answer"
+        assert result.metadata["retrieved_chunk_ids"] == [1]
+        assert result.metadata["evidence"] == ["high"]
+        assert result.metadata["terminated_by"] == "max_turns_fallback"
+
+    @pytest.mark.asyncio
+    async def test_generate_backfills_missing_contents(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<queries>\na\n</queries>"),
+                _mock_response("<answer>done</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(default_results=[{"doc_id": 7, "score": 0.9}])
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        service.get_chunk_contents.return_value = ["Fetched content."]
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_turns=2, k_per_query=1)
+
+        result = await pipeline._generate(1, top_k=1)
+
+        service.get_chunk_contents.assert_called_once_with([7])
+        assert result.metadata["evidence"] == ["Fetched content."]

--- a/tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py
@@ -272,5 +272,43 @@ class TestHybridDeepSearcherPipeline:
         metadata = _metadata(result)
         assert metadata["evidence"] == ["usable evidence"]
         assert metadata["retrieval_failures"] == [
-            {"query": "broken generated subquery", "error": "retriever unavailable"}
+            {"query": "broken generated subquery", "error": "RuntimeError: retrieval failed"}
         ]
+
+    @pytest.mark.asyncio
+    async def test_partial_retrieval_failure_metadata_sanitizes_backend_exception_details(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<queries>\nleaky generated subquery\n</queries>"),
+                _mock_response("fallback without evidence"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline.retrieve = AsyncMock(
+            side_effect=RuntimeError("dsn=postgres://user:SECRET_PASSWORD@localhost/db")
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(
+            llm,
+            retrieval_pipeline,
+            service,
+            max_turns=1,
+            allow_partial_retrieval_failures=True,
+        )
+
+        result = await pipeline._generate(1, top_k=1)
+
+        metadata = _metadata(result)
+        assert metadata["retrieval_failures"] == [
+            {"query": "leaky generated subquery", "error": "RuntimeError: retrieval failed"}
+        ]
+        assert "SECRET_PASSWORD" not in str(metadata)
+
+    def test_hybrid_deep_searcher_docs_cover_runtime_contract(self):
+        docs = Path("docs/pipelines/generation/hybrid-deep-searcher.md").read_text()
+
+        assert "text-query-capable" in docs
+        assert "inference-only" in docs
+        assert "max_concurrency x retrieval_concurrency" in docs

--- a/tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py
@@ -122,6 +122,15 @@ class TestHybridDeepSearcherPipelineConfig:
 
         assert kwargs["retrieval_pipeline"] is retrieval_pipeline
 
+    def test_default_yaml_references_existing_llm_config(self):
+        config_path = Path("configs/pipelines/generation/hybrid_deep_searcher.yaml")
+        llm_config_name = OmegaConf.load(config_path).llm
+        llm_config_dir = Path("configs/llm")
+
+        assert (llm_config_dir / f"{llm_config_name}.yaml").exists() or (
+            llm_config_dir / f"{llm_config_name}.yml"
+        ).exists()
+
 
 class TestHybridDeepSearcherPipeline:
     """Tests for HDS generation behavior."""


### PR DESCRIPTION
## Summary
- Adds an inference-only Hybrid Deep Searcher generation pipeline that combines sequential planning with parallel fan-out retrieval.
- Reuses existing retrieval pipelines for evidence gathering, merges/deduplicates retrieved evidence, and persists fan-out traces/metadata.
- Adds YAML config, exports, and focused tests for parsing, config injection, parallel retrieval, deduplication, fallback, and content backfill.

## Scope
- Implements the HDS-style inference/evaluation baseline suitable for AutoRAG-Research.
- Does not add HDS-specific training infrastructure or paper-scale benchmark reproduction.

## Validation
- uv sync --all-extras --all-groups
- uv run pytest tests/autorag_research/pipelines/generation/test_hybrid_deep_searcher_pipeline.py -q
- make check

Closes #180

<!-- dani:stage=implementation;job=97fefe0c8d2a921c0b18042e54ecb6aa;issue=180 -->
