### PR TITLE
Add AdaptiveRAG generation pipeline

### DIFF
--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -1,3 +1,4 @@
+from autorag_research.pipelines.generation.adaptive_rag import AdaptiveRAGPipeline, AdaptiveRAGPipelineConfig
 from autorag_research.pipelines.generation.autothinkrag import AutoThinkRAGPipeline, AutoThinkRAGPipelineConfig
 from autorag_research.pipelines.generation.base import BaseGenerationPipeline
 from autorag_research.pipelines.generation.basic_rag import BasicRAGPipeline, BasicRAGPipelineConfig
@@ -25,6 +26,8 @@ from autorag_research.pipelines.generation.visrag_gen import (
 __all__ = [
     "DEFAULT_PROMPT_TEMPLATE",
     "DEFAULT_VISRAG_PROMPT",
+    "AdaptiveRAGPipeline",
+    "AdaptiveRAGPipelineConfig",
     "AutoThinkRAGPipeline",
     "AutoThinkRAGPipelineConfig",
     "BaseGenerationPipeline",

--- a/autorag_research/pipelines/generation/adaptive_rag.py
+++ b/autorag_research/pipelines/generation/adaptive_rag.py
@@ -1,0 +1,361 @@
+"""AdaptiveRAG generation pipeline for AutoRAG-Research.
+
+AdaptiveRAG routes each query to a retrieval strategy based on predicted complexity:
+- zero: answer directly without retrieval
+- single: single-pass retrieval then generation
+- multi: iterative retrieval with follow-up query generation
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker
+
+DEFAULT_COMPLEXITY_PROMPT_TEMPLATE = """Classify the following question complexity as exactly one of: simple, moderate, complex.
+
+- simple: can be answered directly without retrieval
+- moderate: needs one retrieval pass
+- complex: needs iterative multi-step retrieval
+
+Question: {query}
+
+Return only one word: simple, moderate, or complex."""
+
+DEFAULT_ZERO_RETRIEVAL_PROMPT_TEMPLATE = """Answer the question directly.
+
+Question: {query}
+
+Answer:"""
+
+DEFAULT_SINGLE_RETRIEVAL_PROMPT_TEMPLATE = """Answer the question with the provided context.
+
+Context:
+{context}
+
+Question: {query}
+
+Answer:"""
+
+DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE = """You are performing iterative retrieval for a complex question.
+
+Question: {query}
+
+Current Context:
+{context}
+
+Previous Follow-up Queries:
+{follow_up_queries}
+
+Generate the next short retrieval query to gather missing evidence.
+If enough evidence is already available, respond exactly with STOP.
+
+Next Retrieval Query:"""
+
+DEFAULT_MULTI_RETRIEVAL_ANSWER_PROMPT_TEMPLATE = """Answer the question using the collected evidence.
+
+Question: {query}
+
+Collected Context:
+{context}
+
+Follow-up Queries Used:
+{follow_up_queries}
+
+Answer:"""
+
+
+@dataclass(kw_only=True)
+class AdaptiveRAGPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for AdaptiveRAG generation pipeline."""
+
+    complexity_prompt_template: str = field(default=DEFAULT_COMPLEXITY_PROMPT_TEMPLATE)
+    zero_retrieval_prompt_template: str = field(default=DEFAULT_ZERO_RETRIEVAL_PROMPT_TEMPLATE)
+    single_retrieval_prompt_template: str = field(default=DEFAULT_SINGLE_RETRIEVAL_PROMPT_TEMPLATE)
+    multi_retrieval_query_prompt_template: str = field(default=DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE)
+    multi_retrieval_answer_prompt_template: str = field(default=DEFAULT_MULTI_RETRIEVAL_ANSWER_PROMPT_TEMPLATE)
+    route_for_simple: Literal["zero", "single", "multi"] = "zero"
+    route_for_moderate: Literal["zero", "single", "multi"] = "single"
+    route_for_complex: Literal["zero", "single", "multi"] = "multi"
+    max_multi_steps: int = 2
+    stop_query_signal: str = "STOP"
+
+    def get_pipeline_class(self) -> type["AdaptiveRAGPipeline"]:
+        """Return the AdaptiveRAGPipeline class."""
+        return AdaptiveRAGPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for AdaptiveRAGPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "complexity_prompt_template": self.complexity_prompt_template,
+            "zero_retrieval_prompt_template": self.zero_retrieval_prompt_template,
+            "single_retrieval_prompt_template": self.single_retrieval_prompt_template,
+            "multi_retrieval_query_prompt_template": self.multi_retrieval_query_prompt_template,
+            "multi_retrieval_answer_prompt_template": self.multi_retrieval_answer_prompt_template,
+            "route_for_simple": self.route_for_simple,
+            "route_for_moderate": self.route_for_moderate,
+            "route_for_complex": self.route_for_complex,
+            "max_multi_steps": self.max_multi_steps,
+            "stop_query_signal": self.stop_query_signal,
+        }
+
+
+class AdaptiveRAGPipeline(BaseGenerationPipeline):
+    """Adaptive routing generation pipeline with zero/single/multi retrieval modes."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        complexity_prompt_template: str = DEFAULT_COMPLEXITY_PROMPT_TEMPLATE,
+        zero_retrieval_prompt_template: str = DEFAULT_ZERO_RETRIEVAL_PROMPT_TEMPLATE,
+        single_retrieval_prompt_template: str = DEFAULT_SINGLE_RETRIEVAL_PROMPT_TEMPLATE,
+        multi_retrieval_query_prompt_template: str = DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE,
+        multi_retrieval_answer_prompt_template: str = DEFAULT_MULTI_RETRIEVAL_ANSWER_PROMPT_TEMPLATE,
+        route_for_simple: Literal["zero", "single", "multi"] = "zero",
+        route_for_moderate: Literal["zero", "single", "multi"] = "single",
+        route_for_complex: Literal["zero", "single", "multi"] = "multi",
+        max_multi_steps: int = 2,
+        stop_query_signal: str = "STOP",
+        schema: Any | None = None,
+    ):
+        """Initialize AdaptiveRAG pipeline."""
+        self._complexity_prompt_template = complexity_prompt_template
+        self._zero_retrieval_prompt_template = zero_retrieval_prompt_template
+        self._single_retrieval_prompt_template = single_retrieval_prompt_template
+        self._multi_retrieval_query_prompt_template = multi_retrieval_query_prompt_template
+        self._multi_retrieval_answer_prompt_template = multi_retrieval_answer_prompt_template
+        self._route_for_simple = route_for_simple
+        self._route_for_moderate = route_for_moderate
+        self._route_for_complex = route_for_complex
+        self._max_multi_steps = max_multi_steps
+        self._stop_query_signal = stop_query_signal
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return AdaptiveRAG pipeline configuration."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+
+        return {
+            "type": "adaptive_rag",
+            "complexity_prompt_template": self._complexity_prompt_template,
+            "zero_retrieval_prompt_template": self._zero_retrieval_prompt_template,
+            "single_retrieval_prompt_template": self._single_retrieval_prompt_template,
+            "multi_retrieval_query_prompt_template": self._multi_retrieval_query_prompt_template,
+            "multi_retrieval_answer_prompt_template": self._multi_retrieval_answer_prompt_template,
+            "route_for_simple": self._route_for_simple,
+            "route_for_moderate": self._route_for_moderate,
+            "route_for_complex": self._route_for_complex,
+            "max_multi_steps": self._max_multi_steps,
+            "stop_query_signal": self._stop_query_signal,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract text content from an LLM response."""
+        return response.content if hasattr(response, "content") else str(response)
+
+    @staticmethod
+    def _normalize_score(score: Any) -> float:
+        """Normalize retrieval score to float."""
+        if isinstance(score, (int, float)):
+            return float(score)
+        return 0.0
+
+    @staticmethod
+    def _parse_complexity_tier(response_text: str) -> Literal["simple", "moderate", "complex"]:
+        """Parse complexity output, defaulting to moderate for unknown outputs."""
+        normalized = response_text.strip().lower()
+
+        if normalized == "simple":
+            return "simple"
+        if normalized == "moderate":
+            return "moderate"
+        if normalized == "complex":
+            return "complex"
+        if normalized == "medium":
+            return "moderate"
+
+        if "simple" in normalized:
+            return "simple"
+        if "moderate" in normalized or "medium" in normalized:
+            return "moderate"
+        if "complex" in normalized:
+            return "complex"
+
+        return "moderate"
+
+    @staticmethod
+    def _normalize_route(route: str) -> Literal["zero", "single", "multi"]:
+        """Normalize route labels to supported route names."""
+        normalized = route.strip().lower()
+        if normalized in {"zero", "single", "multi"}:
+            if normalized == "zero":
+                return "zero"
+            if normalized == "single":
+                return "single"
+            if normalized == "multi":
+                return "multi"
+        return "single"
+
+    def _select_route(
+        self, complexity_tier: Literal["simple", "moderate", "complex"]
+    ) -> Literal["zero", "single", "multi"]:
+        """Select route name from tier-specific mapping."""
+        route_map = {
+            "simple": self._route_for_simple,
+            "moderate": self._route_for_moderate,
+            "complex": self._route_for_complex,
+        }
+        return self._normalize_route(route_map[complexity_tier])
+
+    @staticmethod
+    def _merge_retrieval_results(result_sets: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+        """Merge retrieval results by doc_id, keeping the highest score per document."""
+        merged: dict[int | str, dict[str, Any]] = {}
+
+        for result_set in result_sets:
+            for result in result_set:
+                doc_id = result.get("doc_id")
+                if doc_id is None:
+                    continue
+
+                score = AdaptiveRAGPipeline._normalize_score(result.get("score"))
+                existing = merged.get(doc_id)
+                if existing is None or score > AdaptiveRAGPipeline._normalize_score(existing.get("score")):
+                    merged[doc_id] = {
+                        "doc_id": doc_id,
+                        "score": score,
+                    }
+
+        return sorted(
+            merged.values(),
+            key=lambda item: (-AdaptiveRAGPipeline._normalize_score(item.get("score")), str(item.get("doc_id"))),
+        )
+
+    def _build_context(self, chunk_ids: list[int | str]) -> str:
+        """Build context text from chunk IDs."""
+        if not chunk_ids:
+            return ""
+        chunk_contents = self._service.get_chunk_contents(chunk_ids)
+        return "\n\n".join(content for content in chunk_contents if content)
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate answer using adaptive route selection."""
+        query_text = self._service.get_query_text(query_id)
+        tracker = TokenUsageTracker()
+
+        complexity_prompt = self._complexity_prompt_template.format(query=query_text)
+        complexity_response = await self._llm.ainvoke(complexity_prompt)
+        tracker.record(complexity_response)
+        complexity_tier = self._parse_complexity_tier(self._extract_text(complexity_response))
+        route = self._select_route(complexity_tier)
+
+        if route == "zero":
+            prompt = self._zero_retrieval_prompt_template.format(query=query_text)
+            answer_response = await self._llm.ainvoke(prompt)
+            tracker.record(answer_response)
+            answer_text = self._extract_text(answer_response)
+
+            return GenerationResult(
+                text=answer_text,
+                token_usage=tracker.total,
+                metadata={
+                    "complexity_tier": complexity_tier,
+                    "route": route,
+                    "retrieved_chunk_ids": [],
+                    "retrieved_scores": [],
+                    "follow_up_queries": [],
+                },
+            )
+
+        if route == "single":
+            retrieved_results = await self._retrieval_pipeline._retrieve_by_id(query_id, top_k)
+            chunk_ids = [item["doc_id"] for item in retrieved_results if item.get("doc_id") is not None]
+            context = self._build_context(chunk_ids)
+            prompt = self._single_retrieval_prompt_template.format(context=context, query=query_text)
+            answer_response = await self._llm.ainvoke(prompt)
+            tracker.record(answer_response)
+            answer_text = self._extract_text(answer_response)
+
+            return GenerationResult(
+                text=answer_text,
+                token_usage=tracker.total,
+                metadata={
+                    "complexity_tier": complexity_tier,
+                    "route": route,
+                    "retrieved_chunk_ids": chunk_ids,
+                    "retrieved_scores": [self._normalize_score(item.get("score")) for item in retrieved_results],
+                    "follow_up_queries": [],
+                },
+            )
+
+        # multi route
+        retrieved_sets: list[list[dict[str, Any]]] = [
+            await self._retrieval_pipeline._retrieve_by_id(query_id, top_k),
+        ]
+        follow_up_queries: list[str] = []
+
+        for _ in range(self._max_multi_steps):
+            merged_so_far = self._merge_retrieval_results(retrieved_sets)[:top_k]
+            context = self._build_context([item["doc_id"] for item in merged_so_far])
+            previous_queries = "\n".join(follow_up_queries) if follow_up_queries else "(none)"
+            next_query_prompt = self._multi_retrieval_query_prompt_template.format(
+                query=query_text,
+                context=context,
+                follow_up_queries=previous_queries,
+            )
+
+            next_query_response = await self._llm.ainvoke(next_query_prompt)
+            tracker.record(next_query_response)
+            next_query = self._extract_text(next_query_response).strip()
+
+            if not next_query or next_query.upper() == self._stop_query_signal.upper():
+                break
+
+            follow_up_queries.append(next_query)
+            retrieved_sets.append(await self._retrieval_pipeline.retrieve(next_query, top_k))
+
+        merged_results = self._merge_retrieval_results(retrieved_sets)[:top_k]
+        merged_chunk_ids = [item["doc_id"] for item in merged_results]
+        final_context = self._build_context(merged_chunk_ids)
+        final_follow_ups = "\n".join(follow_up_queries) if follow_up_queries else "(none)"
+        answer_prompt = self._multi_retrieval_answer_prompt_template.format(
+            query=query_text,
+            context=final_context,
+            follow_up_queries=final_follow_ups,
+        )
+        answer_response = await self._llm.ainvoke(answer_prompt)
+        tracker.record(answer_response)
+        answer_text = self._extract_text(answer_response)
+
+        return GenerationResult(
+            text=answer_text,
+            token_usage=tracker.total,
+            metadata={
+                "complexity_tier": complexity_tier,
+                "route": route,
+                "retrieved_chunk_ids": merged_chunk_ids,
+                "retrieved_scores": [self._normalize_score(item.get("score")) for item in merged_results],
+                "follow_up_queries": follow_up_queries,
+            },
+        )

--- a/autorag_research/pipelines/generation/adaptive_rag.py
+++ b/autorag_research/pipelines/generation/adaptive_rag.py
@@ -54,7 +54,7 @@ Previous Follow-up Queries:
 {follow_up_queries}
 
 Generate the next short retrieval query to gather missing evidence.
-If enough evidence is already available, respond exactly with STOP.
+If enough evidence is already available, respond exactly with {stop_query_signal}.
 
 Next Retrieval Query:"""
 
@@ -96,6 +96,12 @@ class AdaptiveRAGPipelineConfig(BaseGenerationPipelineConfig):
             msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
             raise ValueError(msg)
 
+        route_map = AdaptiveRAGPipeline._validate_route_map(
+            route_for_simple=self.route_for_simple,
+            route_for_moderate=self.route_for_moderate,
+            route_for_complex=self.route_for_complex,
+        )
+
         return {
             "llm": self.llm,
             "retrieval_pipeline": self._retrieval_pipeline,
@@ -104,9 +110,9 @@ class AdaptiveRAGPipelineConfig(BaseGenerationPipelineConfig):
             "single_retrieval_prompt_template": self.single_retrieval_prompt_template,
             "multi_retrieval_query_prompt_template": self.multi_retrieval_query_prompt_template,
             "multi_retrieval_answer_prompt_template": self.multi_retrieval_answer_prompt_template,
-            "route_for_simple": self.route_for_simple,
-            "route_for_moderate": self.route_for_moderate,
-            "route_for_complex": self.route_for_complex,
+            "route_for_simple": route_map["simple"],
+            "route_for_moderate": route_map["moderate"],
+            "route_for_complex": route_map["complex"],
             "max_multi_steps": self.max_multi_steps,
             "stop_query_signal": self.stop_query_signal,
         }
@@ -139,9 +145,14 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
         self._single_retrieval_prompt_template = single_retrieval_prompt_template
         self._multi_retrieval_query_prompt_template = multi_retrieval_query_prompt_template
         self._multi_retrieval_answer_prompt_template = multi_retrieval_answer_prompt_template
-        self._route_for_simple = route_for_simple
-        self._route_for_moderate = route_for_moderate
-        self._route_for_complex = route_for_complex
+        route_map = self._validate_route_map(
+            route_for_simple=route_for_simple,
+            route_for_moderate=route_for_moderate,
+            route_for_complex=route_for_complex,
+        )
+        self._route_for_simple = route_map["simple"]
+        self._route_for_moderate = route_map["moderate"]
+        self._route_for_complex = route_map["complex"]
         self._max_multi_steps = max_multi_steps
         self._stop_query_signal = stop_query_signal
 
@@ -205,28 +216,44 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
         return "moderate"
 
     @staticmethod
-    def _normalize_route(route: str) -> Literal["zero", "single", "multi"]:
-        """Normalize route labels to supported route names."""
+    def _normalize_route(route: str, field_name: str = "route") -> Literal["zero", "single", "multi"]:
+        """Normalize and validate route labels to supported route names."""
         normalized = route.strip().lower()
-        if normalized in {"zero", "single", "multi"}:
-            if normalized == "zero":
-                return "zero"
-            if normalized == "single":
-                return "single"
-            if normalized == "multi":
-                return "multi"
-        return "single"
+        if normalized == "zero":
+            return "zero"
+        if normalized == "single":
+            return "single"
+        if normalized == "multi":
+            return "multi"
+
+        msg = f"{field_name} must be one of: zero, single, multi (got {route!r})"
+        raise ValueError(msg)
+
+    @classmethod
+    def _validate_route_map(
+        cls,
+        *,
+        route_for_simple: str,
+        route_for_moderate: str,
+        route_for_complex: str,
+    ) -> dict[Literal["simple", "moderate", "complex"], Literal["zero", "single", "multi"]]:
+        """Validate tier-specific route configuration and return normalized routes."""
+        return {
+            "simple": cls._normalize_route(route_for_simple, "route_for_simple"),
+            "moderate": cls._normalize_route(route_for_moderate, "route_for_moderate"),
+            "complex": cls._normalize_route(route_for_complex, "route_for_complex"),
+        }
 
     def _select_route(
         self, complexity_tier: Literal["simple", "moderate", "complex"]
     ) -> Literal["zero", "single", "multi"]:
         """Select route name from tier-specific mapping."""
-        route_map = {
+        route_map: dict[Literal["simple", "moderate", "complex"], Literal["zero", "single", "multi"]] = {
             "simple": self._route_for_simple,
             "moderate": self._route_for_moderate,
             "complex": self._route_for_complex,
         }
-        return self._normalize_route(route_map[complexity_tier])
+        return route_map[complexity_tier]
 
     @staticmethod
     def _merge_retrieval_results(result_sets: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
@@ -323,6 +350,7 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
                 query=query_text,
                 context=context,
                 follow_up_queries=previous_queries,
+                stop_query_signal=self._stop_query_signal,
             )
 
             next_query_response = await self._llm.ainvoke(next_query_prompt)

--- a/autorag_research/pipelines/generation/adaptive_rag.py
+++ b/autorag_research/pipelines/generation/adaptive_rag.py
@@ -6,6 +6,7 @@ AdaptiveRAG routes each query to a retrieval strategy based on predicted complex
 - multi: iterative retrieval with follow-up query generation
 """
 
+import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -194,24 +195,23 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
 
     @staticmethod
     def _parse_complexity_tier(response_text: str) -> Literal["simple", "moderate", "complex"]:
-        """Parse complexity output, defaulting to moderate for unknown outputs."""
+        """Parse complexity output, defaulting to moderate for unknown outputs.
+
+        The classifier prompt asks for one label, but LLMs can still return explanatory text.
+        Match labels as whole tokens and choose the safest mentioned tier when output is ambiguous.
+        """
         normalized = response_text.strip().lower()
+        tier_tokens = {
+            "moderate" if label == "medium" else label
+            for label in re.findall(r"\b(simple|moderate|medium|complex)\b", normalized)
+        }
 
-        if normalized == "simple":
-            return "simple"
-        if normalized == "moderate":
-            return "moderate"
-        if normalized == "complex":
+        if "complex" in tier_tokens:
             return "complex"
-        if normalized == "medium":
+        if "moderate" in tier_tokens:
             return "moderate"
-
-        if "simple" in normalized:
+        if "simple" in tier_tokens:
             return "simple"
-        if "moderate" in normalized or "medium" in normalized:
-            return "moderate"
-        if "complex" in normalized:
-            return "complex"
 
         return "moderate"
 

--- a/configs/pipelines/generation/adaptive_rag.yaml
+++ b/configs/pipelines/generation/adaptive_rag.yaml
@@ -1,0 +1,15 @@
+_target_: autorag_research.pipelines.generation.adaptive_rag.AdaptiveRAGPipelineConfig
+description: "AdaptiveRAG: route queries across zero/single/multi retrieval by predicted complexity"
+name: adaptive_rag
+retrieval_pipeline_name: bm25
+llm: gpt-4o-mini
+route_for_simple: zero
+route_for_moderate: single
+route_for_complex: multi
+max_multi_steps: 2
+stop_query_signal: STOP
+top_k: 10
+batch_size: 128
+max_concurrency: 8
+max_retries: 3
+retry_delay: 1.0

--- a/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
@@ -163,6 +163,16 @@ class TestAdaptiveRAGPipeline:
         mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 4)
         assert mock_retrieval.retrieve.await_count == 0
 
+    def test_complexity_parser_uses_safest_tier_when_multiple_labels_are_present(self):
+        assert AdaptiveRAGPipeline._parse_complexity_tier("not simple; this is complex") == "complex"
+
+    def test_complexity_parser_accepts_single_label_explanatory_output(self):
+        assert AdaptiveRAGPipeline._parse_complexity_tier("The question is moderate.") == "moderate"
+
+    @pytest.mark.parametrize("response_text", ["simplicity", "simplex", "complexity"])
+    def test_complexity_parser_matches_labels_as_whole_tokens(self, response_text):
+        assert AdaptiveRAGPipeline._parse_complexity_tier(response_text) == "moderate"
+
     def test_config_rejects_invalid_route_values(self, mock_retrieval):
         llm = FakeListLLM(responses=["answer"])
         invalid_route = cast(Any, "singel")

--- a/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -124,6 +125,58 @@ class TestAdaptiveRAGPipeline:
         mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 2)
         assert mock_retrieval.retrieve.await_count == 0
 
+    @pytest.mark.asyncio
+    async def test_multi_route_uses_configured_stop_query_signal_in_prompt(self, mock_retrieval):
+        class StubService:
+            def get_query_text(self, query_id: int | str) -> str:
+                return f"query {query_id}"
+
+            def get_chunk_contents(self, chunk_ids: list[int | str]) -> list[str]:
+                return [f"chunk {chunk_id}" for chunk_id in chunk_ids]
+
+        llm = FakeListLLM(responses=["complex", "DONE", "Complex answer"])
+        mock_retrieval._retrieve_by_id = AsyncMock(return_value=[{"doc_id": 1, "score": 0.8}])
+        mock_retrieval.retrieve = AsyncMock(return_value=[{"doc_id": 4, "score": 0.95}])
+        pipeline = AdaptiveRAGPipeline.__new__(AdaptiveRAGPipeline)
+        pipeline._service = StubService()
+        pipeline._llm = llm
+        pipeline._retrieval_pipeline = mock_retrieval
+        pipeline._complexity_prompt_template = "{query}"
+        pipeline._zero_retrieval_prompt_template = "{query}"
+        pipeline._single_retrieval_prompt_template = "{context} {query}"
+        pipeline._multi_retrieval_query_prompt_template = (
+            "Question: {query}\nContext: {context}\nPrevious: {follow_up_queries}\n"
+            "Respond with {stop_query_signal} when enough evidence is available."
+        )
+        pipeline._multi_retrieval_answer_prompt_template = "{query} {context} {follow_up_queries}"
+        pipeline._route_for_simple = "zero"
+        pipeline._route_for_moderate = "single"
+        pipeline._route_for_complex = "multi"
+        pipeline._max_multi_steps = 2
+        pipeline._stop_query_signal = "DONE"
+
+        result = await pipeline._generate(query_id=1, top_k=4)
+
+        assert result.text == "Complex answer"
+        assert result.metadata is not None
+        assert result.metadata["follow_up_queries"] == []
+        mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 4)
+        assert mock_retrieval.retrieve.await_count == 0
+
+    def test_config_rejects_invalid_route_values(self, mock_retrieval):
+        llm = FakeListLLM(responses=["answer"])
+        invalid_route = cast(Any, "singel")
+        config = AdaptiveRAGPipelineConfig(
+            name="adaptive_rag_invalid_route_cfg",
+            retrieval_pipeline_name="bm25",
+            llm=llm,
+            route_for_simple=invalid_route,
+        )
+        config.inject_retrieval_pipeline(mock_retrieval)
+
+        with pytest.raises(ValueError, match="route_for_simple"):
+            config.get_pipeline_kwargs()
+
     def test_adaptive_rag_config(self, mock_retrieval):
         llm = FakeListLLM(responses=["answer"])
         config = AdaptiveRAGPipelineConfig(
@@ -206,5 +259,6 @@ class TestAdaptiveRAGPipeline:
             check_execution_time=True,
             check_persistence=True,
         )
+        assert isinstance(pipeline.pipeline_id, int)
         verifier = PipelineTestVerifier(result, pipeline.pipeline_id, session_factory, config)
         verifier.verify_all()

--- a/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
@@ -1,0 +1,210 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from autorag_research.pipelines.generation.adaptive_rag import AdaptiveRAGPipeline, AdaptiveRAGPipelineConfig
+from tests.autorag_research.pipelines.pipeline_test_utils import (
+    PipelineTestConfig,
+    PipelineTestVerifier,
+    cleanup_pipeline_results_factory,
+    create_mock_llm,
+    create_mock_retrieval_pipeline,
+)
+
+
+@pytest.fixture
+def cleanup(session_factory):
+    yield from cleanup_pipeline_results_factory(session_factory)
+
+
+@pytest.fixture
+def mock_retrieval():
+    return create_mock_retrieval_pipeline(
+        default_results=[
+            {"doc_id": 1, "score": 0.95},
+            {"doc_id": 2, "score": 0.85},
+            {"doc_id": 3, "score": 0.75},
+        ]
+    )
+
+
+class TestAdaptiveRAGPipeline:
+    @pytest.mark.asyncio
+    async def test_zero_route_skips_retrieval(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["simple", "Direct answer"])
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_zero",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=3)
+
+        assert result.text == "Direct answer"
+        assert result.metadata is not None
+        assert result.metadata["complexity_tier"] == "simple"
+        assert result.metadata["route"] == "zero"
+        assert result.metadata["retrieved_chunk_ids"] == []
+        assert result.metadata["follow_up_queries"] == []
+        assert mock_retrieval._retrieve_by_id.await_count == 0
+        assert mock_retrieval.retrieve.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_single_route_uses_single_retrieval(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["moderate", "Single answer"])
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_single",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=3)
+
+        assert result.text == "Single answer"
+        assert result.metadata is not None
+        assert result.metadata["complexity_tier"] == "moderate"
+        assert result.metadata["route"] == "single"
+        assert result.metadata["retrieved_chunk_ids"] == [1, 2, 3]
+        assert result.metadata["retrieved_scores"] == [0.95, 0.85, 0.75]
+        assert result.metadata["follow_up_queries"] == []
+        mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 3)
+        assert mock_retrieval.retrieve.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_multi_route_performs_iterative_retrieval(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["complex", "follow up query", "STOP", "Complex answer"])
+        mock_retrieval._retrieve_by_id = AsyncMock(
+            return_value=[{"doc_id": 1, "score": 0.8}, {"doc_id": 2, "score": 0.7}]
+        )
+        mock_retrieval.retrieve = AsyncMock(return_value=[{"doc_id": 4, "score": 0.95}])
+
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_multi",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+            max_multi_steps=2,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=4)
+
+        assert result.text == "Complex answer"
+        assert result.metadata is not None
+        assert result.metadata["complexity_tier"] == "complex"
+        assert result.metadata["route"] == "multi"
+        assert result.metadata["follow_up_queries"] == ["follow up query"]
+        assert result.metadata["retrieved_chunk_ids"] == [4, 1, 2]
+        assert result.metadata["retrieved_scores"] == [0.95, 0.8, 0.7]
+        mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 4)
+        mock_retrieval.retrieve.assert_awaited_once_with("follow up query", 4)
+
+    @pytest.mark.asyncio
+    async def test_unknown_complexity_falls_back_to_single_route(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["uncertain", "Fallback single answer"])
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_fallback",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=2)
+
+        assert result.text == "Fallback single answer"
+        assert result.metadata is not None
+        assert result.metadata["complexity_tier"] == "moderate"
+        assert result.metadata["route"] == "single"
+        mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 2)
+        assert mock_retrieval.retrieve.await_count == 0
+
+    def test_adaptive_rag_config(self, mock_retrieval):
+        llm = FakeListLLM(responses=["answer"])
+        config = AdaptiveRAGPipelineConfig(
+            name="adaptive_rag_cfg",
+            retrieval_pipeline_name="bm25",
+            llm=llm,
+            route_for_simple="single",
+            route_for_moderate="multi",
+            route_for_complex="zero",
+            max_multi_steps=4,
+            stop_query_signal="DONE",
+        )
+        config.inject_retrieval_pipeline(mock_retrieval)
+
+        kwargs = config.get_pipeline_kwargs()
+
+        assert config.get_pipeline_class() is AdaptiveRAGPipeline
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is mock_retrieval
+        assert kwargs["route_for_simple"] == "single"
+        assert kwargs["route_for_moderate"] == "multi"
+        assert kwargs["route_for_complex"] == "zero"
+        assert kwargs["max_multi_steps"] == 4
+        assert kwargs["stop_query_signal"] == "DONE"
+
+    def test_pipeline_config_output(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["simple", "answer"])
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_config_output",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+            route_for_simple="zero",
+            route_for_moderate="single",
+            route_for_complex="multi",
+            max_multi_steps=3,
+            stop_query_signal="HALT",
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        config = pipeline._get_pipeline_config()
+
+        assert config["type"] == "adaptive_rag"
+        assert config["retrieval_pipeline_id"] == mock_retrieval.pipeline_id
+        assert config["route_for_simple"] == "zero"
+        assert config["route_for_moderate"] == "single"
+        assert config["route_for_complex"] == "multi"
+        assert config["max_multi_steps"] == 3
+        assert config["stop_query_signal"] == "HALT"
+        assert "complexity_prompt_template" in config
+        assert "zero_retrieval_prompt_template" in config
+        assert "single_retrieval_prompt_template" in config
+        assert "multi_retrieval_query_prompt_template" in config
+        assert "multi_retrieval_answer_prompt_template" in config
+
+    def test_run_pipeline(self, session_factory, cleanup):
+        from autorag_research.orm.repository.query import QueryRepository
+
+        with session_factory() as session:
+            query_repo = QueryRepository(session)
+            query_count = query_repo.count()
+
+        retrieval = create_mock_retrieval_pipeline()
+        llm = create_mock_llm()
+
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_run",
+            llm=llm,
+            retrieval_pipeline=retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = pipeline.run(top_k=2, batch_size=10)
+
+        config = PipelineTestConfig(
+            pipeline_type="generation",
+            expected_total_queries=query_count,
+            check_token_usage=True,
+            check_execution_time=True,
+            check_persistence=True,
+        )
+        verifier = PipelineTestVerifier(result, pipeline.pipeline_id, session_factory, config)
+        verifier.verify_all()


### PR DESCRIPTION
## Summary
- Adds AdaptiveRAG generation pipeline with complexity routing across zero/single/multi retrieval effort.
- Exports the pipeline, adds runnable YAML config, and persists route metadata including complexity tier, route, retrieved chunk IDs/scores, and follow-up queries.
- Adds focused tests for config and routing behavior.

## Validation
- make check
- uv run pytest tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py::TestAdaptiveRAGPipeline::test_adaptive_rag_config -v

## Notes
- Full DB-backed AdaptiveRAG test file could not be validated locally because Docker/PostgreSQL test runtime was unavailable.

Closes #115

<!-- dani:stage=implementation;job=593cc1c681a14f92e9175c839599f572;issue=115 -->
