### PR TITLE
Add GQR hybrid retrieval pipeline

### DIFF
--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -1,3 +1,4 @@
+from autorag_research.pipelines.generation.adaptive_rag import AdaptiveRAGPipeline, AdaptiveRAGPipelineConfig
 from autorag_research.pipelines.generation.autothinkrag import AutoThinkRAGPipeline, AutoThinkRAGPipelineConfig
 from autorag_research.pipelines.generation.base import BaseGenerationPipeline
 from autorag_research.pipelines.generation.basic_rag import BasicRAGPipeline, BasicRAGPipelineConfig
@@ -25,6 +26,8 @@ from autorag_research.pipelines.generation.visrag_gen import (
 __all__ = [
     "DEFAULT_PROMPT_TEMPLATE",
     "DEFAULT_VISRAG_PROMPT",
+    "AdaptiveRAGPipeline",
+    "AdaptiveRAGPipelineConfig",
     "AutoThinkRAGPipeline",
     "AutoThinkRAGPipelineConfig",
     "BaseGenerationPipeline",

--- a/autorag_research/pipelines/generation/adaptive_rag.py
+++ b/autorag_research/pipelines/generation/adaptive_rag.py
@@ -6,6 +6,7 @@ AdaptiveRAG routes each query to a retrieval strategy based on predicted complex
 - multi: iterative retrieval with follow-up query generation
 """
 
+import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -54,7 +55,7 @@ Previous Follow-up Queries:
 {follow_up_queries}
 
 Generate the next short retrieval query to gather missing evidence.
-If enough evidence is already available, respond exactly with STOP.
+If enough evidence is already available, respond exactly with {stop_query_signal}.
 
 Next Retrieval Query:"""
 
@@ -195,12 +196,16 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
         if normalized == "medium":
             return "moderate"
 
-        if "simple" in normalized:
-            return "simple"
-        if "moderate" in normalized or "medium" in normalized:
-            return "moderate"
-        if "complex" in normalized:
-            return "complex"
+        tier_tokens = {
+            "moderate" if label == "medium" else label
+            for label in re.findall(r"\b(simple|moderate|medium|complex)\b", normalized)
+        }
+        if len(tier_tokens) == 1:
+            tier = tier_tokens.pop()
+            if tier == "simple":
+                return "simple"
+            if tier == "complex":
+                return "complex"
 
         return "moderate"
 
@@ -323,6 +328,7 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
                 query=query_text,
                 context=context,
                 follow_up_queries=previous_queries,
+                stop_query_signal=self._stop_query_signal,
             )
 
             next_query_response = await self._llm.ainvoke(next_query_prompt)

--- a/autorag_research/pipelines/generation/adaptive_rag.py
+++ b/autorag_research/pipelines/generation/adaptive_rag.py
@@ -71,6 +71,22 @@ Follow-up Queries Used:
 
 Answer:"""
 
+_SUPPORTED_ROUTES = {"zero", "single", "multi"}
+
+
+def _normalize_adaptive_route(route: str, field_name: str) -> Literal["zero", "single", "multi"]:
+    """Normalize and validate AdaptiveRAG route labels."""
+    normalized = route.strip().lower()
+    if normalized == "zero":
+        return "zero"
+    if normalized == "single":
+        return "single"
+    if normalized == "multi":
+        return "multi"
+
+    msg = f"{field_name} must be one of {sorted(_SUPPORTED_ROUTES)}; got {route!r}"
+    raise ValueError(msg)
+
 
 @dataclass(kw_only=True)
 class AdaptiveRAGPipelineConfig(BaseGenerationPipelineConfig):
@@ -86,6 +102,11 @@ class AdaptiveRAGPipelineConfig(BaseGenerationPipelineConfig):
     route_for_complex: Literal["zero", "single", "multi"] = "multi"
     max_multi_steps: int = 2
     stop_query_signal: str = "STOP"
+
+    def __post_init__(self) -> None:
+        self.route_for_simple = _normalize_adaptive_route(self.route_for_simple, "route_for_simple")
+        self.route_for_moderate = _normalize_adaptive_route(self.route_for_moderate, "route_for_moderate")
+        self.route_for_complex = _normalize_adaptive_route(self.route_for_complex, "route_for_complex")
 
     def get_pipeline_class(self) -> type["AdaptiveRAGPipeline"]:
         """Return the AdaptiveRAGPipeline class."""
@@ -140,9 +161,9 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
         self._single_retrieval_prompt_template = single_retrieval_prompt_template
         self._multi_retrieval_query_prompt_template = multi_retrieval_query_prompt_template
         self._multi_retrieval_answer_prompt_template = multi_retrieval_answer_prompt_template
-        self._route_for_simple = route_for_simple
-        self._route_for_moderate = route_for_moderate
-        self._route_for_complex = route_for_complex
+        self._route_for_simple = self._normalize_route(route_for_simple, "route_for_simple")
+        self._route_for_moderate = self._normalize_route(route_for_moderate, "route_for_moderate")
+        self._route_for_complex = self._normalize_route(route_for_complex, "route_for_complex")
         self._max_multi_steps = max_multi_steps
         self._stop_query_signal = stop_query_signal
 
@@ -210,17 +231,9 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
         return "moderate"
 
     @staticmethod
-    def _normalize_route(route: str) -> Literal["zero", "single", "multi"]:
+    def _normalize_route(route: str, field_name: str = "route") -> Literal["zero", "single", "multi"]:
         """Normalize route labels to supported route names."""
-        normalized = route.strip().lower()
-        if normalized in {"zero", "single", "multi"}:
-            if normalized == "zero":
-                return "zero"
-            if normalized == "single":
-                return "single"
-            if normalized == "multi":
-                return "multi"
-        return "single"
+        return _normalize_adaptive_route(route, field_name)
 
     def _select_route(
         self, complexity_tier: Literal["simple", "moderate", "complex"]
@@ -231,7 +244,7 @@ class AdaptiveRAGPipeline(BaseGenerationPipeline):
             "moderate": self._route_for_moderate,
             "complex": self._route_for_complex,
         }
-        return self._normalize_route(route_map[complexity_tier])
+        return self._normalize_route(route_map[complexity_tier], f"route_for_{complexity_tier}")
 
     @staticmethod
     def _merge_retrieval_results(result_sets: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:

--- a/autorag_research/pipelines/generation/adaptive_rag.py
+++ b/autorag_research/pipelines/generation/adaptive_rag.py
@@ -1,0 +1,361 @@
+"""AdaptiveRAG generation pipeline for AutoRAG-Research.
+
+AdaptiveRAG routes each query to a retrieval strategy based on predicted complexity:
+- zero: answer directly without retrieval
+- single: single-pass retrieval then generation
+- multi: iterative retrieval with follow-up query generation
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker
+
+DEFAULT_COMPLEXITY_PROMPT_TEMPLATE = """Classify the following question complexity as exactly one of: simple, moderate, complex.
+
+- simple: can be answered directly without retrieval
+- moderate: needs one retrieval pass
+- complex: needs iterative multi-step retrieval
+
+Question: {query}
+
+Return only one word: simple, moderate, or complex."""
+
+DEFAULT_ZERO_RETRIEVAL_PROMPT_TEMPLATE = """Answer the question directly.
+
+Question: {query}
+
+Answer:"""
+
+DEFAULT_SINGLE_RETRIEVAL_PROMPT_TEMPLATE = """Answer the question with the provided context.
+
+Context:
+{context}
+
+Question: {query}
+
+Answer:"""
+
+DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE = """You are performing iterative retrieval for a complex question.
+
+Question: {query}
+
+Current Context:
+{context}
+
+Previous Follow-up Queries:
+{follow_up_queries}
+
+Generate the next short retrieval query to gather missing evidence.
+If enough evidence is already available, respond exactly with STOP.
+
+Next Retrieval Query:"""
+
+DEFAULT_MULTI_RETRIEVAL_ANSWER_PROMPT_TEMPLATE = """Answer the question using the collected evidence.
+
+Question: {query}
+
+Collected Context:
+{context}
+
+Follow-up Queries Used:
+{follow_up_queries}
+
+Answer:"""
+
+
+@dataclass(kw_only=True)
+class AdaptiveRAGPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for AdaptiveRAG generation pipeline."""
+
+    complexity_prompt_template: str = field(default=DEFAULT_COMPLEXITY_PROMPT_TEMPLATE)
+    zero_retrieval_prompt_template: str = field(default=DEFAULT_ZERO_RETRIEVAL_PROMPT_TEMPLATE)
+    single_retrieval_prompt_template: str = field(default=DEFAULT_SINGLE_RETRIEVAL_PROMPT_TEMPLATE)
+    multi_retrieval_query_prompt_template: str = field(default=DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE)
+    multi_retrieval_answer_prompt_template: str = field(default=DEFAULT_MULTI_RETRIEVAL_ANSWER_PROMPT_TEMPLATE)
+    route_for_simple: Literal["zero", "single", "multi"] = "zero"
+    route_for_moderate: Literal["zero", "single", "multi"] = "single"
+    route_for_complex: Literal["zero", "single", "multi"] = "multi"
+    max_multi_steps: int = 2
+    stop_query_signal: str = "STOP"
+
+    def get_pipeline_class(self) -> type["AdaptiveRAGPipeline"]:
+        """Return the AdaptiveRAGPipeline class."""
+        return AdaptiveRAGPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for AdaptiveRAGPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "complexity_prompt_template": self.complexity_prompt_template,
+            "zero_retrieval_prompt_template": self.zero_retrieval_prompt_template,
+            "single_retrieval_prompt_template": self.single_retrieval_prompt_template,
+            "multi_retrieval_query_prompt_template": self.multi_retrieval_query_prompt_template,
+            "multi_retrieval_answer_prompt_template": self.multi_retrieval_answer_prompt_template,
+            "route_for_simple": self.route_for_simple,
+            "route_for_moderate": self.route_for_moderate,
+            "route_for_complex": self.route_for_complex,
+            "max_multi_steps": self.max_multi_steps,
+            "stop_query_signal": self.stop_query_signal,
+        }
+
+
+class AdaptiveRAGPipeline(BaseGenerationPipeline):
+    """Adaptive routing generation pipeline with zero/single/multi retrieval modes."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        complexity_prompt_template: str = DEFAULT_COMPLEXITY_PROMPT_TEMPLATE,
+        zero_retrieval_prompt_template: str = DEFAULT_ZERO_RETRIEVAL_PROMPT_TEMPLATE,
+        single_retrieval_prompt_template: str = DEFAULT_SINGLE_RETRIEVAL_PROMPT_TEMPLATE,
+        multi_retrieval_query_prompt_template: str = DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE,
+        multi_retrieval_answer_prompt_template: str = DEFAULT_MULTI_RETRIEVAL_ANSWER_PROMPT_TEMPLATE,
+        route_for_simple: Literal["zero", "single", "multi"] = "zero",
+        route_for_moderate: Literal["zero", "single", "multi"] = "single",
+        route_for_complex: Literal["zero", "single", "multi"] = "multi",
+        max_multi_steps: int = 2,
+        stop_query_signal: str = "STOP",
+        schema: Any | None = None,
+    ):
+        """Initialize AdaptiveRAG pipeline."""
+        self._complexity_prompt_template = complexity_prompt_template
+        self._zero_retrieval_prompt_template = zero_retrieval_prompt_template
+        self._single_retrieval_prompt_template = single_retrieval_prompt_template
+        self._multi_retrieval_query_prompt_template = multi_retrieval_query_prompt_template
+        self._multi_retrieval_answer_prompt_template = multi_retrieval_answer_prompt_template
+        self._route_for_simple = route_for_simple
+        self._route_for_moderate = route_for_moderate
+        self._route_for_complex = route_for_complex
+        self._max_multi_steps = max_multi_steps
+        self._stop_query_signal = stop_query_signal
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return AdaptiveRAG pipeline configuration."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+
+        return {
+            "type": "adaptive_rag",
+            "complexity_prompt_template": self._complexity_prompt_template,
+            "zero_retrieval_prompt_template": self._zero_retrieval_prompt_template,
+            "single_retrieval_prompt_template": self._single_retrieval_prompt_template,
+            "multi_retrieval_query_prompt_template": self._multi_retrieval_query_prompt_template,
+            "multi_retrieval_answer_prompt_template": self._multi_retrieval_answer_prompt_template,
+            "route_for_simple": self._route_for_simple,
+            "route_for_moderate": self._route_for_moderate,
+            "route_for_complex": self._route_for_complex,
+            "max_multi_steps": self._max_multi_steps,
+            "stop_query_signal": self._stop_query_signal,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract text content from an LLM response."""
+        return response.content if hasattr(response, "content") else str(response)
+
+    @staticmethod
+    def _normalize_score(score: Any) -> float:
+        """Normalize retrieval score to float."""
+        if isinstance(score, (int, float)):
+            return float(score)
+        return 0.0
+
+    @staticmethod
+    def _parse_complexity_tier(response_text: str) -> Literal["simple", "moderate", "complex"]:
+        """Parse complexity output, defaulting to moderate for unknown outputs."""
+        normalized = response_text.strip().lower()
+
+        if normalized == "simple":
+            return "simple"
+        if normalized == "moderate":
+            return "moderate"
+        if normalized == "complex":
+            return "complex"
+        if normalized == "medium":
+            return "moderate"
+
+        if "simple" in normalized:
+            return "simple"
+        if "moderate" in normalized or "medium" in normalized:
+            return "moderate"
+        if "complex" in normalized:
+            return "complex"
+
+        return "moderate"
+
+    @staticmethod
+    def _normalize_route(route: str) -> Literal["zero", "single", "multi"]:
+        """Normalize route labels to supported route names."""
+        normalized = route.strip().lower()
+        if normalized in {"zero", "single", "multi"}:
+            if normalized == "zero":
+                return "zero"
+            if normalized == "single":
+                return "single"
+            if normalized == "multi":
+                return "multi"
+        return "single"
+
+    def _select_route(
+        self, complexity_tier: Literal["simple", "moderate", "complex"]
+    ) -> Literal["zero", "single", "multi"]:
+        """Select route name from tier-specific mapping."""
+        route_map = {
+            "simple": self._route_for_simple,
+            "moderate": self._route_for_moderate,
+            "complex": self._route_for_complex,
+        }
+        return self._normalize_route(route_map[complexity_tier])
+
+    @staticmethod
+    def _merge_retrieval_results(result_sets: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+        """Merge retrieval results by doc_id, keeping the highest score per document."""
+        merged: dict[int | str, dict[str, Any]] = {}
+
+        for result_set in result_sets:
+            for result in result_set:
+                doc_id = result.get("doc_id")
+                if doc_id is None:
+                    continue
+
+                score = AdaptiveRAGPipeline._normalize_score(result.get("score"))
+                existing = merged.get(doc_id)
+                if existing is None or score > AdaptiveRAGPipeline._normalize_score(existing.get("score")):
+                    merged[doc_id] = {
+                        "doc_id": doc_id,
+                        "score": score,
+                    }
+
+        return sorted(
+            merged.values(),
+            key=lambda item: (-AdaptiveRAGPipeline._normalize_score(item.get("score")), str(item.get("doc_id"))),
+        )
+
+    def _build_context(self, chunk_ids: list[int | str]) -> str:
+        """Build context text from chunk IDs."""
+        if not chunk_ids:
+            return ""
+        chunk_contents = self._service.get_chunk_contents(chunk_ids)
+        return "\n\n".join(content for content in chunk_contents if content)
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate answer using adaptive route selection."""
+        query_text = self._service.get_query_text(query_id)
+        tracker = TokenUsageTracker()
+
+        complexity_prompt = self._complexity_prompt_template.format(query=query_text)
+        complexity_response = await self._llm.ainvoke(complexity_prompt)
+        tracker.record(complexity_response)
+        complexity_tier = self._parse_complexity_tier(self._extract_text(complexity_response))
+        route = self._select_route(complexity_tier)
+
+        if route == "zero":
+            prompt = self._zero_retrieval_prompt_template.format(query=query_text)
+            answer_response = await self._llm.ainvoke(prompt)
+            tracker.record(answer_response)
+            answer_text = self._extract_text(answer_response)
+
+            return GenerationResult(
+                text=answer_text,
+                token_usage=tracker.total,
+                metadata={
+                    "complexity_tier": complexity_tier,
+                    "route": route,
+                    "retrieved_chunk_ids": [],
+                    "retrieved_scores": [],
+                    "follow_up_queries": [],
+                },
+            )
+
+        if route == "single":
+            retrieved_results = await self._retrieval_pipeline._retrieve_by_id(query_id, top_k)
+            chunk_ids = [item["doc_id"] for item in retrieved_results if item.get("doc_id") is not None]
+            context = self._build_context(chunk_ids)
+            prompt = self._single_retrieval_prompt_template.format(context=context, query=query_text)
+            answer_response = await self._llm.ainvoke(prompt)
+            tracker.record(answer_response)
+            answer_text = self._extract_text(answer_response)
+
+            return GenerationResult(
+                text=answer_text,
+                token_usage=tracker.total,
+                metadata={
+                    "complexity_tier": complexity_tier,
+                    "route": route,
+                    "retrieved_chunk_ids": chunk_ids,
+                    "retrieved_scores": [self._normalize_score(item.get("score")) for item in retrieved_results],
+                    "follow_up_queries": [],
+                },
+            )
+
+        # multi route
+        retrieved_sets: list[list[dict[str, Any]]] = [
+            await self._retrieval_pipeline._retrieve_by_id(query_id, top_k),
+        ]
+        follow_up_queries: list[str] = []
+
+        for _ in range(self._max_multi_steps):
+            merged_so_far = self._merge_retrieval_results(retrieved_sets)[:top_k]
+            context = self._build_context([item["doc_id"] for item in merged_so_far])
+            previous_queries = "\n".join(follow_up_queries) if follow_up_queries else "(none)"
+            next_query_prompt = self._multi_retrieval_query_prompt_template.format(
+                query=query_text,
+                context=context,
+                follow_up_queries=previous_queries,
+            )
+
+            next_query_response = await self._llm.ainvoke(next_query_prompt)
+            tracker.record(next_query_response)
+            next_query = self._extract_text(next_query_response).strip()
+
+            if not next_query or next_query.upper() == self._stop_query_signal.upper():
+                break
+
+            follow_up_queries.append(next_query)
+            retrieved_sets.append(await self._retrieval_pipeline.retrieve(next_query, top_k))
+
+        merged_results = self._merge_retrieval_results(retrieved_sets)[:top_k]
+        merged_chunk_ids = [item["doc_id"] for item in merged_results]
+        final_context = self._build_context(merged_chunk_ids)
+        final_follow_ups = "\n".join(follow_up_queries) if follow_up_queries else "(none)"
+        answer_prompt = self._multi_retrieval_answer_prompt_template.format(
+            query=query_text,
+            context=final_context,
+            follow_up_queries=final_follow_ups,
+        )
+        answer_response = await self._llm.ainvoke(answer_prompt)
+        tracker.record(answer_response)
+        answer_text = self._extract_text(answer_response)
+
+        return GenerationResult(
+            text=answer_text,
+            token_usage=tracker.total,
+            metadata={
+                "complexity_tier": complexity_tier,
+                "route": route,
+                "retrieved_chunk_ids": merged_chunk_ids,
+                "retrieved_scores": [self._normalize_score(item.get("score")) for item in merged_results],
+                "follow_up_queries": follow_up_queries,
+            },
+        )

--- a/autorag_research/pipelines/retrieval/__init__.py
+++ b/autorag_research/pipelines/retrieval/__init__.py
@@ -1,5 +1,9 @@
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
 from autorag_research.pipelines.retrieval.bm25 import BM25PipelineConfig, BM25RetrievalPipeline
+from autorag_research.pipelines.retrieval.gqr_hybrid import (
+    GQRHybridRetrievalPipeline,
+    GQRHybridRetrievalPipelineConfig,
+)
 from autorag_research.pipelines.retrieval.heaven import (
     HEAVENPipelineConfig,
     HEAVENRetrievalPipeline,
@@ -39,6 +43,8 @@ __all__ = [
     "BM25PipelineConfig",
     "BM25RetrievalPipeline",
     "BaseRetrievalPipeline",
+    "GQRHybridRetrievalPipeline",
+    "GQRHybridRetrievalPipelineConfig",
     "HEAVENPipelineConfig",
     "HEAVENRetrievalPipeline",
     "HyDEPipelineConfig",

--- a/autorag_research/pipelines/retrieval/gqr_hybrid.py
+++ b/autorag_research/pipelines/retrieval/gqr_hybrid.py
@@ -1,0 +1,416 @@
+"""Guided Query Refinement (GQR) hybrid retrieval pipeline.
+
+This module adapts the GQR test-time optimization workflow to AutoRAG-Research
+without adding new dependencies:
+
+1. Retrieve first-pass candidates from a primary retriever.
+2. Build complementary guidance scores from another retriever.
+3. Optimize the primary query representation over the candidate pool so the
+   primary score distribution approaches the hybrid guidance distribution.
+4. Rerank the candidate pool with the optimized query representation.
+
+When embedding-level refinement cannot be executed (for example, missing
+query/chunk embeddings), the pipeline falls back to a score-space refinement
+loop that preserves the same optimization objective.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import numpy as np
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseRetrievalPipelineConfig
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.hybrid import HybridRetrievalPipeline
+from autorag_research.util import normalize_zscore
+
+CandidatePoolMode = Literal["primary", "union"]
+
+_EPSILON = 1e-8
+
+
+def _softmax(scores: np.ndarray, temperature: float) -> np.ndarray:
+    """Compute numerically stable softmax probabilities."""
+    if scores.size == 0:
+        return scores
+
+    safe_temperature = max(temperature, _EPSILON)
+    shifted = scores / safe_temperature
+    shifted = shifted - np.max(shifted)
+    exp_scores = np.exp(shifted)
+    denom = float(np.sum(exp_scores))
+    if not np.isfinite(denom) or denom <= _EPSILON:
+        return np.full(scores.shape, 1.0 / scores.size, dtype=np.float64)
+    return exp_scores / denom
+
+
+def _missing_score_floor(score_map: dict[int | str, float]) -> float:
+    """Return a conservative floor score for missing documents."""
+    if not score_map:
+        return -1.0
+
+    values = list(score_map.values())
+    min_score = min(values)
+    max_score = max(values)
+    spread = max_score - min_score
+    return min_score - max(1.0, spread)
+
+
+def _normalize_scores(scores: list[float]) -> np.ndarray:
+    """Normalize score vectors with z-score normalization."""
+    normalized = normalize_zscore(cast(list[float | None], scores))
+    return np.asarray([0.0 if value is None else float(value) for value in normalized], dtype=np.float64)
+
+
+def _cosine_scores(query_vector: np.ndarray, candidate_matrix: np.ndarray) -> np.ndarray:
+    """Compute cosine-similarity scores between query and candidate vectors."""
+    query_norm = np.linalg.norm(query_vector)
+    if query_norm <= _EPSILON:
+        return np.zeros(candidate_matrix.shape[0], dtype=np.float64)
+
+    candidate_norms = np.linalg.norm(candidate_matrix, axis=1)
+    safe_candidate_norms = np.maximum(candidate_norms, _EPSILON)
+    return (candidate_matrix @ query_vector) / (safe_candidate_norms * query_norm)
+
+
+def _cosine_gradients(
+    query_vector: np.ndarray,
+    candidate_matrix: np.ndarray,
+    cosine_scores: np.ndarray,
+) -> np.ndarray:
+    """Compute gradients of cosine scores with respect to query vector."""
+    query_norm = np.linalg.norm(query_vector)
+    if query_norm <= _EPSILON:
+        return np.zeros_like(candidate_matrix)
+
+    candidate_norms = np.linalg.norm(candidate_matrix, axis=1)
+    safe_candidate_norms = np.maximum(candidate_norms, _EPSILON)
+    left = candidate_matrix / (safe_candidate_norms[:, None] * query_norm)
+    right = (cosine_scores[:, None] * query_vector[None, :]) / (query_norm**2)
+    return left - right
+
+
+@dataclass(kw_only=True)
+class GQRHybridRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
+    """Configuration for the GQR hybrid retrieval pipeline."""
+
+    primary_retrieval_pipeline_name: str
+    complementary_retrieval_pipeline_name: str
+    fetch_k_multiplier: int = 2
+    n_steps: int = 25
+    learning_rate: float = 0.1
+    temperature: float = 1.0
+    mixture_alpha: float = 0.5
+    candidate_pool_mode: CandidatePoolMode = "primary"
+
+    def __post_init__(self) -> None:
+        if self.fetch_k_multiplier <= 0:
+            msg = "fetch_k_multiplier must be positive"
+            raise ValueError(msg)
+        if self.n_steps <= 0:
+            msg = "n_steps must be positive"
+            raise ValueError(msg)
+        if self.learning_rate <= 0:
+            msg = "learning_rate must be positive"
+            raise ValueError(msg)
+        if self.temperature <= 0:
+            msg = "temperature must be positive"
+            raise ValueError(msg)
+        if not 0 <= self.mixture_alpha <= 1:
+            msg = "mixture_alpha must be between 0 and 1"
+            raise ValueError(msg)
+        if self.candidate_pool_mode not in {"primary", "union"}:
+            msg = "candidate_pool_mode must be either 'primary' or 'union'"
+            raise ValueError(msg)
+
+    def get_pipeline_class(self) -> type["GQRHybridRetrievalPipeline"]:
+        """Return the GQRHybridRetrievalPipeline class."""
+        return GQRHybridRetrievalPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for GQRHybridRetrievalPipeline constructor."""
+        return {
+            "primary_retrieval_pipeline": self.primary_retrieval_pipeline_name,
+            "complementary_retrieval_pipeline": self.complementary_retrieval_pipeline_name,
+            "fetch_k_multiplier": self.fetch_k_multiplier,
+            "n_steps": self.n_steps,
+            "learning_rate": self.learning_rate,
+            "temperature": self.temperature,
+            "mixture_alpha": self.mixture_alpha,
+            "candidate_pool_mode": self.candidate_pool_mode,
+        }
+
+
+class GQRHybridRetrievalPipeline(BaseRetrievalPipeline):
+    """Guided Query Refinement hybrid retrieval pipeline."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        primary_retrieval_pipeline: BaseRetrievalPipeline | str,
+        complementary_retrieval_pipeline: BaseRetrievalPipeline | str,
+        fetch_k_multiplier: int = 2,
+        n_steps: int = 25,
+        learning_rate: float = 0.1,
+        temperature: float = 1.0,
+        mixture_alpha: float = 0.5,
+        candidate_pool_mode: CandidatePoolMode = "primary",
+        schema: Any | None = None,
+        config_dir: Path | None = None,
+    ):
+        if fetch_k_multiplier <= 0:
+            msg = "fetch_k_multiplier must be positive"
+            raise ValueError(msg)
+        if n_steps <= 0:
+            msg = "n_steps must be positive"
+            raise ValueError(msg)
+        if learning_rate <= 0:
+            msg = "learning_rate must be positive"
+            raise ValueError(msg)
+        if temperature <= 0:
+            msg = "temperature must be positive"
+            raise ValueError(msg)
+        if not 0 <= mixture_alpha <= 1:
+            msg = "mixture_alpha must be between 0 and 1"
+            raise ValueError(msg)
+        if candidate_pool_mode not in {"primary", "union"}:
+            msg = "candidate_pool_mode must be either 'primary' or 'union'"
+            raise ValueError(msg)
+
+        if isinstance(primary_retrieval_pipeline, str):
+            primary_retrieval_pipeline = HybridRetrievalPipeline._load_pipeline(
+                primary_retrieval_pipeline,
+                session_factory,
+                schema,
+                config_dir,
+            )
+        if isinstance(complementary_retrieval_pipeline, str):
+            complementary_retrieval_pipeline = HybridRetrievalPipeline._load_pipeline(
+                complementary_retrieval_pipeline,
+                session_factory,
+                schema,
+                config_dir,
+            )
+
+        self._primary_retrieval_pipeline = primary_retrieval_pipeline
+        self._complementary_retrieval_pipeline = complementary_retrieval_pipeline
+        self.fetch_k_multiplier = fetch_k_multiplier
+        self.n_steps = n_steps
+        self.learning_rate = learning_rate
+        self.temperature = temperature
+        self.mixture_alpha = mixture_alpha
+        self.candidate_pool_mode = candidate_pool_mode
+
+        super().__init__(session_factory, name, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return GQR pipeline configuration."""
+        return {
+            "type": "gqr_hybrid",
+            "primary_retrieval_pipeline": self._primary_retrieval_pipeline.name,
+            "complementary_retrieval_pipeline": self._complementary_retrieval_pipeline.name,
+            "fetch_k_multiplier": self.fetch_k_multiplier,
+            "n_steps": self.n_steps,
+            "learning_rate": self.learning_rate,
+            "temperature": self.temperature,
+            "mixture_alpha": self.mixture_alpha,
+            "candidate_pool_mode": self.candidate_pool_mode,
+        }
+
+    @staticmethod
+    def _build_score_map(results: list[dict[str, Any]]) -> dict[int | str, float]:
+        """Build doc_id -> score mapping."""
+        return {result["doc_id"]: float(result["score"]) for result in results}
+
+    def _build_candidate_ids(
+        self,
+        primary_results: list[dict[str, Any]],
+        complementary_results: list[dict[str, Any]],
+    ) -> list[int | str]:
+        """Build candidate pool IDs based on configured strategy."""
+        if self.candidate_pool_mode == "primary":
+            return [result["doc_id"] for result in primary_results]
+
+        seen: set[int | str] = set()
+        candidate_ids: list[int | str] = []
+        for result in [*primary_results, *complementary_results]:
+            doc_id = result["doc_id"]
+            if doc_id in seen:
+                continue
+            seen.add(doc_id)
+            candidate_ids.append(doc_id)
+        return candidate_ids
+
+    @staticmethod
+    def _build_score_vector(candidate_ids: list[int | str], score_map: dict[int | str, float]) -> np.ndarray:
+        """Build a normalized score vector aligned to candidate_ids."""
+        missing_floor = _missing_score_floor(score_map)
+        raw_scores = [score_map.get(doc_id, missing_floor) for doc_id in candidate_ids]
+        return _normalize_scores(raw_scores)
+
+    @staticmethod
+    def _sort_results(score_map: dict[int | str, float], top_k: int) -> list[dict[str, Any]]:
+        """Sort results by score and truncate to top_k."""
+        sorted_items = sorted(score_map.items(), key=lambda item: item[1], reverse=True)
+        return [{"doc_id": doc_id, "score": score} for doc_id, score in sorted_items[:top_k]]
+
+    def _get_query_embedding_by_id(self, query_id: int | str) -> np.ndarray | None:
+        """Fetch stored query embedding for optimization."""
+        with self._service._create_uow() as uow:
+            query = uow.queries.get_by_id(query_id)
+            if query is None or query.embedding is None:
+                return None
+            return np.asarray(list(query.embedding), dtype=np.float64)
+
+    async def _get_query_embedding_by_text(self, query_text: str) -> np.ndarray | None:
+        """Build query embedding for ad-hoc text when the primary pipeline supports it."""
+        embedding_model = getattr(self._primary_retrieval_pipeline, "_embedding_model", None)
+        if embedding_model is None:
+            return None
+
+        query_embedding = await embedding_model.aembed_query(query_text)
+        return np.asarray(query_embedding, dtype=np.float64)
+
+    def _get_candidate_embeddings(
+        self,
+        candidate_ids: list[int | str],
+    ) -> tuple[list[int | str], np.ndarray]:
+        """Load candidate chunk embeddings from the database."""
+        if not candidate_ids:
+            return [], np.empty((0, 0), dtype=np.float64)
+
+        with self._service._create_uow() as uow:
+            chunks = uow.chunks.get_by_ids(candidate_ids)
+
+        chunk_by_id = {chunk.id: chunk for chunk in chunks}
+        embedding_ids: list[int | str] = []
+        embedding_rows: list[list[float]] = []
+        for doc_id in candidate_ids:
+            chunk = chunk_by_id.get(doc_id)
+            if chunk is None or chunk.embedding is None:
+                continue
+            embedding_ids.append(doc_id)
+            embedding_rows.append(list(chunk.embedding))
+
+        if not embedding_rows:
+            return [], np.empty((0, 0), dtype=np.float64)
+
+        return embedding_ids, np.asarray(embedding_rows, dtype=np.float64)
+
+    def _optimize_in_score_space(
+        self,
+        primary_scores: np.ndarray,
+        target_distribution: np.ndarray,
+    ) -> np.ndarray:
+        """Fallback optimization directly over primary score logits."""
+        logits = primary_scores.astype(np.float64, copy=True)
+        temperature = max(self.temperature, _EPSILON)
+        for _ in range(self.n_steps):
+            probs = _softmax(logits, temperature)
+            grad_logits = (probs - target_distribution) / temperature
+            logits -= self.learning_rate * grad_logits
+        return logits
+
+    def _optimize_query_embedding(
+        self,
+        query_embedding: np.ndarray,
+        candidate_embeddings: np.ndarray,
+        target_distribution: np.ndarray,
+    ) -> np.ndarray:
+        """Optimize the primary query embedding with KL guidance."""
+        refined_query = query_embedding.astype(np.float64, copy=True)
+        temperature = max(self.temperature, _EPSILON)
+
+        for _ in range(self.n_steps):
+            cosine_scores = _cosine_scores(refined_query, candidate_embeddings)
+            probs = _softmax(cosine_scores, temperature)
+            grad_logits = (probs - target_distribution) / temperature
+            grad_scores = _cosine_gradients(refined_query, candidate_embeddings, cosine_scores)
+            grad_query = np.sum(grad_logits[:, None] * grad_scores, axis=0)
+            refined_query -= self.learning_rate * grad_query
+
+        return _cosine_scores(refined_query, candidate_embeddings)
+
+    async def _run_gqr(
+        self,
+        *,
+        top_k: int,
+        query_embedding: np.ndarray | None,
+        primary_results: list[dict[str, Any]],
+        complementary_results: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Execute GQR refinement and rerank the candidate pool."""
+        candidate_ids = self._build_candidate_ids(primary_results, complementary_results)
+        if not candidate_ids:
+            return []
+
+        primary_score_map = self._build_score_map(primary_results)
+        complementary_score_map = self._build_score_map(complementary_results)
+
+        primary_scores = self._build_score_vector(candidate_ids, primary_score_map)
+        complementary_scores = self._build_score_vector(candidate_ids, complementary_score_map)
+
+        primary_distribution = _softmax(primary_scores, self.temperature)
+        complementary_distribution = _softmax(complementary_scores, self.temperature)
+        target_distribution = (
+            (1 - self.mixture_alpha) * primary_distribution + self.mixture_alpha * complementary_distribution
+        )
+
+        final_score_map: dict[int | str, float] = {
+            doc_id: float(primary_scores[index]) for index, doc_id in enumerate(candidate_ids)
+        }
+
+        embedding_ids, candidate_embeddings = self._get_candidate_embeddings(candidate_ids)
+        if query_embedding is not None and embedding_ids and candidate_embeddings.size > 0:
+            id_to_index = {doc_id: idx for idx, doc_id in enumerate(candidate_ids)}
+            distribution_indices = [id_to_index[doc_id] for doc_id in embedding_ids]
+            embedding_target = target_distribution[distribution_indices]
+            embedding_target = embedding_target / max(float(embedding_target.sum()), _EPSILON)
+            optimized_scores = self._optimize_query_embedding(
+                query_embedding=query_embedding,
+                candidate_embeddings=candidate_embeddings,
+                target_distribution=embedding_target,
+            )
+            for doc_id, score in zip(embedding_ids, optimized_scores, strict=True):
+                final_score_map[doc_id] = float(score)
+        else:
+            optimized_scores = self._optimize_in_score_space(primary_scores, target_distribution)
+            final_score_map = {
+                doc_id: float(optimized_scores[index]) for index, doc_id in enumerate(candidate_ids)
+            }
+
+        return self._sort_results(final_score_map, top_k)
+
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        """Retrieve with Guided Query Refinement using query ID."""
+        fetch_k = top_k * self.fetch_k_multiplier
+        primary_results = await self._primary_retrieval_pipeline._retrieve_by_id(query_id, fetch_k)
+        complementary_results = await self._complementary_retrieval_pipeline._retrieve_by_id(query_id, fetch_k)
+
+        query_embedding = self._get_query_embedding_by_id(query_id)
+        return await self._run_gqr(
+            top_k=top_k,
+            query_embedding=query_embedding,
+            primary_results=primary_results,
+            complementary_results=complementary_results,
+        )
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        """Retrieve with Guided Query Refinement using raw query text."""
+        fetch_k = top_k * self.fetch_k_multiplier
+        primary_results = await self._primary_retrieval_pipeline._retrieve_by_text(query_text, fetch_k)
+        complementary_results = await self._complementary_retrieval_pipeline._retrieve_by_text(query_text, fetch_k)
+
+        query_embedding = await self._get_query_embedding_by_text(query_text)
+        return await self._run_gqr(
+            top_k=top_k,
+            query_embedding=query_embedding,
+            primary_results=primary_results,
+            complementary_results=complementary_results,
+        )
+
+
+__all__ = ["GQRHybridRetrievalPipeline", "GQRHybridRetrievalPipelineConfig"]

--- a/autorag_research/pipelines/retrieval/gqr_hybrid.py
+++ b/autorag_research/pipelines/retrieval/gqr_hybrid.py
@@ -22,6 +22,7 @@ import numpy as np
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
+from autorag_research.exceptions import EmbeddingError
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
 from autorag_research.pipelines.retrieval.hybrid import HybridRetrievalPipeline
 from autorag_research.util import normalize_zscore
@@ -103,7 +104,7 @@ class GQRHybridRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
     learning_rate: float = 0.1
     temperature: float = 1.0
     mixture_alpha: float = 0.5
-    candidate_pool_mode: CandidatePoolMode = "primary"
+    candidate_pool_mode: CandidatePoolMode = "union"
 
     def __post_init__(self) -> None:
         if self.fetch_k_multiplier <= 0:
@@ -157,7 +158,7 @@ class GQRHybridRetrievalPipeline(BaseRetrievalPipeline):
         learning_rate: float = 0.1,
         temperature: float = 1.0,
         mixture_alpha: float = 0.5,
-        candidate_pool_mode: CandidatePoolMode = "primary",
+        candidate_pool_mode: CandidatePoolMode = "union",
         schema: Any | None = None,
         config_dir: Path | None = None,
     ):
@@ -356,8 +357,8 @@ class GQRHybridRetrievalPipeline(BaseRetrievalPipeline):
         primary_distribution = _softmax(primary_scores, self.temperature)
         complementary_distribution = _softmax(complementary_scores, self.temperature)
         target_distribution = (
-            (1 - self.mixture_alpha) * primary_distribution + self.mixture_alpha * complementary_distribution
-        )
+            1 - self.mixture_alpha
+        ) * primary_distribution + self.mixture_alpha * complementary_distribution
 
         final_score_map: dict[int | str, float] = {
             doc_id: float(primary_scores[index]) for index, doc_id in enumerate(candidate_ids)
@@ -378,9 +379,7 @@ class GQRHybridRetrievalPipeline(BaseRetrievalPipeline):
                 final_score_map[doc_id] = float(score)
         else:
             optimized_scores = self._optimize_in_score_space(primary_scores, target_distribution)
-            final_score_map = {
-                doc_id: float(optimized_scores[index]) for index, doc_id in enumerate(candidate_ids)
-            }
+            final_score_map = {doc_id: float(optimized_scores[index]) for index, doc_id in enumerate(candidate_ids)}
 
         return self._sort_results(final_score_map, top_k)
 
@@ -401,8 +400,21 @@ class GQRHybridRetrievalPipeline(BaseRetrievalPipeline):
     async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
         """Retrieve with Guided Query Refinement using raw query text."""
         fetch_k = top_k * self.fetch_k_multiplier
-        primary_results = await self._primary_retrieval_pipeline._retrieve_by_text(query_text, fetch_k)
-        complementary_results = await self._complementary_retrieval_pipeline._retrieve_by_text(query_text, fetch_k)
+        primary_results: list[dict[str, Any]]
+        complementary_results: list[dict[str, Any]]
+
+        try:
+            primary_results = await self._primary_retrieval_pipeline._retrieve_by_text(query_text, fetch_k)
+        except EmbeddingError:
+            complementary_results = await self._complementary_retrieval_pipeline._retrieve_by_text(query_text, fetch_k)
+            primary_results = complementary_results
+        else:
+            try:
+                complementary_results = await self._complementary_retrieval_pipeline._retrieve_by_text(
+                    query_text, fetch_k
+                )
+            except EmbeddingError:
+                complementary_results = primary_results
 
         query_embedding = await self._get_query_embedding_by_text(query_text)
         return await self._run_gqr(

--- a/autorag_research/pipelines/retrieval/gqr_hybrid.py
+++ b/autorag_research/pipelines/retrieval/gqr_hybrid.py
@@ -365,7 +365,8 @@ class GQRHybridRetrievalPipeline(BaseRetrievalPipeline):
         }
 
         embedding_ids, candidate_embeddings = self._get_candidate_embeddings(candidate_ids)
-        if query_embedding is not None and embedding_ids and candidate_embeddings.size > 0:
+        all_candidates_have_embeddings = len(embedding_ids) == len(candidate_ids)
+        if query_embedding is not None and all_candidates_have_embeddings and candidate_embeddings.size > 0:
             id_to_index = {doc_id: idx for idx, doc_id in enumerate(candidate_ids)}
             distribution_indices = [id_to_index[doc_id] for doc_id in embedding_ids]
             embedding_target = target_distribution[distribution_indices]

--- a/configs/pipelines/generation/adaptive_rag.yaml
+++ b/configs/pipelines/generation/adaptive_rag.yaml
@@ -1,0 +1,15 @@
+_target_: autorag_research.pipelines.generation.adaptive_rag.AdaptiveRAGPipelineConfig
+description: "AdaptiveRAG: route queries across zero/single/multi retrieval by predicted complexity"
+name: adaptive_rag
+retrieval_pipeline_name: bm25
+llm: gpt-4o-mini
+route_for_simple: zero
+route_for_moderate: single
+route_for_complex: multi
+max_multi_steps: 2
+stop_query_signal: STOP
+top_k: 10
+batch_size: 128
+max_concurrency: 8
+max_retries: 3
+retry_delay: 1.0

--- a/configs/pipelines/retrieval/gqr_hybrid.yaml
+++ b/configs/pipelines/retrieval/gqr_hybrid.yaml
@@ -13,7 +13,7 @@
 #   learning_rate: Query update step size
 #   temperature: Softmax temperature for retrieval distributions
 #   mixture_alpha: Guidance weight from complementary distribution (0-1)
-#   candidate_pool_mode: "primary" (primary-only pool) or "union" (primary∪complementary)
+#   candidate_pool_mode: "union" (true hybrid pool) or "primary" (primary-bounded reranker)
 #
 _target_: autorag_research.pipelines.retrieval.gqr_hybrid.GQRHybridRetrievalPipelineConfig
 description: "Guided Query Refinement hybrid retrieval"
@@ -25,7 +25,7 @@ n_steps: 25
 learning_rate: 0.1
 temperature: 1.0
 mixture_alpha: 0.5
-candidate_pool_mode: primary
+candidate_pool_mode: union
 top_k: 10
 batch_size: 128
 max_concurrency: 16

--- a/configs/pipelines/retrieval/gqr_hybrid.yaml
+++ b/configs/pipelines/retrieval/gqr_hybrid.yaml
@@ -1,0 +1,33 @@
+# GQR Hybrid Retrieval Pipeline Configuration
+#
+# Guided Query Refinement (GQR) performs test-time optimization of a primary
+# retriever's query representation using guidance signals from a complementary
+# retriever. Optimization is bounded to the candidate pool (no second full-index
+# search required).
+#
+# Parameters:
+#   primary_retrieval_pipeline_name: Primary pipeline to optimize (usually dense)
+#   complementary_retrieval_pipeline_name: Guidance pipeline
+#   fetch_k_multiplier: Retrieves top_k * multiplier from each pipeline first
+#   n_steps: Number of test-time optimization steps
+#   learning_rate: Query update step size
+#   temperature: Softmax temperature for retrieval distributions
+#   mixture_alpha: Guidance weight from complementary distribution (0-1)
+#   candidate_pool_mode: "primary" (primary-only pool) or "union" (primary∪complementary)
+#
+_target_: autorag_research.pipelines.retrieval.gqr_hybrid.GQRHybridRetrievalPipelineConfig
+description: "Guided Query Refinement hybrid retrieval"
+name: gqr_hybrid
+primary_retrieval_pipeline_name: vector_search
+complementary_retrieval_pipeline_name: bm25
+fetch_k_multiplier: 2
+n_steps: 25
+learning_rate: 0.1
+temperature: 1.0
+mixture_alpha: 0.5
+candidate_pool_mode: primary
+top_k: 10
+batch_size: 128
+max_concurrency: 16
+max_retries: 3
+retry_delay: 1.0

--- a/docs/pipelines/retrieval/gqr-hybrid.md
+++ b/docs/pipelines/retrieval/gqr-hybrid.md
@@ -1,0 +1,60 @@
+# GQR Hybrid Retrieval
+
+Guided Query Refinement (GQR) is a hybrid retrieval wrapper that uses one primary retriever for the first-pass candidate scores and one complementary retriever as guidance. It then optimizes the primary query representation, or a score-space fallback, so the final ranking moves toward the hybrid guidance distribution.
+
+## When to use
+
+Use GQR when you want dense-first retrieval to benefit from a complementary lexical or sparse signal without adding a separate reranker dependency.
+
+Typical pairing:
+
+- **Primary**: `vector_search`
+- **Complementary**: `bm25`
+- **Candidate pool**: `union` for true hybrid coverage, or `primary` for primary-bounded reranking
+
+## Configuration
+
+```yaml
+_target_: autorag_research.pipelines.retrieval.gqr_hybrid.GQRHybridRetrievalPipelineConfig
+name: gqr_hybrid
+primary_retrieval_pipeline_name: vector_search
+complementary_retrieval_pipeline_name: bm25
+fetch_k_multiplier: 2
+n_steps: 25
+learning_rate: 0.1
+temperature: 1.0
+mixture_alpha: 0.5
+candidate_pool_mode: union
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `primary_retrieval_pipeline_name` | string | required | First-pass retriever that provides the primary scores and, when available, the query embedding. |
+| `complementary_retrieval_pipeline_name` | string | required | Guidance retriever used to build the complementary target distribution. |
+| `fetch_k_multiplier` | int | `2` | Fetches `top_k * fetch_k_multiplier` from each child before reranking. |
+| `n_steps` | int | `25` | Optimization steps for embedding-level or score-space refinement. |
+| `learning_rate` | float | `0.1` | Step size for refinement. |
+| `temperature` | float | `1.0` | Softmax temperature used for primary, complementary, and target distributions. |
+| `mixture_alpha` | float | `0.5` | Guidance weight: `0.0` follows primary scores, `1.0` follows complementary scores. |
+| `candidate_pool_mode` | `union` or `primary` | `union` | `union` includes candidates from both retrievers; `primary` keeps only primary candidates. |
+
+## Scoring contract
+
+GQR result scores are **ranking scores**: higher is better within the returned list, but the numeric magnitude is not calibrated across execution modes or against other pipelines.
+
+GQR has two scoring paths:
+
+1. **Embedding-level refinement** runs when a query embedding exists and every selected candidate has a chunk embedding. Scores are cosine-derived values from the refined query embedding.
+2. **Score-space fallback** runs when query embeddings are unavailable or when any selected candidate lacks an embedding. In partial-embedding pools, GQR falls back for the entire pool so one result list does not mix cosine scores with normalized primary-score values.
+
+Use ordering and retrieval metrics for evaluation. Do not compare raw GQR score magnitudes across embedding-backed and fallback-backed runs.
+
+## Text-query behavior
+
+For ad-hoc text queries, GQR first asks its child retrievers for text results. If the primary vector retriever cannot embed raw text, GQR falls back to text-capable complementary results and then applies score-space refinement.
+
+For ID/batch retrieval, stored query and chunk embeddings enable the embedding-level path when all selected candidates are embedded.
+
+## Dependency loading note
+
+GQR currently resolves `primary_retrieval_pipeline_name` and `complementary_retrieval_pipeline_name` through the same child-loader helper used by hybrid retrieval. This keeps the runnable YAML config compatible with existing retrieval pipeline loading while preserving explicit primary/complementary roles in the GQR config.

--- a/docs/pipelines/retrieval/index.md
+++ b/docs/pipelines/retrieval/index.md
@@ -8,6 +8,7 @@ Algorithms that take a query and return relevant documents.
 |----------|-----------|----------|
 | [BM25](bm25.md) | Sparse (term frequency) | Text |
 | [Hybrid](hybrid.md) | RRF / Convex Combination | Text |
+| [GQR Hybrid](gqr-hybrid.md) | Guided Query Refinement over hybrid candidates | Text |
 | [Vector Search](vector-search.md) | Dense (vector similarity) | Text |
 | [HyDE](hyde.md) | Dense (hypothetical document embeddings) | Text |
 | [Query Rewrite](query-rewrite.md) | Rewrite query text before retrieval | Text |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
           - pipelines/retrieval/bm25.md
           - pipelines/retrieval/retro-star.md
           - pipelines/retrieval/vector-search.md
+          - pipelines/retrieval/gqr-hybrid.md
           - pipelines/retrieval/power-of-noise.md
       - Generation:
           - pipelines/generation/index.md

--- a/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -133,6 +134,27 @@ class TestAdaptiveRAGPipeline:
 
     def test_default_multi_retrieval_query_prompt_uses_configurable_stop_signal(self):
         assert "{stop_query_signal}" in DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE
+
+    def test_invalid_constructor_route_raises_value_error(self, session_factory, mock_retrieval):
+        llm = FakeListLLM(responses=["answer"])
+
+        with pytest.raises(ValueError, match="route_for_simple"):
+            AdaptiveRAGPipeline(
+                session_factory=session_factory,
+                name="test_adaptive_rag_invalid_route",
+                llm=llm,
+                retrieval_pipeline=mock_retrieval,
+                route_for_simple=cast(Any, "singel"),
+            )
+
+    def test_invalid_config_route_raises_value_error(self):
+        with pytest.raises(ValueError, match="route_for_complex"):
+            AdaptiveRAGPipelineConfig(
+                name="adaptive_rag_invalid_cfg",
+                retrieval_pipeline_name="bm25",
+                llm=FakeListLLM(responses=["answer"]),
+                route_for_complex=cast(Any, "mulit"),
+            )
 
     def test_adaptive_rag_config(self, mock_retrieval):
         llm = FakeListLLM(responses=["answer"])

--- a/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
@@ -1,0 +1,210 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from autorag_research.pipelines.generation.adaptive_rag import AdaptiveRAGPipeline, AdaptiveRAGPipelineConfig
+from tests.autorag_research.pipelines.pipeline_test_utils import (
+    PipelineTestConfig,
+    PipelineTestVerifier,
+    cleanup_pipeline_results_factory,
+    create_mock_llm,
+    create_mock_retrieval_pipeline,
+)
+
+
+@pytest.fixture
+def cleanup(session_factory):
+    yield from cleanup_pipeline_results_factory(session_factory)
+
+
+@pytest.fixture
+def mock_retrieval():
+    return create_mock_retrieval_pipeline(
+        default_results=[
+            {"doc_id": 1, "score": 0.95},
+            {"doc_id": 2, "score": 0.85},
+            {"doc_id": 3, "score": 0.75},
+        ]
+    )
+
+
+class TestAdaptiveRAGPipeline:
+    @pytest.mark.asyncio
+    async def test_zero_route_skips_retrieval(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["simple", "Direct answer"])
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_zero",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=3)
+
+        assert result.text == "Direct answer"
+        assert result.metadata is not None
+        assert result.metadata["complexity_tier"] == "simple"
+        assert result.metadata["route"] == "zero"
+        assert result.metadata["retrieved_chunk_ids"] == []
+        assert result.metadata["follow_up_queries"] == []
+        assert mock_retrieval._retrieve_by_id.await_count == 0
+        assert mock_retrieval.retrieve.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_single_route_uses_single_retrieval(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["moderate", "Single answer"])
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_single",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=3)
+
+        assert result.text == "Single answer"
+        assert result.metadata is not None
+        assert result.metadata["complexity_tier"] == "moderate"
+        assert result.metadata["route"] == "single"
+        assert result.metadata["retrieved_chunk_ids"] == [1, 2, 3]
+        assert result.metadata["retrieved_scores"] == [0.95, 0.85, 0.75]
+        assert result.metadata["follow_up_queries"] == []
+        mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 3)
+        assert mock_retrieval.retrieve.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_multi_route_performs_iterative_retrieval(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["complex", "follow up query", "STOP", "Complex answer"])
+        mock_retrieval._retrieve_by_id = AsyncMock(
+            return_value=[{"doc_id": 1, "score": 0.8}, {"doc_id": 2, "score": 0.7}]
+        )
+        mock_retrieval.retrieve = AsyncMock(return_value=[{"doc_id": 4, "score": 0.95}])
+
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_multi",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+            max_multi_steps=2,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=4)
+
+        assert result.text == "Complex answer"
+        assert result.metadata is not None
+        assert result.metadata["complexity_tier"] == "complex"
+        assert result.metadata["route"] == "multi"
+        assert result.metadata["follow_up_queries"] == ["follow up query"]
+        assert result.metadata["retrieved_chunk_ids"] == [4, 1, 2]
+        assert result.metadata["retrieved_scores"] == [0.95, 0.8, 0.7]
+        mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 4)
+        mock_retrieval.retrieve.assert_awaited_once_with("follow up query", 4)
+
+    @pytest.mark.asyncio
+    async def test_unknown_complexity_falls_back_to_single_route(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["uncertain", "Fallback single answer"])
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_fallback",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = await pipeline._generate(query_id=1, top_k=2)
+
+        assert result.text == "Fallback single answer"
+        assert result.metadata is not None
+        assert result.metadata["complexity_tier"] == "moderate"
+        assert result.metadata["route"] == "single"
+        mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 2)
+        assert mock_retrieval.retrieve.await_count == 0
+
+    def test_adaptive_rag_config(self, mock_retrieval):
+        llm = FakeListLLM(responses=["answer"])
+        config = AdaptiveRAGPipelineConfig(
+            name="adaptive_rag_cfg",
+            retrieval_pipeline_name="bm25",
+            llm=llm,
+            route_for_simple="single",
+            route_for_moderate="multi",
+            route_for_complex="zero",
+            max_multi_steps=4,
+            stop_query_signal="DONE",
+        )
+        config.inject_retrieval_pipeline(mock_retrieval)
+
+        kwargs = config.get_pipeline_kwargs()
+
+        assert config.get_pipeline_class() is AdaptiveRAGPipeline
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is mock_retrieval
+        assert kwargs["route_for_simple"] == "single"
+        assert kwargs["route_for_moderate"] == "multi"
+        assert kwargs["route_for_complex"] == "zero"
+        assert kwargs["max_multi_steps"] == 4
+        assert kwargs["stop_query_signal"] == "DONE"
+
+    def test_pipeline_config_output(self, session_factory, mock_retrieval, cleanup):
+        llm = FakeListLLM(responses=["simple", "answer"])
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_config_output",
+            llm=llm,
+            retrieval_pipeline=mock_retrieval,
+            route_for_simple="zero",
+            route_for_moderate="single",
+            route_for_complex="multi",
+            max_multi_steps=3,
+            stop_query_signal="HALT",
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        config = pipeline._get_pipeline_config()
+
+        assert config["type"] == "adaptive_rag"
+        assert config["retrieval_pipeline_id"] == mock_retrieval.pipeline_id
+        assert config["route_for_simple"] == "zero"
+        assert config["route_for_moderate"] == "single"
+        assert config["route_for_complex"] == "multi"
+        assert config["max_multi_steps"] == 3
+        assert config["stop_query_signal"] == "HALT"
+        assert "complexity_prompt_template" in config
+        assert "zero_retrieval_prompt_template" in config
+        assert "single_retrieval_prompt_template" in config
+        assert "multi_retrieval_query_prompt_template" in config
+        assert "multi_retrieval_answer_prompt_template" in config
+
+    def test_run_pipeline(self, session_factory, cleanup):
+        from autorag_research.orm.repository.query import QueryRepository
+
+        with session_factory() as session:
+            query_repo = QueryRepository(session)
+            query_count = query_repo.count()
+
+        retrieval = create_mock_retrieval_pipeline()
+        llm = create_mock_llm()
+
+        pipeline = AdaptiveRAGPipeline(
+            session_factory=session_factory,
+            name="test_adaptive_rag_run",
+            llm=llm,
+            retrieval_pipeline=retrieval,
+        )
+        cleanup.append(pipeline.pipeline_id)
+
+        result = pipeline.run(top_k=2, batch_size=10)
+
+        config = PipelineTestConfig(
+            pipeline_type="generation",
+            expected_total_queries=query_count,
+            check_token_usage=True,
+            check_execution_time=True,
+            check_persistence=True,
+        )
+        verifier = PipelineTestVerifier(result, pipeline.pipeline_id, session_factory, config)
+        verifier.verify_all()

--- a/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py
@@ -3,7 +3,11 @@ from unittest.mock import AsyncMock
 import pytest
 from langchain_core.language_models.fake import FakeListLLM
 
-from autorag_research.pipelines.generation.adaptive_rag import AdaptiveRAGPipeline, AdaptiveRAGPipelineConfig
+from autorag_research.pipelines.generation.adaptive_rag import (
+    DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE,
+    AdaptiveRAGPipeline,
+    AdaptiveRAGPipelineConfig,
+)
 from tests.autorag_research.pipelines.pipeline_test_utils import (
     PipelineTestConfig,
     PipelineTestVerifier,
@@ -124,6 +128,12 @@ class TestAdaptiveRAGPipeline:
         mock_retrieval._retrieve_by_id.assert_awaited_once_with(1, 2)
         assert mock_retrieval.retrieve.await_count == 0
 
+    def test_ambiguous_complexity_output_falls_back_to_moderate(self):
+        assert AdaptiveRAGPipeline._parse_complexity_tier("not simple; complex") == "moderate"
+
+    def test_default_multi_retrieval_query_prompt_uses_configurable_stop_signal(self):
+        assert "{stop_query_signal}" in DEFAULT_MULTI_RETRIEVAL_QUERY_PROMPT_TEMPLATE
+
     def test_adaptive_rag_config(self, mock_retrieval):
         llm = FakeListLLM(responses=["answer"])
         config = AdaptiveRAGPipelineConfig(
@@ -206,5 +216,6 @@ class TestAdaptiveRAGPipeline:
             check_execution_time=True,
             check_persistence=True,
         )
+        assert isinstance(pipeline.pipeline_id, int)
         verifier = PipelineTestVerifier(result, pipeline.pipeline_id, session_factory, config)
         verifier.verify_all()

--- a/tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py
@@ -1,0 +1,232 @@
+"""Tests for GQR hybrid retrieval pipeline."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.gqr_hybrid import (
+    GQRHybridRetrievalPipeline,
+    GQRHybridRetrievalPipelineConfig,
+)
+
+
+def _make_stub_pipeline(name: str, by_id_results: list[dict], by_text_results: list[dict]) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        _retrieve_by_id=AsyncMock(return_value=by_id_results),
+        _retrieve_by_text=AsyncMock(return_value=by_text_results),
+    )
+
+
+class TestGQRHybridRetrievalPipelineConfig:
+    """Tests for GQRHybridRetrievalPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        config = GQRHybridRetrievalPipelineConfig(
+            name="gqr_test",
+            primary_retrieval_pipeline_name="vector_search",
+            complementary_retrieval_pipeline_name="bm25",
+        )
+
+        assert config.get_pipeline_class() == GQRHybridRetrievalPipeline
+
+    def test_get_pipeline_kwargs(self):
+        config = GQRHybridRetrievalPipelineConfig(
+            name="gqr_test",
+            primary_retrieval_pipeline_name="vector_search",
+            complementary_retrieval_pipeline_name="bm25",
+            fetch_k_multiplier=3,
+            n_steps=10,
+            learning_rate=0.3,
+            temperature=0.8,
+            mixture_alpha=0.2,
+            candidate_pool_mode="union",
+        )
+
+        assert config.get_pipeline_kwargs() == {
+            "primary_retrieval_pipeline": "vector_search",
+            "complementary_retrieval_pipeline": "bm25",
+            "fetch_k_multiplier": 3,
+            "n_steps": 10,
+            "learning_rate": 0.3,
+            "temperature": 0.8,
+            "mixture_alpha": 0.2,
+            "candidate_pool_mode": "union",
+        }
+
+
+class TestGQRHybridRetrievalPipeline:
+    """Tests for GQRHybridRetrievalPipeline behavior."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_base_pipeline_init(self, monkeypatch: pytest.MonkeyPatch):
+        def _fake_base_init(self, session_factory, name, schema=None):
+            self.session_factory = session_factory
+            self.name = name
+            self._schema = schema
+            self.pipeline_id = 1
+            self._is_new_pipeline = True
+            self._service = SimpleNamespace(_create_uow=lambda: None)
+
+        monkeypatch.setattr(BaseRetrievalPipeline, "__init__", _fake_base_init)
+
+    def test_pipeline_creation_with_names(self, session_factory: sessionmaker[Session]):
+        with patch("autorag_research.pipelines.retrieval.hybrid.HybridRetrievalPipeline._load_pipeline") as mock_load:
+            primary = _make_stub_pipeline(
+                "vector_search",
+                by_id_results=[{"doc_id": 1, "score": 0.9}],
+                by_text_results=[{"doc_id": 1, "score": 0.9}],
+            )
+            complementary = _make_stub_pipeline(
+                "bm25",
+                by_id_results=[{"doc_id": 1, "score": 3.0}],
+                by_text_results=[{"doc_id": 1, "score": 3.0}],
+            )
+            mock_load.side_effect = [primary, complementary]
+
+            pipeline = GQRHybridRetrievalPipeline(
+                session_factory=session_factory,
+                name="gqr_creation",
+                primary_retrieval_pipeline="vector_search",
+                complementary_retrieval_pipeline="bm25",
+            )
+
+            assert mock_load.call_count == 2
+            assert pipeline._primary_retrieval_pipeline == primary
+            assert pipeline._complementary_retrieval_pipeline == complementary
+
+    @pytest.mark.asyncio
+    async def test_candidate_pool_mode_primary_keeps_primary_candidates_only(
+        self,
+        session_factory: sessionmaker[Session],
+    ):
+        primary = _make_stub_pipeline(
+            "vector_search",
+            by_id_results=[{"doc_id": 1, "score": 0.9}, {"doc_id": 2, "score": 0.8}],
+            by_text_results=[],
+        )
+        complementary = _make_stub_pipeline(
+            "bm25",
+            by_id_results=[{"doc_id": 3, "score": 10.0}],
+            by_text_results=[],
+        )
+        pipeline = GQRHybridRetrievalPipeline(
+            session_factory=session_factory,
+            name="gqr_primary_pool",
+            primary_retrieval_pipeline=primary,
+            complementary_retrieval_pipeline=complementary,
+            candidate_pool_mode="primary",
+            n_steps=5,
+        )
+        with (
+            patch.object(pipeline, "_get_query_embedding_by_id", return_value=None),
+            patch.object(pipeline, "_get_candidate_embeddings", return_value=([], np.empty((0, 0)))),
+        ):
+            results = await pipeline._retrieve_by_id(query_id=1, top_k=3)
+
+        result_doc_ids = [result["doc_id"] for result in results]
+        assert set(result_doc_ids) == {1, 2}
+        assert 3 not in result_doc_ids
+
+    @pytest.mark.asyncio
+    async def test_candidate_pool_mode_union_includes_complementary_candidates(
+        self,
+        session_factory: sessionmaker[Session],
+    ):
+        primary = _make_stub_pipeline(
+            "vector_search",
+            by_id_results=[{"doc_id": 1, "score": 0.9}, {"doc_id": 2, "score": 0.8}],
+            by_text_results=[],
+        )
+        complementary = _make_stub_pipeline(
+            "bm25",
+            by_id_results=[{"doc_id": 3, "score": 10.0}],
+            by_text_results=[],
+        )
+        pipeline = GQRHybridRetrievalPipeline(
+            session_factory=session_factory,
+            name="gqr_union_pool",
+            primary_retrieval_pipeline=primary,
+            complementary_retrieval_pipeline=complementary,
+            candidate_pool_mode="union",
+            n_steps=5,
+        )
+        with (
+            patch.object(pipeline, "_get_query_embedding_by_id", return_value=None),
+            patch.object(pipeline, "_get_candidate_embeddings", return_value=([], np.empty((0, 0)))),
+        ):
+            results = await pipeline._retrieve_by_id(query_id=1, top_k=3)
+
+        result_doc_ids = [result["doc_id"] for result in results]
+        assert 3 in result_doc_ids
+
+    @pytest.mark.asyncio
+    async def test_embedding_level_refinement_reranks_with_guidance(
+        self,
+        session_factory: sessionmaker[Session],
+    ):
+        primary = _make_stub_pipeline(
+            "vector_search",
+            by_id_results=[{"doc_id": 1, "score": 0.9}, {"doc_id": 2, "score": 0.1}],
+            by_text_results=[],
+        )
+        complementary = _make_stub_pipeline(
+            "bm25",
+            by_id_results=[{"doc_id": 2, "score": 10.0}, {"doc_id": 1, "score": 0.1}],
+            by_text_results=[],
+        )
+        pipeline = GQRHybridRetrievalPipeline(
+            session_factory=session_factory,
+            name="gqr_embedding_refinement",
+            primary_retrieval_pipeline=primary,
+            complementary_retrieval_pipeline=complementary,
+            candidate_pool_mode="primary",
+            mixture_alpha=1.0,
+            n_steps=50,
+            learning_rate=0.5,
+            temperature=0.5,
+        )
+        with (
+            patch.object(pipeline, "_get_query_embedding_by_id", return_value=np.asarray([1.0, 0.0])),
+            patch.object(
+                pipeline,
+                "_get_candidate_embeddings",
+                return_value=([1, 2], np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=np.float64)),
+            ),
+        ):
+            results = await pipeline._retrieve_by_id(query_id=1, top_k=2)
+
+        assert results[0]["doc_id"] == 2
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_uses_score_space_when_embedding_model_missing(
+        self,
+        session_factory: sessionmaker[Session],
+    ):
+        primary = _make_stub_pipeline(
+            "vector_search",
+            by_id_results=[],
+            by_text_results=[{"doc_id": 1, "score": 0.9}, {"doc_id": 2, "score": 0.1}],
+        )
+        complementary = _make_stub_pipeline(
+            "bm25",
+            by_id_results=[],
+            by_text_results=[{"doc_id": 2, "score": 8.0}, {"doc_id": 1, "score": 0.2}],
+        )
+        pipeline = GQRHybridRetrievalPipeline(
+            session_factory=session_factory,
+            name="gqr_text_score_space",
+            primary_retrieval_pipeline=primary,
+            complementary_retrieval_pipeline=complementary,
+            candidate_pool_mode="primary",
+            n_steps=10,
+        )
+        with patch.object(pipeline, "_get_candidate_embeddings", return_value=([], np.empty((0, 0)))):
+            results = await pipeline._retrieve_by_text("ad hoc query", top_k=2)
+
+        assert len(results) == 2
+        assert {results[0]["doc_id"], results[1]["doc_id"]} == {1, 2}

--- a/tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from sqlalchemy.orm import Session, sessionmaker
 
+from autorag_research.exceptions import EmbeddingError
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
 from autorag_research.pipelines.retrieval.gqr_hybrid import (
     GQRHybridRetrievalPipeline,
@@ -14,12 +15,40 @@ from autorag_research.pipelines.retrieval.gqr_hybrid import (
 )
 
 
-def _make_stub_pipeline(name: str, by_id_results: list[dict], by_text_results: list[dict]) -> SimpleNamespace:
-    return SimpleNamespace(
-        name=name,
-        _retrieve_by_id=AsyncMock(return_value=by_id_results),
-        _retrieve_by_text=AsyncMock(return_value=by_text_results),
-    )
+class StubRetrievalPipeline(BaseRetrievalPipeline):
+    """Typed retrieval test double for GQR child pipelines."""
+
+    def __init__(
+        self,
+        name: str,
+        by_id_results: list[dict],
+        by_text_results: list[dict] | BaseException,
+    ):
+        self.name = name
+        self.pipeline_id = 1
+        self._retrieve_by_id_mock = AsyncMock(return_value=by_id_results)
+        self._retrieve_by_text_mock = AsyncMock(
+            side_effect=by_text_results if isinstance(by_text_results, BaseException) else None
+        )
+        if not isinstance(by_text_results, BaseException):
+            self._retrieve_by_text_mock.return_value = by_text_results
+
+    def _get_pipeline_config(self) -> dict:
+        return {"type": "stub"}
+
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict]:
+        return await self._retrieve_by_id_mock(query_id, top_k)
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict]:
+        return await self._retrieve_by_text_mock(query_text, top_k)
+
+
+def _make_stub_pipeline(
+    name: str,
+    by_id_results: list[dict],
+    by_text_results: list[dict] | BaseException,
+) -> StubRetrievalPipeline:
+    return StubRetrievalPipeline(name=name, by_id_results=by_id_results, by_text_results=by_text_results)
 
 
 class TestGQRHybridRetrievalPipelineConfig:
