### PR TITLE
Add RAS structured generation pipeline

### DIFF
--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -14,6 +14,7 @@ from autorag_research.pipelines.generation.question_decomposition import (
     QuestionDecompositionPipelineConfig,
 )
 from autorag_research.pipelines.generation.rag_critic import RAGCriticPipeline, RAGCriticPipelineConfig
+from autorag_research.pipelines.generation.ras import RASGenerationPipeline, RASGenerationPipelineConfig
 from autorag_research.pipelines.generation.self_rag import SelfRAGPipeline, SelfRAGPipelineConfig
 from autorag_research.pipelines.generation.spd_rag import SPDRAGPipeline, SPDRAGPipelineConfig
 from autorag_research.pipelines.generation.visrag_gen import (
@@ -40,6 +41,8 @@ __all__ = [
     "QuestionDecompositionPipelineConfig",
     "RAGCriticPipeline",
     "RAGCriticPipelineConfig",
+    "RASGenerationPipeline",
+    "RASGenerationPipelineConfig",
     "SPDRAGPipeline",
     "SPDRAGPipelineConfig",
     "SelfRAGPipeline",

--- a/autorag_research/pipelines/generation/ras.py
+++ b/autorag_research/pipelines/generation/ras.py
@@ -1,0 +1,380 @@
+"""RAS (Retrieval-And-Structuring) generation pipeline.
+
+This module implements an AutoRAG-compatible, inference-time RAS baseline: plan
+retrieval needs, retrieve passages, extract triples into a question-specific
+structured graph, and answer from that graph plus supporting evidence. Heavy
+GraphLLM/GNN training components from the paper are out of scope for this
+pipeline implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.util import TokenUsageTracker
+
+logger = logging.getLogger("AutoRAG-Research")
+
+RASPlanKind = Literal["retrieve", "sufficient"]
+
+DEFAULT_RAS_PLAN_PROMPT = """You are a Retrieval-And-Structuring (RAS) planner.
+Decide whether more retrieval is needed before building the structured answer graph.
+Return exactly one action:
+- <subquery>standalone retrieval query</subquery>
+- <sufficient>brief reason evidence is sufficient</sufficient>
+
+Question:
+{query}
+
+Step: {step}/{max_steps}
+Current triples:
+{triples}
+
+Evidence:
+{evidence}
+
+Next action:"""
+
+DEFAULT_RAS_TRIPLE_PROMPT = """Extract question-relevant factual triples from the passage.
+Return each triple as <triple>subject | predicate | object</triple>.
+If no useful triple exists, return <none/>.
+
+Question:
+{query}
+
+Passage:
+{passage}
+
+Triples:"""
+
+DEFAULT_RAS_ANSWER_PROMPT = """Answer the question using the structured triples and supporting evidence.
+
+Question:
+{query}
+
+Structured triples:
+{triples}
+
+Supporting evidence:
+{evidence}
+
+Answer:"""
+
+_SUBQUERY_RE = re.compile(r"<subquery>\s*(.*?)\s*</subquery>", re.IGNORECASE | re.DOTALL)
+_SUFFICIENT_RE = re.compile(r"<sufficient>\s*(.*?)\s*</sufficient>", re.IGNORECASE | re.DOTALL)
+_TRIPLE_RE = re.compile(r"<triple>\s*(.*?)\s*</triple>", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass(frozen=True)
+class RASPlanAction:
+    """Parsed RAS planning action."""
+
+    kind: RASPlanKind
+    text: str
+
+
+@dataclass(frozen=True)
+class RASTriple:
+    """Serializable question-specific graph triple."""
+
+    subject: str
+    predicate: str
+    object: str
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        """Return a tuple representation."""
+        return (self.subject, self.predicate, self.object)
+
+    def as_text(self) -> str:
+        """Return a prompt-friendly text representation."""
+        return f"({self.subject}) -[{self.predicate}]-> ({self.object})"
+
+
+def parse_ras_plan_action(response_text: str) -> RASPlanAction:
+    """Parse RAS planner output."""
+    sufficient_match = _SUFFICIENT_RE.search(response_text)
+    if sufficient_match is not None:
+        return RASPlanAction(kind="sufficient", text=sufficient_match.group(1).strip())
+
+    subquery_match = _SUBQUERY_RE.search(response_text)
+    if subquery_match is not None:
+        return RASPlanAction(kind="retrieve", text=subquery_match.group(1).strip())
+
+    stripped_response = response_text.strip()
+    if stripped_response.lower().startswith("subquery:"):
+        return RASPlanAction(kind="retrieve", text=stripped_response.split(":", 1)[1].strip())
+    return RASPlanAction(kind="sufficient", text=stripped_response)
+
+
+def parse_ras_triples(response_text: str) -> list[RASTriple]:
+    """Parse triples from extractor output."""
+    triples: list[RASTriple] = []
+    for match in _TRIPLE_RE.finditer(response_text):
+        parts = [part.strip() for part in match.group(1).split("|")]
+        if len(parts) != 3 or not all(parts):
+            continue
+        triple = RASTriple(subject=parts[0], predicate=parts[1], object=parts[2])
+        if triple not in triples:
+            triples.append(triple)
+    return triples
+
+
+@dataclass(kw_only=True)
+class RASGenerationPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for RASGenerationPipeline."""
+
+    plan_prompt_template: str = field(default=DEFAULT_RAS_PLAN_PROMPT)
+    triple_prompt_template: str = field(default=DEFAULT_RAS_TRIPLE_PROMPT)
+    answer_prompt_template: str = field(default=DEFAULT_RAS_ANSWER_PROMPT)
+    max_steps: int = 3
+    k_per_step: int = 4
+    evidence_budget: int = 12
+    triple_budget: int = 40
+
+    def get_pipeline_class(self) -> type[RASGenerationPipeline]:
+        """Return the RASGenerationPipeline class."""
+        return RASGenerationPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for RASGenerationPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "plan_prompt_template": self.plan_prompt_template,
+            "triple_prompt_template": self.triple_prompt_template,
+            "answer_prompt_template": self.answer_prompt_template,
+            "max_steps": self.max_steps,
+            "k_per_step": self.k_per_step,
+            "evidence_budget": self.evidence_budget,
+            "triple_budget": self.triple_budget,
+        }
+
+
+class RASGenerationPipeline(BaseGenerationPipeline):
+    """Retrieval-And-Structuring generation pipeline."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        plan_prompt_template: str = DEFAULT_RAS_PLAN_PROMPT,
+        triple_prompt_template: str = DEFAULT_RAS_TRIPLE_PROMPT,
+        answer_prompt_template: str = DEFAULT_RAS_ANSWER_PROMPT,
+        max_steps: int = 3,
+        k_per_step: int = 4,
+        evidence_budget: int = 12,
+        triple_budget: int = 40,
+        schema: Any | None = None,
+    ):
+        """Initialize RASGenerationPipeline."""
+        if max_steps < 1:
+            msg = "max_steps must be >= 1"
+            raise ValueError(msg)
+        if k_per_step < 1:
+            msg = "k_per_step must be >= 1"
+            raise ValueError(msg)
+        if evidence_budget < 1 or triple_budget < 1:
+            msg = "evidence_budget and triple_budget must be >= 1"
+            raise ValueError(msg)
+
+        self.plan_prompt_template = plan_prompt_template
+        self.triple_prompt_template = triple_prompt_template
+        self.answer_prompt_template = answer_prompt_template
+        self.max_steps = max_steps
+        self.k_per_step = k_per_step
+        self.evidence_budget = evidence_budget
+        self.triple_budget = triple_budget
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return RAS configuration for storage."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+        return {
+            "type": "ras",
+            "plan_prompt_template": self.plan_prompt_template,
+            "triple_prompt_template": self.triple_prompt_template,
+            "answer_prompt_template": self.answer_prompt_template,
+            "max_steps": self.max_steps,
+            "k_per_step": self.k_per_step,
+            "evidence_budget": self.evidence_budget,
+            "triple_budget": self.triple_budget,
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract text from a LangChain response."""
+        return response.content if hasattr(response, "content") else str(response)
+
+    @staticmethod
+    def _format_evidence(evidence: list[str]) -> str:
+        """Format evidence for prompts."""
+        if not evidence:
+            return "(none)"
+        return "\n\n".join(f"[{index + 1}] {item}" for index, item in enumerate(evidence))
+
+    @staticmethod
+    def _format_triples(triples: list[RASTriple]) -> str:
+        """Format triples for prompts."""
+        if not triples:
+            return "(none)"
+        return "\n".join(f"[{index + 1}] {triple.as_text()}" for index, triple in enumerate(triples))
+
+    def _build_plan_prompt(self, query: str, evidence: list[str], triples: list[RASTriple], step: int) -> str:
+        """Build a retrieval planning prompt."""
+        return self.plan_prompt_template.format(
+            query=query,
+            evidence=self._format_evidence(evidence),
+            triples=self._format_triples(triples),
+            step=step,
+            max_steps=self.max_steps,
+        )
+
+    def _build_triple_prompt(self, query: str, passage: str) -> str:
+        """Build a triple extraction prompt."""
+        return self.triple_prompt_template.format(query=query, passage=passage)
+
+    def _build_answer_prompt(self, query: str, evidence: list[str], triples: list[RASTriple]) -> str:
+        """Build final answer prompt."""
+        return self.answer_prompt_template.format(
+            query=query,
+            evidence=self._format_evidence(evidence),
+            triples=self._format_triples(triples),
+        )
+
+    def _contents_from_results(self, results: list[dict[str, Any]]) -> tuple[list[int | str], list[str]]:
+        """Extract IDs and passage text from retrieval results."""
+        doc_ids: list[int | str] = []
+        contents: list[str | None] = []
+        missing_positions: list[int] = []
+        missing_ids: list[int | str] = []
+        for result in results:
+            doc_id = result.get("doc_id")
+            if doc_id is None:
+                continue
+            doc_ids.append(doc_id)
+            content = result.get("content")
+            if content:
+                contents.append(str(content))
+            else:
+                missing_positions.append(len(contents))
+                missing_ids.append(doc_id)
+                contents.append(None)
+        if missing_ids:
+            fetched_contents = self._service.get_chunk_contents(missing_ids)
+            for position, fetched_content in zip(missing_positions, fetched_contents, strict=False):
+                contents[position] = fetched_content
+        return doc_ids, [content or "" for content in contents]
+
+    def _append_evidence(self, evidence: list[str], passages: list[str]) -> list[str]:
+        """Append deduplicated passages within evidence budget."""
+        updated = list(evidence)
+        for passage in passages:
+            if passage and passage not in updated:
+                updated.append(passage)
+        return updated[-self.evidence_budget :]
+
+    def _merge_triples(self, triples: list[RASTriple], new_triples: list[RASTriple]) -> list[RASTriple]:
+        """Merge deduplicated triples within triple budget."""
+        merged = list(triples)
+        for triple in new_triples:
+            if triple not in merged:
+                merged.append(triple)
+        return merged[-self.triple_budget :]
+
+    async def _extract_triples_for_passages(
+        self,
+        query: str,
+        passages: list[str],
+        tracker: TokenUsageTracker,
+    ) -> list[RASTriple]:
+        """Extract triples from retrieved passages."""
+        extracted: list[RASTriple] = []
+        for passage in passages:
+            prompt = self._build_triple_prompt(query, passage)
+            response = await self._llm.ainvoke(prompt)
+            tracker.record(response)
+            extracted = self._merge_triples(extracted, parse_ras_triples(self._extract_text(response)))
+        return extracted
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate an answer using retrieval-and-structuring."""
+        query_text = self._service.get_query_text(query_id)
+        retrieval_k = max(1, min(top_k, self.k_per_step)) if top_k > 0 else self.k_per_step
+        tracker = TokenUsageTracker()
+        evidence: list[str] = []
+        triples: list[RASTriple] = []
+        subqueries: list[str] = []
+        retrieved_chunk_ids: list[int | str] = []
+        plan_trace: list[str] = []
+
+        for step in range(1, self.max_steps + 1):
+            plan_prompt = self._build_plan_prompt(query_text, evidence, triples, step)
+            plan_response = await self._llm.ainvoke(plan_prompt)
+            tracker.record(plan_response)
+            action = parse_ras_plan_action(self._extract_text(plan_response))
+            plan_trace.append(f"{action.kind}: {action.text}")
+            if action.kind == "sufficient":
+                break
+
+            subqueries.append(action.text)
+            results = await self._retrieval_pipeline.retrieve(action.text, retrieval_k)
+            doc_ids, passages = self._contents_from_results(results)
+            for doc_id in doc_ids:
+                if doc_id not in retrieved_chunk_ids:
+                    retrieved_chunk_ids.append(doc_id)
+            evidence = self._append_evidence(evidence, passages)
+            triples = self._merge_triples(
+                triples,
+                await self._extract_triples_for_passages(query_text, passages, tracker),
+            )
+
+        answer_prompt = self._build_answer_prompt(query_text, evidence, triples)
+        answer_response = await self._llm.ainvoke(answer_prompt)
+        tracker.record(answer_response)
+        answer_text = self._extract_text(answer_response)
+
+        return GenerationResult(
+            text=answer_text,
+            token_usage=tracker.total,
+            metadata={
+                "subqueries": subqueries,
+                "retrieved_chunk_ids": retrieved_chunk_ids,
+                "triples": [triple.as_tuple() for triple in triples],
+                "triple_texts": [triple.as_text() for triple in triples],
+                "evidence": evidence,
+                "plan_trace": plan_trace,
+            },
+        )
+
+
+__all__ = [
+    "DEFAULT_RAS_ANSWER_PROMPT",
+    "DEFAULT_RAS_PLAN_PROMPT",
+    "DEFAULT_RAS_TRIPLE_PROMPT",
+    "RASGenerationPipeline",
+    "RASGenerationPipelineConfig",
+    "RASPlanAction",
+    "RASTriple",
+    "parse_ras_plan_action",
+    "parse_ras_triples",
+]

--- a/autorag_research/pipelines/generation/ras.py
+++ b/autorag_research/pipelines/generation/ras.py
@@ -117,10 +117,6 @@ def parse_ras_plan_action(response_text: str) -> RASPlanAction:
         return RASPlanAction(kind="invalid", text=response_text.strip())
 
     stripped_response = response_text.strip()
-    if stripped_response.lower().startswith("subquery:"):
-        text = stripped_response.split(":", 1)[1].strip()
-        if text:
-            return RASPlanAction(kind="retrieve", text=text)
     return RASPlanAction(kind="invalid", text=stripped_response)
 
 
@@ -336,15 +332,21 @@ class RASGenerationPipeline(BaseGenerationPipeline):
         plan_trace: list[str] = []
         malformed_plans: list[str] = []
 
+        extracted_chunk_ids: set[int | str] = set()
+
         initial_results = await self._retrieval_pipeline._retrieve_by_id(query_id, top_k)
         doc_ids, passages = self._contents_from_results(initial_results)
-        for doc_id in doc_ids:
+        new_passages: list[str] = []
+        for doc_id, passage in zip(doc_ids, passages, strict=False):
             if doc_id not in retrieved_chunk_ids:
                 retrieved_chunk_ids.append(doc_id)
+            if doc_id not in extracted_chunk_ids:
+                extracted_chunk_ids.add(doc_id)
+                new_passages.append(passage)
         evidence = self._append_evidence(evidence, passages)
         triples = self._merge_triples(
             triples,
-            await self._extract_triples_for_passages(query_text, passages, tracker),
+            await self._extract_triples_for_passages(query_text, new_passages, tracker),
         )
 
         for step in range(1, self.max_steps + 1):
@@ -364,13 +366,17 @@ class RASGenerationPipeline(BaseGenerationPipeline):
             subqueries.append(retrieval_query)
             results = await self._retrieval_pipeline.retrieve(retrieval_query, retrieval_k)
             doc_ids, passages = self._contents_from_results(results)
-            for doc_id in doc_ids:
+            new_passages = []
+            for doc_id, passage in zip(doc_ids, passages, strict=False):
                 if doc_id not in retrieved_chunk_ids:
                     retrieved_chunk_ids.append(doc_id)
+                if doc_id not in extracted_chunk_ids:
+                    extracted_chunk_ids.add(doc_id)
+                    new_passages.append(passage)
             evidence = self._append_evidence(evidence, passages)
             triples = self._merge_triples(
                 triples,
-                await self._extract_triples_for_passages(query_text, passages, tracker),
+                await self._extract_triples_for_passages(query_text, new_passages, tracker),
             )
 
         answer_prompt = self._build_answer_prompt(query_text, evidence, triples)

--- a/autorag_research/pipelines/generation/ras.py
+++ b/autorag_research/pipelines/generation/ras.py
@@ -25,7 +25,7 @@ from autorag_research.util import TokenUsageTracker
 
 logger = logging.getLogger("AutoRAG-Research")
 
-RASPlanKind = Literal["retrieve", "sufficient"]
+RASPlanKind = Literal["retrieve", "sufficient", "invalid"]
 
 DEFAULT_RAS_PLAN_PROMPT = """You are a Retrieval-And-Structuring (RAS) planner.
 Decide whether more retrieval is needed before building the structured answer graph.
@@ -104,16 +104,24 @@ def parse_ras_plan_action(response_text: str) -> RASPlanAction:
     """Parse RAS planner output."""
     sufficient_match = _SUFFICIENT_RE.search(response_text)
     if sufficient_match is not None:
-        return RASPlanAction(kind="sufficient", text=sufficient_match.group(1).strip())
+        text = sufficient_match.group(1).strip()
+        if text:
+            return RASPlanAction(kind="sufficient", text=text)
+        return RASPlanAction(kind="invalid", text=response_text.strip())
 
     subquery_match = _SUBQUERY_RE.search(response_text)
     if subquery_match is not None:
-        return RASPlanAction(kind="retrieve", text=subquery_match.group(1).strip())
+        text = subquery_match.group(1).strip()
+        if text:
+            return RASPlanAction(kind="retrieve", text=text)
+        return RASPlanAction(kind="invalid", text=response_text.strip())
 
     stripped_response = response_text.strip()
     if stripped_response.lower().startswith("subquery:"):
-        return RASPlanAction(kind="retrieve", text=stripped_response.split(":", 1)[1].strip())
-    return RASPlanAction(kind="sufficient", text=stripped_response)
+        text = stripped_response.split(":", 1)[1].strip()
+        if text:
+            return RASPlanAction(kind="retrieve", text=text)
+    return RASPlanAction(kind="invalid", text=stripped_response)
 
 
 def parse_ras_triples(response_text: str) -> list[RASTriple]:
@@ -326,6 +334,18 @@ class RASGenerationPipeline(BaseGenerationPipeline):
         subqueries: list[str] = []
         retrieved_chunk_ids: list[int | str] = []
         plan_trace: list[str] = []
+        malformed_plans: list[str] = []
+
+        initial_results = await self._retrieval_pipeline._retrieve_by_id(query_id, top_k)
+        doc_ids, passages = self._contents_from_results(initial_results)
+        for doc_id in doc_ids:
+            if doc_id not in retrieved_chunk_ids:
+                retrieved_chunk_ids.append(doc_id)
+        evidence = self._append_evidence(evidence, passages)
+        triples = self._merge_triples(
+            triples,
+            await self._extract_triples_for_passages(query_text, passages, tracker),
+        )
 
         for step in range(1, self.max_steps + 1):
             plan_prompt = self._build_plan_prompt(query_text, evidence, triples, step)
@@ -336,8 +356,13 @@ class RASGenerationPipeline(BaseGenerationPipeline):
             if action.kind == "sufficient":
                 break
 
-            subqueries.append(action.text)
-            results = await self._retrieval_pipeline.retrieve(action.text, retrieval_k)
+            retrieval_query = action.text
+            if action.kind == "invalid":
+                malformed_plans.append(action.text)
+                retrieval_query = query_text
+
+            subqueries.append(retrieval_query)
+            results = await self._retrieval_pipeline.retrieve(retrieval_query, retrieval_k)
             doc_ids, passages = self._contents_from_results(results)
             for doc_id in doc_ids:
                 if doc_id not in retrieved_chunk_ids:
@@ -363,6 +388,7 @@ class RASGenerationPipeline(BaseGenerationPipeline):
                 "triple_texts": [triple.as_text() for triple in triples],
                 "evidence": evidence,
                 "plan_trace": plan_trace,
+                "malformed_plans": malformed_plans,
             },
         )
 

