### PR TITLE
Add DeepRAG generation pipeline

### DIFF
--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -1,6 +1,7 @@
 from autorag_research.pipelines.generation.autothinkrag import AutoThinkRAGPipeline, AutoThinkRAGPipelineConfig
 from autorag_research.pipelines.generation.base import BaseGenerationPipeline
 from autorag_research.pipelines.generation.basic_rag import BasicRAGPipeline, BasicRAGPipelineConfig
+from autorag_research.pipelines.generation.deep_rag import DeepRAGPipeline, DeepRAGPipelineConfig
 from autorag_research.pipelines.generation.et2rag import (
     DEFAULT_PROMPT_TEMPLATE,
     ET2RAGPipeline,
@@ -30,6 +31,8 @@ __all__ = [
     "BaseGenerationPipeline",
     "BasicRAGPipeline",
     "BasicRAGPipelineConfig",
+    "DeepRAGPipeline",
+    "DeepRAGPipelineConfig",
     "ET2RAGPipeline",
     "ET2RAGPipelineConfig",
     "IRCoTGenerationPipeline",

--- a/autorag_research/pipelines/generation/deep_rag.py
+++ b/autorag_research/pipelines/generation/deep_rag.py
@@ -1,0 +1,311 @@
+"""DeepRAG-style adaptive iterative generation pipeline.
+
+DeepRAG is best represented in AutoRAG-Research as an inference-time generation
+pipeline that decomposes a question into stepwise subqueries, decides whether a
+retrieval step is needed, accumulates evidence, and stops once enough evidence is
+available. Training/data-construction parts from the paper are intentionally out
+of scope for this repo-native baseline.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker
+
+logger = logging.getLogger("AutoRAG-Research")
+
+DeepRAGActionKind = Literal["retrieve", "reason", "answer"]
+
+DEFAULT_DEEPRAG_STEP_PROMPT = """You are a DeepRAG controller for adaptive multi-step question answering.
+At each step, decide whether retrieval is needed or whether you can reason from existing evidence.
+Return exactly one action:
+- <retrieve>standalone subquery</retrieve> when more evidence is needed
+- <reason>short reasoning update</reason> when no retrieval is needed for this step
+- <answer>final answer</answer> when enough evidence has been gathered
+
+Question:
+{query}
+
+Step: {step}/{max_steps}
+Evidence:
+{evidence}
+
+Reasoning trace:
+{trace}
+
+Next action:"""
+
+DEFAULT_DEEPRAG_FINAL_PROMPT = """Answer the question using the DeepRAG reasoning trace and evidence.
+
+Question:
+{query}
+
+Evidence:
+{evidence}
+
+Reasoning trace:
+{trace}
+
+Final answer:"""
+
+_RETRIEVE_RE = re.compile(r"<retrieve>\s*(.*?)\s*</retrieve>", re.IGNORECASE | re.DOTALL)
+_REASON_RE = re.compile(r"<reason>\s*(.*?)\s*</reason>", re.IGNORECASE | re.DOTALL)
+_ANSWER_RE = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass(frozen=True)
+class DeepRAGAction:
+    """Parsed DeepRAG controller action."""
+
+    kind: DeepRAGActionKind
+    text: str
+
+
+def parse_deeprag_action(response_text: str) -> DeepRAGAction:
+    """Parse a DeepRAG controller action from an LLM response."""
+    answer_match = _ANSWER_RE.search(response_text)
+    if answer_match is not None:
+        return DeepRAGAction(kind="answer", text=answer_match.group(1).strip())
+
+    retrieve_match = _RETRIEVE_RE.search(response_text)
+    if retrieve_match is not None:
+        return DeepRAGAction(kind="retrieve", text=retrieve_match.group(1).strip())
+
+    reason_match = _REASON_RE.search(response_text)
+    if reason_match is not None:
+        return DeepRAGAction(kind="reason", text=reason_match.group(1).strip())
+
+    stripped_response = response_text.strip()
+    if stripped_response.lower().startswith("answer:"):
+        return DeepRAGAction(kind="answer", text=stripped_response.split(":", 1)[1].strip())
+    return DeepRAGAction(kind="reason", text=stripped_response)
+
+
+@dataclass(kw_only=True)
+class DeepRAGPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for DeepRAGPipeline."""
+
+    step_prompt_template: str = field(default=DEFAULT_DEEPRAG_STEP_PROMPT)
+    final_prompt_template: str = field(default=DEFAULT_DEEPRAG_FINAL_PROMPT)
+    max_steps: int = 5
+    k_per_retrieval: int = 5
+    evidence_budget: int = 12
+    fallback_to_final_prompt: bool = True
+
+    def get_pipeline_class(self) -> type[DeepRAGPipeline]:
+        """Return the DeepRAGPipeline class."""
+        return DeepRAGPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for DeepRAGPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "step_prompt_template": self.step_prompt_template,
+            "final_prompt_template": self.final_prompt_template,
+            "max_steps": self.max_steps,
+            "k_per_retrieval": self.k_per_retrieval,
+            "evidence_budget": self.evidence_budget,
+            "fallback_to_final_prompt": self.fallback_to_final_prompt,
+        }
+
+
+class DeepRAGPipeline(BaseGenerationPipeline):
+    """Adaptive iterative retrieve-or-reason generation pipeline."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        step_prompt_template: str = DEFAULT_DEEPRAG_STEP_PROMPT,
+        final_prompt_template: str = DEFAULT_DEEPRAG_FINAL_PROMPT,
+        max_steps: int = 5,
+        k_per_retrieval: int = 5,
+        evidence_budget: int = 12,
+        fallback_to_final_prompt: bool = True,
+        schema: Any | None = None,
+    ):
+        """Initialize DeepRAGPipeline."""
+        if max_steps < 1:
+            msg = "max_steps must be >= 1"
+            raise ValueError(msg)
+        if k_per_retrieval < 1:
+            msg = "k_per_retrieval must be >= 1"
+            raise ValueError(msg)
+        if evidence_budget < 1:
+            msg = "evidence_budget must be >= 1"
+            raise ValueError(msg)
+
+        self.step_prompt_template = step_prompt_template
+        self.final_prompt_template = final_prompt_template
+        self.max_steps = max_steps
+        self.k_per_retrieval = k_per_retrieval
+        self.evidence_budget = evidence_budget
+        self.fallback_to_final_prompt = fallback_to_final_prompt
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return DeepRAG configuration for storage."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+        return {
+            "type": "deeprag",
+            "step_prompt_template": self.step_prompt_template,
+            "final_prompt_template": self.final_prompt_template,
+            "max_steps": self.max_steps,
+            "k_per_retrieval": self.k_per_retrieval,
+            "evidence_budget": self.evidence_budget,
+            "fallback_to_final_prompt": self.fallback_to_final_prompt,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract content from a LangChain response."""
+        return response.content if hasattr(response, "content") else str(response)
+
+    @staticmethod
+    def _format_items(items: list[str], empty: str = "(none)") -> str:
+        """Format a list for prompts."""
+        if not items:
+            return empty
+        return "\n\n".join(f"[{index + 1}] {item}" for index, item in enumerate(items))
+
+    def _build_step_prompt(self, query: str, evidence: list[str], trace: list[str], step: int) -> str:
+        """Build one DeepRAG control prompt."""
+        return self.step_prompt_template.format(
+            query=query,
+            evidence=self._format_items(evidence),
+            trace=self._format_items(trace),
+            step=step,
+            max_steps=self.max_steps,
+        )
+
+    def _build_final_prompt(self, query: str, evidence: list[str], trace: list[str]) -> str:
+        """Build fallback final prompt."""
+        return self.final_prompt_template.format(
+            query=query,
+            evidence=self._format_items(evidence),
+            trace=self._format_items(trace),
+        )
+
+    def _contents_from_results(self, results: list[dict[str, Any]]) -> tuple[list[int | str], list[str], list[float]]:
+        """Extract doc IDs, contents, and scores from retrieval results."""
+        doc_ids: list[int | str] = []
+        contents: list[str | None] = []
+        scores: list[float] = []
+        missing_positions: list[int] = []
+        missing_ids: list[int | str] = []
+        for result in results:
+            doc_id = result.get("doc_id")
+            if doc_id is None:
+                continue
+            doc_ids.append(doc_id)
+            score = result.get("score", 0.0)
+            scores.append(float(score) if isinstance(score, (int, float)) else 0.0)
+            content = result.get("content")
+            if content:
+                contents.append(str(content))
+            else:
+                missing_positions.append(len(contents))
+                missing_ids.append(doc_id)
+                contents.append(None)
+        if missing_ids:
+            fetched_contents = self._service.get_chunk_contents(missing_ids)
+            for position, fetched_content in zip(missing_positions, fetched_contents, strict=False):
+                contents[position] = fetched_content
+        return doc_ids, [content or "" for content in contents], scores
+
+    def _append_evidence(self, evidence: list[str], new_contents: list[str]) -> list[str]:
+        """Append non-empty deduplicated evidence within budget."""
+        updated = list(evidence)
+        for content in new_contents:
+            if content and content not in updated:
+                updated.append(content)
+        return updated[-self.evidence_budget :]
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate an answer using adaptive DeepRAG control actions."""
+        query_text = self._service.get_query_text(query_id)
+        retrieval_k = max(1, min(top_k, self.k_per_retrieval)) if top_k > 0 else self.k_per_retrieval
+        tracker = TokenUsageTracker()
+        evidence: list[str] = []
+        trace: list[str] = []
+        follow_up_queries: list[str] = []
+        retrieved_chunk_ids: list[int | str] = []
+        retrieved_scores: list[float] = []
+        final_answer = ""
+        terminated_by = "max_steps"
+
+        for step in range(1, self.max_steps + 1):
+            prompt = self._build_step_prompt(query_text, evidence, trace, step)
+            response = await self._llm.ainvoke(prompt)
+            tracker.record(response)
+            action = parse_deeprag_action(self._extract_text(response))
+            if action.kind == "answer":
+                final_answer = action.text
+                trace.append(f"answer: {final_answer}")
+                terminated_by = "answer"
+                break
+            if action.kind == "reason":
+                trace.append(f"reason: {action.text}")
+                continue
+
+            follow_up_queries.append(action.text)
+            trace.append(f"retrieve: {action.text}")
+            results = await self._retrieval_pipeline.retrieve(action.text, retrieval_k)
+            doc_ids, contents, scores = self._contents_from_results(results)
+            for doc_id, score in zip(doc_ids, scores, strict=False):
+                if doc_id not in retrieved_chunk_ids:
+                    retrieved_chunk_ids.append(doc_id)
+                    retrieved_scores.append(score)
+            evidence = self._append_evidence(evidence, contents)
+
+        if not final_answer and self.fallback_to_final_prompt:
+            final_prompt = self._build_final_prompt(query_text, evidence, trace)
+            final_response = await self._llm.ainvoke(final_prompt)
+            tracker.record(final_response)
+            final_answer = self._extract_text(final_response)
+            terminated_by = f"{terminated_by}_fallback"
+
+        return GenerationResult(
+            text=final_answer,
+            token_usage=tracker.total,
+            metadata={
+                "trace": trace,
+                "evidence": evidence,
+                "follow_up_queries": follow_up_queries,
+                "retrieved_chunk_ids": retrieved_chunk_ids,
+                "retrieved_scores": retrieved_scores,
+                "terminated_by": terminated_by,
+            },
+        )
+
+
+__all__ = [
+    "DEFAULT_DEEPRAG_FINAL_PROMPT",
+    "DEFAULT_DEEPRAG_STEP_PROMPT",
+    "DeepRAGAction",
+    "DeepRAGPipeline",
+    "DeepRAGPipelineConfig",
+    "parse_deeprag_action",
+]

--- a/autorag_research/pipelines/generation/deep_rag.py
+++ b/autorag_research/pipelines/generation/deep_rag.py
@@ -243,10 +243,14 @@ class DeepRAGPipeline(BaseGenerationPipeline):
                 updated.append(content)
         return updated[-self.evidence_budget :]
 
+    def _resolve_retrieval_k(self, top_k: int) -> int:
+        """Resolve per-step retrieval size using top_k as a global runner cap when provided."""
+        return max(1, min(top_k, self.k_per_retrieval)) if top_k > 0 else self.k_per_retrieval
+
     async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
         """Generate an answer using adaptive DeepRAG control actions."""
         query_text = self._service.get_query_text(query_id)
-        retrieval_k = max(1, min(top_k, self.k_per_retrieval)) if top_k > 0 else self.k_per_retrieval
+        retrieval_k = self._resolve_retrieval_k(top_k)
         tracker = TokenUsageTracker()
         evidence: list[str] = []
         trace: list[str] = []
@@ -296,6 +300,8 @@ class DeepRAGPipeline(BaseGenerationPipeline):
                 "follow_up_queries": follow_up_queries,
                 "retrieved_chunk_ids": retrieved_chunk_ids,
                 "retrieved_scores": retrieved_scores,
+                "effective_retrieval_k": retrieval_k,
+                "top_k_cap": top_k,
                 "terminated_by": terminated_by,
             },
         )

--- a/configs/pipelines/generation/deep_rag.yaml
+++ b/configs/pipelines/generation/deep_rag.yaml
@@ -4,6 +4,8 @@ name: deep_rag
 retrieval_pipeline_name: bm25
 llm: mock
 max_steps: 5
+# Per DeepRAG retrieval action, request up to this many chunks.
+# The inherited top_k below remains the global runner cap when it is > 0.
 k_per_retrieval: 5
 evidence_budget: 12
 fallback_to_final_prompt: true

--- a/configs/pipelines/generation/deep_rag.yaml
+++ b/configs/pipelines/generation/deep_rag.yaml
@@ -2,7 +2,7 @@ _target_: autorag_research.pipelines.generation.deep_rag.DeepRAGPipelineConfig
 description: "DeepRAG-style adaptive iterative retrieve-or-reason generation pipeline"
 name: deep_rag
 retrieval_pipeline_name: bm25
-llm: openai-gpt4o-mini
+llm: mock
 max_steps: 5
 k_per_retrieval: 5
 evidence_budget: 12

--- a/configs/pipelines/generation/deep_rag.yaml
+++ b/configs/pipelines/generation/deep_rag.yaml
@@ -1,0 +1,14 @@
+_target_: autorag_research.pipelines.generation.deep_rag.DeepRAGPipelineConfig
+description: "DeepRAG-style adaptive iterative retrieve-or-reason generation pipeline"
+name: deep_rag
+retrieval_pipeline_name: bm25
+llm: openai-gpt4o-mini
+max_steps: 5
+k_per_retrieval: 5
+evidence_budget: 12
+fallback_to_final_prompt: true
+top_k: 5
+batch_size: 32
+max_concurrency: 4
+max_retries: 3
+retry_delay: 1.0

--- a/tests/autorag_research/pipelines/generation/test_deep_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_deep_rag_pipeline.py
@@ -1,0 +1,179 @@
+"""Tests for the DeepRAG generation pipeline."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from autorag_research.pipelines.generation.deep_rag import DeepRAGPipeline, DeepRAGPipelineConfig, parse_deeprag_action
+from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_retrieval_pipeline
+
+
+def _mock_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
+    return response
+
+
+def _build_unit_pipeline(llm: Any, retrieval_pipeline: Any, service: Any, **kwargs: Any) -> DeepRAGPipeline:
+    with patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None):
+        pipeline = DeepRAGPipeline(
+            session_factory=MagicMock(),
+            name="deeprag_unit",
+            llm=llm,
+            retrieval_pipeline=retrieval_pipeline,
+            **kwargs,
+        )
+    pipeline._llm = llm
+    pipeline._retrieval_pipeline = retrieval_pipeline
+    pipeline._service = service
+    pipeline.pipeline_id = 1
+    return pipeline
+
+
+class TestDeepRAGActionParsing:
+    """Tests for DeepRAG action parsing."""
+
+    def test_parse_retrieve(self):
+        action = parse_deeprag_action("Need evidence. <retrieve>moon origin</retrieve>")
+
+        assert action.kind == "retrieve"
+        assert action.text == "moon origin"
+
+    def test_parse_reason(self):
+        action = parse_deeprag_action("<reason>Known from prior evidence.</reason>")
+
+        assert action.kind == "reason"
+        assert action.text == "Known from prior evidence."
+
+    def test_parse_answer_preferred(self):
+        action = parse_deeprag_action("<retrieve>x</retrieve><answer>final</answer>")
+
+        assert action.kind == "answer"
+        assert action.text == "final"
+
+
+class TestDeepRAGPipelineConfig:
+    """Tests for DeepRAGPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        config = DeepRAGPipelineConfig(
+            name="deep_rag",
+            llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+            retrieval_pipeline_name="bm25",
+        )
+
+        assert config.get_pipeline_class() == DeepRAGPipeline
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        config = DeepRAGPipelineConfig(
+            name="deep_rag",
+            llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+            retrieval_pipeline_name="bm25",
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        retrieval_pipeline = create_mock_retrieval_pipeline(pipeline_id=33)
+        llm = FakeListLLM(responses=["<answer>ok</answer>"])
+        config = DeepRAGPipelineConfig(
+            name="deep_rag",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+            max_steps=4,
+            k_per_retrieval=3,
+        )
+
+        config.inject_retrieval_pipeline(retrieval_pipeline)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is retrieval_pipeline
+        assert kwargs["max_steps"] == 4
+        assert kwargs["k_per_retrieval"] == 3
+
+
+class TestDeepRAGPipeline:
+    """Tests for DeepRAG generation behavior."""
+
+    def test_initialization_rejects_invalid_steps(self):
+        with (
+            patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="max_steps must be >= 1"),
+        ):
+            DeepRAGPipeline(
+                session_factory=MagicMock(),
+                name="invalid_deeprag",
+                llm=FakeListLLM(responses=["<answer>ok</answer>"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                max_steps=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_retrieves_reasons_then_answers(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<retrieve>apollo 11 date</retrieve>"),
+                _mock_response("<reason>The evidence gives the date.</reason>"),
+                _mock_response("<answer>Apollo 11 landed in July 1969.</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 10, "score": 0.9, "content": "Apollo 11 landed in July 1969."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "When did Apollo 11 land?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=4, k_per_retrieval=3)
+
+        result = await pipeline._generate(1, top_k=2)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("apollo 11 date", 2)
+        assert result.text == "Apollo 11 landed in July 1969."
+        assert result.metadata["follow_up_queries"] == ["apollo 11 date"]
+        assert result.metadata["retrieved_chunk_ids"] == [10]
+        assert result.metadata["retrieved_scores"] == [0.9]
+        assert result.metadata["terminated_by"] == "answer"
+        assert result.token_usage == {"prompt_tokens": 6, "completion_tokens": 9, "total_tokens": 15}
+
+    @pytest.mark.asyncio
+    async def test_generate_falls_back_after_max_steps(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<reason>Need to think.</reason>"),
+                _mock_response("fallback answer"),
+            ]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(llm, create_mock_retrieval_pipeline(), service, max_steps=1)
+
+        result = await pipeline._generate(1, top_k=5)
+
+        assert result.text == "fallback answer"
+        assert result.metadata["terminated_by"] == "max_steps_fallback"
+
+    @pytest.mark.asyncio
+    async def test_generate_backfills_missing_contents(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<retrieve>missing content</retrieve>"),
+                _mock_response("<answer>done</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(default_results=[{"doc_id": 5, "score": 0.7}])
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        service.get_chunk_contents.return_value = ["Fetched evidence."]
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=2, k_per_retrieval=1)
+
+        result = await pipeline._generate(1, top_k=1)
+
+        service.get_chunk_contents.assert_called_once_with([5])
+        assert result.metadata["evidence"] == ["Fetched evidence."]

--- a/tests/autorag_research/pipelines/generation/test_deep_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_deep_rag_pipeline.py
@@ -149,8 +149,33 @@ class TestDeepRAGPipeline:
         assert result.metadata["follow_up_queries"] == ["apollo 11 date"]
         assert result.metadata["retrieved_chunk_ids"] == [10]
         assert result.metadata["retrieved_scores"] == [0.9]
+        assert result.metadata["effective_retrieval_k"] == 2
+        assert result.metadata["top_k_cap"] == 2
         assert result.metadata["terminated_by"] == "answer"
         assert result.token_usage == {"prompt_tokens": 6, "completion_tokens": 9, "total_tokens": 15}
+
+    @pytest.mark.asyncio
+    async def test_generate_uses_k_per_retrieval_when_top_k_is_not_positive(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<retrieve>broad evidence</retrieve>"),
+                _mock_response("<answer>done</answer>"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 11, "score": 0.8, "content": "Evidence."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=2, k_per_retrieval=4)
+
+        result = await pipeline._generate(1, top_k=0)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("broad evidence", 4)
+        assert result.metadata is not None
+        assert result.metadata["effective_retrieval_k"] == 4
+        assert result.metadata["top_k_cap"] == 0
 
     @pytest.mark.asyncio
     async def test_generate_falls_back_after_max_steps(self):

--- a/tests/autorag_research/pipelines/generation/test_deep_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_deep_rag_pipeline.py
@@ -4,7 +4,9 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from hydra.utils import instantiate
 from langchain_core.language_models.fake import FakeListLLM
+from omegaconf import OmegaConf
 
 from autorag_research.pipelines.generation.deep_rag import DeepRAGPipeline, DeepRAGPipelineConfig, parse_deeprag_action
 from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_retrieval_pipeline
@@ -57,6 +59,15 @@ class TestDeepRAGActionParsing:
 
 class TestDeepRAGPipelineConfig:
     """Tests for DeepRAGPipelineConfig."""
+
+    def test_shipped_yaml_config_instantiates(self):
+        cfg = OmegaConf.load("configs/pipelines/generation/deep_rag.yaml")
+
+        config = instantiate(cfg)
+
+        assert isinstance(config, DeepRAGPipelineConfig)
+        assert config.name == "deep_rag"
+        assert config.retrieval_pipeline_name == "bm25"
 
     def test_get_pipeline_class(self):
         config = DeepRAGPipelineConfig(
@@ -134,6 +145,7 @@ class TestDeepRAGPipeline:
 
         retrieval_pipeline.retrieve.assert_awaited_once_with("apollo 11 date", 2)
         assert result.text == "Apollo 11 landed in July 1969."
+        assert result.metadata is not None
         assert result.metadata["follow_up_queries"] == ["apollo 11 date"]
         assert result.metadata["retrieved_chunk_ids"] == [10]
         assert result.metadata["retrieved_scores"] == [0.9]
@@ -156,6 +168,7 @@ class TestDeepRAGPipeline:
         result = await pipeline._generate(1, top_k=5)
 
         assert result.text == "fallback answer"
+        assert result.metadata is not None
         assert result.metadata["terminated_by"] == "max_steps_fallback"
 
     @pytest.mark.asyncio
@@ -176,4 +189,5 @@ class TestDeepRAGPipeline:
         result = await pipeline._generate(1, top_k=1)
 
         service.get_chunk_contents.assert_called_once_with([5])
+        assert result.metadata is not None
         assert result.metadata["evidence"] == ["Fetched evidence."]


### PR DESCRIPTION
## Summary
- Adds an inference-first DeepRAG generation pipeline with per-step retrieve / reason / answer control actions.
- Reuses existing retrieval pipelines for adaptive evidence gathering and records action traces, follow-up queries, evidence, chunk IDs, and scores.
- Adds YAML config, exports, and focused tests for parsing, config injection, retrieve-vs-reason flow, fallback, and content backfill.

## Scope
- Implements the DeepRAG inference/evaluation baseline suitable for AutoRAG-Research.
- Does not add DeepRAG training/data-construction/RL infrastructure.

## Validation
- uv sync --all-extras --all-groups
- uv run pytest tests/autorag_research/pipelines/generation/test_deep_rag_pipeline.py -q
- make check

Closes #181

<!-- dani:stage=implementation;job=8ade3e7f5e319427e909ef1afc4f530e;issue=181 -->