@@ -230,3 +259,33 @@ class TestGQRHybridRetrievalPipeline:
 
         assert len(results) == 2
         assert {results[0]["doc_id"], results[1]["doc_id"]} == {1, 2}
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_falls_back_to_complementary_when_primary_needs_embedding(
+        self,
+        session_factory: sessionmaker[Session],
+    ):
+        primary = _make_stub_pipeline(
+            "vector_search",
+            by_id_results=[],
+            by_text_results=EmbeddingError(),
+        )
+        complementary = _make_stub_pipeline(
+            "bm25",
+            by_id_results=[],
+            by_text_results=[{"doc_id": 2, "score": 8.0}, {"doc_id": 1, "score": 0.2}],
+        )
+        pipeline = GQRHybridRetrievalPipeline(
+            session_factory=session_factory,
+            name="gqr_text_embedding_boundary",
+            primary_retrieval_pipeline=primary,
+            complementary_retrieval_pipeline=complementary,
+            candidate_pool_mode="union",
+            n_steps=10,
+        )
+        with patch.object(pipeline, "_get_candidate_embeddings", return_value=([], np.empty((0, 0)))):
+            results = await pipeline._retrieve_by_text("ad hoc query", top_k=2)
+
+        assert [result["doc_id"] for result in results] == [2, 1]
+        primary._retrieve_by_text_mock.assert_awaited_once_with("ad hoc query", 4)
+        complementary._retrieve_by_text_mock.assert_awaited_once_with("ad hoc query", 4)