--- a/autorag_research/pipelines/generation/ras.py
+++ b/autorag_research/pipelines/generation/ras.py
@@ -305,6 +305,23 @@ class RASGenerationPipeline(BaseGenerationPipeline):
                 merged.append(triple)
         return merged[-self.triple_budget :]
 
+    def _split_seen_and_new_passages(
+        self,
+        results: list[dict[str, Any]],
+        retrieved_chunk_ids: list[int | str],
+        extracted_chunk_ids: set[int | str],
+    ) -> tuple[list[str], list[str]]:
+        """Record retrieved chunks and return all passages plus extraction-ready new passages."""
+        doc_ids, passages = self._contents_from_results(results)
+        new_passages: list[str] = []
+        for doc_id, passage in zip(doc_ids, passages, strict=False):
+            if doc_id not in retrieved_chunk_ids:
+                retrieved_chunk_ids.append(doc_id)
+            if doc_id not in extracted_chunk_ids:
+                extracted_chunk_ids.add(doc_id)
+                new_passages.append(passage)
+        return passages, new_passages
+
     async def _extract_triples_for_passages(
         self,
         query: str,
@@ -335,14 +352,11 @@ class RASGenerationPipeline(BaseGenerationPipeline):
         extracted_chunk_ids: set[int | str] = set()
 
         initial_results = await self._retrieval_pipeline._retrieve_by_id(query_id, top_k)
-        doc_ids, passages = self._contents_from_results(initial_results)
-        new_passages: list[str] = []
-        for doc_id, passage in zip(doc_ids, passages, strict=False):
-            if doc_id not in retrieved_chunk_ids:
-                retrieved_chunk_ids.append(doc_id)
-            if doc_id not in extracted_chunk_ids:
-                extracted_chunk_ids.add(doc_id)
-                new_passages.append(passage)
+        passages, new_passages = self._split_seen_and_new_passages(
+            initial_results,
+            retrieved_chunk_ids,
+            extracted_chunk_ids,
+        )
         evidence = self._append_evidence(evidence, passages)
         triples = self._merge_triples(
             triples,
@@ -365,15 +379,14 @@ class RASGenerationPipeline(BaseGenerationPipeline):
 
             subqueries.append(retrieval_query)
             results = await self._retrieval_pipeline.retrieve(retrieval_query, retrieval_k)
-            doc_ids, passages = self._contents_from_results(results)
-            new_passages = []
-            for doc_id, passage in zip(doc_ids, passages, strict=False):
-                if doc_id not in retrieved_chunk_ids:
-                    retrieved_chunk_ids.append(doc_id)
-                if doc_id not in extracted_chunk_ids:
-                    extracted_chunk_ids.add(doc_id)
-                    new_passages.append(passage)
+            passages, new_passages = self._split_seen_and_new_passages(
+                results,
+                retrieved_chunk_ids,
+                extracted_chunk_ids,
+            )
             evidence = self._append_evidence(evidence, passages)
+            if not new_passages:
+                break
             triples = self._merge_triples(
                 triples,
                 await self._extract_triples_for_passages(query_text, new_passages, tracker),

--- a/configs/pipelines/generation/ras.yaml
+++ b/configs/pipelines/generation/ras.yaml
@@ -2,11 +2,13 @@ _target_: autorag_research.pipelines.generation.ras.RASGenerationPipelineConfig
 description: "RAS retrieval-and-structuring generation pipeline with question-specific triples"
 name: ras
 retrieval_pipeline_name: bm25
-llm: openai-gpt4o-mini
+llm: openai-gpt5-mini
 max_steps: 3
 k_per_step: 4
 evidence_budget: 12
 triple_budget: 40
+# RAS seeds retrieval with top_k chunks for the original stored query, then each
+# planner-generated subquery retrieves up to min(top_k, k_per_step) more chunks.
 top_k: 4
 batch_size: 32
 max_concurrency: 4

--- a/configs/pipelines/generation/ras.yaml
+++ b/configs/pipelines/generation/ras.yaml
@@ -1,0 +1,14 @@
+_target_: autorag_research.pipelines.generation.ras.RASGenerationPipelineConfig
+description: "RAS retrieval-and-structuring generation pipeline with question-specific triples"
+name: ras
+retrieval_pipeline_name: bm25
+llm: openai-gpt4o-mini
+max_steps: 3
+k_per_step: 4
+evidence_budget: 12
+triple_budget: 40
+top_k: 4
+batch_size: 32
+max_concurrency: 4
+max_retries: 3
+retry_delay: 1.0

--- a/tests/autorag_research/pipelines/generation/test_ras_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_ras_pipeline.py
@@ -198,7 +198,6 @@ class TestRASGenerationPipeline:
             side_effect=[
                 _mock_response("<triple>Apollo 11 | mission | lunar landing</triple>"),
                 _mock_response("<subquery>apollo 11 crew</subquery>"),
-                _mock_response("<sufficient>enough</sufficient>"),
                 _mock_response("Neil Armstrong commanded Apollo 11."),
             ]
         )
@@ -216,7 +215,8 @@ class TestRASGenerationPipeline:
         result = await pipeline._generate(1, top_k=1)
         metadata = _metadata(result)
 
-        assert llm.ainvoke.await_count == 4
+        assert llm.ainvoke.await_count == 3
+        retrieval_pipeline.retrieve.assert_awaited_once_with("apollo 11 crew", 1)
         assert metadata["retrieved_chunk_ids"] == [9]
         assert metadata["evidence"] == ["Apollo 11 was a lunar landing mission."]
         assert metadata["triples"] == [("Apollo 11", "mission", "lunar landing")]

--- a/tests/autorag_research/pipelines/generation/test_ras_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_ras_pipeline.py
@@ -1,0 +1,180 @@
+"""Tests for the RAS generation pipeline."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from autorag_research.pipelines.generation.ras import (
+    RASGenerationPipeline,
+    RASGenerationPipelineConfig,
+    RASTriple,
+    parse_ras_plan_action,
+    parse_ras_triples,
+)
+from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_retrieval_pipeline
+
+
+def _mock_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
+    return response
+
+
+def _build_unit_pipeline(llm: Any, retrieval_pipeline: Any, service: Any, **kwargs: Any) -> RASGenerationPipeline:
+    with patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None):
+        pipeline = RASGenerationPipeline(
+            session_factory=MagicMock(),
+            name="ras_unit",
+            llm=llm,
+            retrieval_pipeline=retrieval_pipeline,
+            **kwargs,
+        )
+    pipeline._llm = llm
+    pipeline._retrieval_pipeline = retrieval_pipeline
+    pipeline._service = service
+    pipeline.pipeline_id = 1
+    return pipeline
+
+
+class TestRASParsing:
+    """Tests for RAS parsing helpers."""
+
+    def test_parse_subquery_action(self):
+        action = parse_ras_plan_action("<subquery>apollo 11 crew</subquery>")
+
+        assert action.kind == "retrieve"
+        assert action.text == "apollo 11 crew"
+
+    def test_parse_sufficient_action(self):
+        action = parse_ras_plan_action("<sufficient>graph is enough</sufficient>")
+
+        assert action.kind == "sufficient"
+        assert action.text == "graph is enough"
+
+    def test_parse_triples(self):
+        triples = parse_ras_triples(
+            "<triple>Apollo 11 | commander | Neil Armstrong</triple>\n"
+            "<triple>Apollo 11 | landed on | Moon</triple>"
+        )
+
+        assert triples == [
+            RASTriple("Apollo 11", "commander", "Neil Armstrong"),
+            RASTriple("Apollo 11", "landed on", "Moon"),
+        ]
+
+
+class TestRASGenerationPipelineConfig:
+    """Tests for RASGenerationPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        config = RASGenerationPipelineConfig(
+            name="ras",
+            llm=FakeListLLM(responses=["answer"]),
+            retrieval_pipeline_name="bm25",
+        )
+
+        assert config.get_pipeline_class() == RASGenerationPipeline
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        config = RASGenerationPipelineConfig(
+            name="ras",
+            llm=FakeListLLM(responses=["answer"]),
+            retrieval_pipeline_name="bm25",
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        retrieval_pipeline = create_mock_retrieval_pipeline(pipeline_id=44)
+        llm = FakeListLLM(responses=["answer"])
+        config = RASGenerationPipelineConfig(
+            name="ras",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+            max_steps=2,
+            k_per_step=3,
+        )
+
+        config.inject_retrieval_pipeline(retrieval_pipeline)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is retrieval_pipeline
+        assert kwargs["max_steps"] == 2
+        assert kwargs["k_per_step"] == 3
+
+
+class TestRASGenerationPipeline:
+    """Tests for RAS pipeline behavior."""
+
+    def test_initialization_rejects_invalid_steps(self):
+        with (
+            patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="max_steps must be >= 1"),
+        ):
+            RASGenerationPipeline(
+                session_factory=MagicMock(),
+                name="invalid_ras",
+                llm=FakeListLLM(responses=["answer"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                max_steps=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_retrieves_extracts_triples_and_answers(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<subquery>apollo 11 crew</subquery>"),
+                _mock_response("<triple>Apollo 11 | commander | Neil Armstrong</triple>"),
+                _mock_response("<sufficient>enough</sufficient>"),
+                _mock_response("Neil Armstrong commanded Apollo 11."),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 10, "score": 0.9, "content": "Neil Armstrong commanded Apollo 11."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Who commanded Apollo 11?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=3, k_per_step=2)
+
+        result = await pipeline._generate(1, top_k=2)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("apollo 11 crew", 2)
+        assert result.text == "Neil Armstrong commanded Apollo 11."
+        assert result.metadata["subqueries"] == ["apollo 11 crew"]
+        assert result.metadata["retrieved_chunk_ids"] == [10]
+        assert result.metadata["triples"] == [("Apollo 11", "commander", "Neil Armstrong")]
+        assert result.token_usage == {"prompt_tokens": 8, "completion_tokens": 12, "total_tokens": 20}
+
+    @pytest.mark.asyncio
+    async def test_generate_backfills_missing_content(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<subquery>missing content</subquery>"),
+                _mock_response("<triple>A | relates to | B</triple>"),
+                _mock_response("answer"),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline(default_results=[{"doc_id": 5, "score": 0.8}])
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        service.get_chunk_contents.return_value = ["Fetched passage."]
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=1, k_per_step=1)
+
+        result = await pipeline._generate(1, top_k=1)
+
+        service.get_chunk_contents.assert_called_once_with([5])
+        assert result.metadata["evidence"] == ["Fetched passage."]
+        assert result.metadata["triples"] == [("A", "relates to", "B")]
+
+    def test_merge_triples_deduplicates(self):
+        pipeline = _build_unit_pipeline(MagicMock(), create_mock_retrieval_pipeline(), MagicMock())
+        triple = RASTriple("A", "p", "B")
+
+        assert pipeline._merge_triples([triple], [triple]) == [triple]

--- a/tests/autorag_research/pipelines/generation/test_ras_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_ras_pipeline.py
@@ -67,6 +67,12 @@ class TestRASParsing:
         assert action.kind == "invalid"
         assert action.text == "I need Apollo 11 context but forgot the tags."
 
+    def test_parse_untagged_subquery_prefix_is_invalid(self):
+        action = parse_ras_plan_action("subquery: apollo 11 crew")
+
+        assert action.kind == "invalid"
+        assert action.text == "subquery: apollo 11 crew"
+
     def test_parse_empty_required_tags_are_invalid(self):
         assert parse_ras_plan_action("<subquery> </subquery>").kind == "invalid"
         assert parse_ras_plan_action("<sufficient> </sufficient>").kind == "invalid"
@@ -184,6 +190,36 @@ class TestRASGenerationPipeline:
         ]
         assert metadata["malformed_plans"] == []
         assert result.token_usage == {"prompt_tokens": 10, "completion_tokens": 15, "total_tokens": 25}
+
+    @pytest.mark.asyncio
+    async def test_generate_skips_duplicate_passages_before_extracting_triples(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("<triple>Apollo 11 | mission | lunar landing</triple>"),
+                _mock_response("<subquery>apollo 11 crew</subquery>"),
+                _mock_response("<sufficient>enough</sufficient>"),
+                _mock_response("Neil Armstrong commanded Apollo 11."),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline._retrieve_by_id = AsyncMock(
+            return_value=[{"doc_id": 9, "score": 1.0, "content": "Apollo 11 was a lunar landing mission."}]
+        )
+        retrieval_pipeline.retrieve = AsyncMock(
+            return_value=[{"doc_id": 9, "score": 0.9, "content": "Apollo 11 was a lunar landing mission."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Who commanded Apollo 11?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=2, k_per_step=1)
+
+        result = await pipeline._generate(1, top_k=1)
+        metadata = _metadata(result)
+
+        assert llm.ainvoke.await_count == 4
+        assert metadata["retrieved_chunk_ids"] == [9]
+        assert metadata["evidence"] == ["Apollo 11 was a lunar landing mission."]
+        assert metadata["triples"] == [("Apollo 11", "mission", "lunar landing")]
 
     @pytest.mark.asyncio
     async def test_generate_backfills_missing_content(self):

--- a/tests/autorag_research/pipelines/generation/test_ras_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_ras_pipeline.py
@@ -1,10 +1,12 @@
 """Tests for the RAS generation pipeline."""
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.language_models.fake import FakeListLLM
+from omegaconf import OmegaConf
 
 from autorag_research.pipelines.generation.ras import (
     RASGenerationPipeline,
@@ -39,6 +41,11 @@ def _build_unit_pipeline(llm: Any, retrieval_pipeline: Any, service: Any, **kwar
     return pipeline
 
 
+def _metadata(result: Any) -> dict[str, Any]:
+    assert result.metadata is not None
+    return result.metadata
+
+
 class TestRASParsing:
     """Tests for RAS parsing helpers."""
 
@@ -54,10 +61,19 @@ class TestRASParsing:
         assert action.kind == "sufficient"
         assert action.text == "graph is enough"
 
+    def test_parse_malformed_action_is_invalid(self):
+        action = parse_ras_plan_action("I need Apollo 11 context but forgot the tags.")
+
+        assert action.kind == "invalid"
+        assert action.text == "I need Apollo 11 context but forgot the tags."
+
+    def test_parse_empty_required_tags_are_invalid(self):
+        assert parse_ras_plan_action("<subquery> </subquery>").kind == "invalid"
+        assert parse_ras_plan_action("<sufficient> </sufficient>").kind == "invalid"
+
     def test_parse_triples(self):
         triples = parse_ras_triples(
-            "<triple>Apollo 11 | commander | Neil Armstrong</triple>\n"
-            "<triple>Apollo 11 | landed on | Moon</triple>"
+            "<triple>Apollo 11 | commander | Neil Armstrong</triple>\n<triple>Apollo 11 | landed on | Moon</triple>"
         )
 
         assert triples == [
@@ -68,6 +84,13 @@ class TestRASParsing:
 
 class TestRASGenerationPipelineConfig:
     """Tests for RASGenerationPipelineConfig."""
+
+    def test_ras_yaml_references_existing_llm_config(self):
+        config_path = Path("configs/pipelines/generation/ras.yaml")
+        config = OmegaConf.load(config_path)
+        llm_name = str(config.llm)
+
+        assert (Path("configs/llm") / f"{llm_name}.yaml").exists() or (Path("configs/llm") / f"{llm_name}.yml").exists()
 
     def test_get_pipeline_class(self):
         config = RASGenerationPipelineConfig(
@@ -129,27 +152,38 @@ class TestRASGenerationPipeline:
         llm = MagicMock()
         llm.ainvoke = AsyncMock(
             side_effect=[
+                _mock_response("<triple>Apollo 11 | mission | lunar landing</triple>"),
                 _mock_response("<subquery>apollo 11 crew</subquery>"),
                 _mock_response("<triple>Apollo 11 | commander | Neil Armstrong</triple>"),
                 _mock_response("<sufficient>enough</sufficient>"),
                 _mock_response("Neil Armstrong commanded Apollo 11."),
             ]
         )
-        retrieval_pipeline = create_mock_retrieval_pipeline(
-            default_results=[{"doc_id": 10, "score": 0.9, "content": "Neil Armstrong commanded Apollo 11."}]
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline._retrieve_by_id = AsyncMock(
+            return_value=[{"doc_id": 9, "score": 1.0, "content": "Apollo 11 was a lunar landing mission."}]
+        )
+        retrieval_pipeline.retrieve = AsyncMock(
+            return_value=[{"doc_id": 10, "score": 0.9, "content": "Neil Armstrong commanded Apollo 11."}]
         )
         service = MagicMock()
         service.get_query_text.return_value = "Who commanded Apollo 11?"
         pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=3, k_per_step=2)
 
         result = await pipeline._generate(1, top_k=2)
+        metadata = _metadata(result)
 
+        retrieval_pipeline._retrieve_by_id.assert_awaited_once_with(1, 2)
         retrieval_pipeline.retrieve.assert_awaited_once_with("apollo 11 crew", 2)
         assert result.text == "Neil Armstrong commanded Apollo 11."
-        assert result.metadata["subqueries"] == ["apollo 11 crew"]
-        assert result.metadata["retrieved_chunk_ids"] == [10]
-        assert result.metadata["triples"] == [("Apollo 11", "commander", "Neil Armstrong")]
-        assert result.token_usage == {"prompt_tokens": 8, "completion_tokens": 12, "total_tokens": 20}
+        assert metadata["subqueries"] == ["apollo 11 crew"]
+        assert metadata["retrieved_chunk_ids"] == [9, 10]
+        assert metadata["triples"] == [
+            ("Apollo 11", "mission", "lunar landing"),
+            ("Apollo 11", "commander", "Neil Armstrong"),
+        ]
+        assert metadata["malformed_plans"] == []
+        assert result.token_usage == {"prompt_tokens": 10, "completion_tokens": 15, "total_tokens": 25}
 
     @pytest.mark.asyncio
     async def test_generate_backfills_missing_content(self):
@@ -161,17 +195,47 @@ class TestRASGenerationPipeline:
                 _mock_response("answer"),
             ]
         )
-        retrieval_pipeline = create_mock_retrieval_pipeline(default_results=[{"doc_id": 5, "score": 0.8}])
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline._retrieve_by_id = AsyncMock(return_value=[])
+        retrieval_pipeline.retrieve = AsyncMock(return_value=[{"doc_id": 5, "score": 0.8}])
         service = MagicMock()
         service.get_query_text.return_value = "Question?"
         service.get_chunk_contents.return_value = ["Fetched passage."]
         pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=1, k_per_step=1)
 
         result = await pipeline._generate(1, top_k=1)
+        metadata = _metadata(result)
 
         service.get_chunk_contents.assert_called_once_with([5])
-        assert result.metadata["evidence"] == ["Fetched passage."]
-        assert result.metadata["triples"] == [("A", "relates to", "B")]
+        assert metadata["evidence"] == ["Fetched passage."]
+        assert metadata["triples"] == [("A", "relates to", "B")]
+
+    @pytest.mark.asyncio
+    async def test_generate_uses_original_query_fallback_for_malformed_plan(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(
+            side_effect=[
+                _mock_response("Need more evidence but omitted required tags."),
+                _mock_response("<triple>Apollo 11 | commander | Neil Armstrong</triple>"),
+                _mock_response("Neil Armstrong."),
+            ]
+        )
+        retrieval_pipeline = create_mock_retrieval_pipeline()
+        retrieval_pipeline._retrieve_by_id = AsyncMock(return_value=[])
+        retrieval_pipeline.retrieve = AsyncMock(
+            return_value=[{"doc_id": 10, "score": 0.9, "content": "Neil Armstrong commanded Apollo 11."}]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Who commanded Apollo 11?"
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, max_steps=1, k_per_step=2)
+
+        result = await pipeline._generate(1, top_k=2)
+        metadata = _metadata(result)
+
+        retrieval_pipeline.retrieve.assert_awaited_once_with("Who commanded Apollo 11?", 2)
+        assert metadata["subqueries"] == ["Who commanded Apollo 11?"]
+        assert metadata["malformed_plans"] == ["Need more evidence but omitted required tags."]
+        assert metadata["plan_trace"] == ["invalid: Need more evidence but omitted required tags."]
 
     def test_merge_triples_deduplicates(self):
         pipeline = _build_unit_pipeline(MagicMock(), create_mock_retrieval_pipeline(), MagicMock())


### PR DESCRIPTION
## Summary
- Adds an inference-first RAS generation pipeline that plans subqueries, retrieves passages, extracts triples, merges a question-specific graph state, and answers from structured evidence.
- Reuses existing retrieval pipelines and records subqueries, retrieved chunk IDs, triples, evidence, and plan traces.
- Adds YAML config, exports, and focused tests for parsing, config injection, triple merge/deduplication, retrieval, content backfill, and answer generation.

## Scope
- Implements the RAS inference/evaluation baseline suitable for AutoRAG-Research.
- Does not add paper-scale trained GraphLLM/GNN components.

## Validation
- uv sync --all-extras --all-groups
- uv run pytest tests/autorag_research/pipelines/generation/test_ras_pipeline.py -q
- make check

Closes #182

<!-- dani:stage=implementation;job=fa0f808358ad131a54ce5e912aad3e1c;issue=182 -->