--- a/tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py
@@ -232,6 +232,44 @@ class TestGQRHybridRetrievalPipeline:
         assert results[0]["doc_id"] == 2
 
     @pytest.mark.asyncio
+    async def test_partial_candidate_embeddings_use_score_space_for_whole_pool(
+        self,
+        session_factory: sessionmaker[Session],
+    ):
+        primary = _make_stub_pipeline(
+            "vector_search",
+            by_id_results=[{"doc_id": 1, "score": 0.9}],
+            by_text_results=[],
+        )
+        complementary = _make_stub_pipeline(
+            "bm25",
+            by_id_results=[{"doc_id": 2, "score": 8.0}],
+            by_text_results=[],
+        )
+        pipeline = GQRHybridRetrievalPipeline(
+            session_factory=session_factory,
+            name="gqr_partial_embeddings",
+            primary_retrieval_pipeline=primary,
+            complementary_retrieval_pipeline=complementary,
+            candidate_pool_mode="union",
+            n_steps=5,
+        )
+        with (
+            patch.object(pipeline, "_get_query_embedding_by_id", return_value=np.asarray([1.0, 0.0])),
+            patch.object(
+                pipeline,
+                "_get_candidate_embeddings",
+                return_value=([1], np.asarray([[1.0, 0.0]], dtype=np.float64)),
+            ),
+            patch.object(pipeline, "_optimize_query_embedding", side_effect=AssertionError("mixed score spaces")),
+            patch.object(pipeline, "_optimize_in_score_space", return_value=np.asarray([0.1, 0.9])),
+        ):
+            results = await pipeline._retrieve_by_id(query_id=1, top_k=2)
+
+        assert [result["doc_id"] for result in results] == [2, 1]
+        assert [result["score"] for result in results] == [0.9, 0.1]
+
+    @pytest.mark.asyncio
     async def test_retrieve_by_text_uses_score_space_when_embedding_model_missing(
         self,
         session_factory: sessionmaker[Session],


### PR DESCRIPTION
## Summary
- Adds GQR Hybrid Retrieval pipeline with candidate-pool selection, guidance mixing, embedding-level query refinement, and score-space fallback.
- Exports the retrieval pipeline/config and adds runnable YAML config.
- Defaults GQR candidate pooling to `union` for true hybrid behavior while keeping `primary` available for primary-bounded reranking.
- Hardens ad-hoc GQR text retrieval when a vector primary lacks an embedding model by falling back to text-capable child results.
- Uses score-space fallback for the full GQR candidate pool whenever any selected candidate lacks an embedding, avoiding mixed score spaces in one result set.
- Documents the GQR retrieval scoring contract, text-query fallback behavior, and dependency-loading boundary in the retrieval docs.
- Hardens AdaptiveRAG complexity parsing for ambiguous multi-label classifier output and wires the default multi-step prompt to the configured stop signal.
- Validates AdaptiveRAG route configuration early so invalid `route_for_*` values fail fast instead of silently defaulting to `single`.
- Adds focused tests for config loading, pool modes, embedding refinement, fallback behavior, ambiguity parsing, stop-signal prompt wiring, route validation, partial-embedding score fallback, and type-check narrowing.

## Validation
- `make check`
- `uv run mkdocs build --strict`
- `uv run ty check autorag_research/pipelines/retrieval/gqr_hybrid.py autorag_research/pipelines/retrieval/__init__.py autorag_research/pipelines/generation/adaptive_rag.py autorag_research/pipelines/generation/__init__.py tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py`
- `uv run ruff check autorag_research/pipelines/retrieval/gqr_hybrid.py autorag_research/pipelines/generation/adaptive_rag.py tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py`
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py::TestAdaptiveRAGPipeline::test_invalid_constructor_route_raises_value_error tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py::TestAdaptiveRAGPipeline::test_invalid_config_route_raises_value_error tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py::TestAdaptiveRAGPipeline::test_ambiguous_complexity_output_falls_back_to_moderate tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py::TestAdaptiveRAGPipeline::test_default_multi_retrieval_query_prompt_uses_configurable_stop_signal -q`

## Notes
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_gqr_hybrid_pipeline.py tests/autorag_research/pipelines/generation/test_adaptive_rag_pipeline.py -q` was attempted; GQR and non-DB AdaptiveRAG coverage passed (`14 passed`), but DB-backed AdaptiveRAG tests failed because local PostgreSQL refused connections.
- `make test` was attempted and failed at `docker-up` because the Docker daemon is unavailable.

Closes #177

<!-- dani:stage=implementation;job=b9189e52c0814c8189235141124f3954;issue=177;pr=362 -->
