### PR TITLE
Add DynamicRAG reranker and generation pipeline

### DIFF
--- a/autorag_research/pipelines/generation/__init__.py
+++ b/autorag_research/pipelines/generation/__init__.py
@@ -1,6 +1,7 @@
 from autorag_research.pipelines.generation.autothinkrag import AutoThinkRAGPipeline, AutoThinkRAGPipelineConfig
 from autorag_research.pipelines.generation.base import BaseGenerationPipeline
 from autorag_research.pipelines.generation.basic_rag import BasicRAGPipeline, BasicRAGPipelineConfig
+from autorag_research.pipelines.generation.dynamic_rag import DynamicRAGPipeline, DynamicRAGPipelineConfig
 from autorag_research.pipelines.generation.et2rag import (
     DEFAULT_PROMPT_TEMPLATE,
     ET2RAGPipeline,
@@ -30,6 +31,8 @@ __all__ = [
     "BaseGenerationPipeline",
     "BasicRAGPipeline",
     "BasicRAGPipelineConfig",
+    "DynamicRAGPipeline",
+    "DynamicRAGPipelineConfig",
     "ET2RAGPipeline",
     "ET2RAGPipelineConfig",
     "IRCoTGenerationPipeline",

--- a/autorag_research/pipelines/generation/dynamic_rag.py
+++ b/autorag_research/pipelines/generation/dynamic_rag.py
@@ -95,6 +95,40 @@ class DynamicRAGPipeline(BaseGenerationPipeline):
 
         super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
 
+    @staticmethod
+    def _is_json_config_value(value: Any) -> bool:
+        """Return whether value is safe to persist as JSON pipeline config."""
+        if value is None or isinstance(value, str | int | float | bool):
+            return True
+        if isinstance(value, list):
+            return all(DynamicRAGPipeline._is_json_config_value(item) for item in value)
+        if isinstance(value, dict):
+            return all(
+                isinstance(key, str) and DynamicRAGPipeline._is_json_config_value(item) for key, item in value.items()
+            )
+        return False
+
+    @staticmethod
+    def _reranker_config(reranker: BaseReranker) -> dict[str, Any]:
+        """Return JSON-safe reranker identity/config for experiment provenance."""
+        excluded_runtime_fields = {"api_key", "base_reranker", "results"}
+        config: dict[str, Any] = {"type": type(reranker).__name__}
+        for field_name in type(reranker).model_fields:
+            if field_name in excluded_runtime_fields:
+                continue
+            value = getattr(reranker, field_name)
+            if DynamicRAGPipeline._is_json_config_value(value):
+                config[field_name] = value
+
+        if isinstance(reranker, DynamicRAGReranker):
+            config["base_reranker"] = (
+                DynamicRAGPipeline._reranker_config(reranker.base_reranker)
+                if reranker.base_reranker is not None
+                else None
+            )
+
+        return config
+
     def _get_pipeline_config(self) -> dict[str, Any]:
         """Return DynamicRAG pipeline configuration."""
         model_name = getattr(self._llm, "model_name", None)
@@ -105,6 +139,7 @@ class DynamicRAGPipeline(BaseGenerationPipeline):
             "prompt_template": self.prompt_template,
             "candidate_top_k": self.candidate_top_k,
             "reranker_model": getattr(self.reranker, "model_name", type(self.reranker).__name__),
+            "reranker": self._reranker_config(self.reranker),
             "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
             "llm_model": model_name,
         }

--- a/autorag_research/pipelines/generation/dynamic_rag.py
+++ b/autorag_research/pipelines/generation/dynamic_rag.py
@@ -1,0 +1,195 @@
+"""DynamicRAG generation pipeline.
+
+This pipeline implements the inference/evaluation slice of DynamicRAG: retrieve a
+candidate pool, dynamically rerank and truncate it, and generate from only the
+selected evidence. Training the original DynamicRAG policy with generator
+feedback is outside this repo-native baseline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.language_models import BaseLanguageModel
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseGenerationPipelineConfig
+from autorag_research.orm.service.generation_pipeline import GenerationResult
+from autorag_research.pipelines.generation.base import BaseGenerationPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.rerankers.base import BaseReranker, RerankResult
+from autorag_research.rerankers.dynamic_rag import DynamicRAGReranker
+from autorag_research.util import TokenUsageTracker
+
+DEFAULT_DYNAMIC_RAG_PROMPT = """Answer the question using only the dynamically selected evidence.
+
+Question:
+{query}
+
+Evidence:
+{context}
+
+Answer:"""
+
+
+@dataclass(kw_only=True)
+class DynamicRAGPipelineConfig(BaseGenerationPipelineConfig):
+    """Configuration for DynamicRAGPipeline."""
+
+    reranker: str | BaseReranker = field(default_factory=DynamicRAGReranker)
+    prompt_template: str = field(default=DEFAULT_DYNAMIC_RAG_PROMPT)
+    candidate_top_k: int = 20
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Auto-convert string reranker config names to reranker instances."""
+        if name == "reranker" and isinstance(value, str):
+            from autorag_research.injection import load_reranker
+
+            value = load_reranker(value)
+        super().__setattr__(name, value)
+
+    def get_pipeline_class(self) -> type[DynamicRAGPipeline]:
+        """Return the DynamicRAGPipeline class."""
+        return DynamicRAGPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for DynamicRAGPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+        return {
+            "llm": self.llm,
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "reranker": self.reranker,
+            "prompt_template": self.prompt_template,
+            "candidate_top_k": self.candidate_top_k,
+        }
+
+
+class DynamicRAGPipeline(BaseGenerationPipeline):
+    """Generation pipeline that applies DynamicRAG reranking before answering."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        llm: BaseLanguageModel,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        reranker: BaseReranker | None = None,
+        prompt_template: str = DEFAULT_DYNAMIC_RAG_PROMPT,
+        candidate_top_k: int = 20,
+        schema: Any | None = None,
+    ):
+        """Initialize DynamicRAGPipeline."""
+        if candidate_top_k < 1:
+            msg = "candidate_top_k must be >= 1"
+            raise ValueError(msg)
+        if "{query}" not in prompt_template or "{context}" not in prompt_template:
+            msg = "prompt_template must contain {query} and {context} placeholders"
+            raise ValueError(msg)
+
+        self.reranker = reranker or DynamicRAGReranker()
+        self.prompt_template = prompt_template
+        self.candidate_top_k = candidate_top_k
+
+        super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return DynamicRAG pipeline configuration."""
+        model_name = getattr(self._llm, "model_name", None)
+        if model_name is None or not isinstance(model_name, str):
+            model_name = type(self._llm).__name__
+        return {
+            "type": "dynamic_rag",
+            "prompt_template": self.prompt_template,
+            "candidate_top_k": self.candidate_top_k,
+            "reranker_model": getattr(self.reranker, "model_name", type(self.reranker).__name__),
+            "retrieval_pipeline_id": self._retrieval_pipeline.pipeline_id,
+            "llm_model": model_name,
+        }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract text from a LangChain response."""
+        return response.content if hasattr(response, "content") else str(response)
+
+    def _contents_from_results(self, results: list[dict[str, Any]]) -> tuple[list[int | str], list[str]]:
+        """Extract IDs and contents from retrieval results, backfilling missing text."""
+        doc_ids: list[int | str] = []
+        contents: list[str | None] = []
+        missing_positions: list[int] = []
+        missing_ids: list[int | str] = []
+        for result in results:
+            doc_id = result.get("doc_id")
+            if doc_id is None:
+                continue
+            doc_ids.append(doc_id)
+            content = result.get("content")
+            if content:
+                contents.append(str(content))
+            else:
+                missing_positions.append(len(contents))
+                missing_ids.append(doc_id)
+                contents.append(None)
+        if missing_ids:
+            fetched_contents = self._service.get_chunk_contents(missing_ids)
+            for position, fetched_content in zip(missing_positions, fetched_contents, strict=False):
+                contents[position] = fetched_content
+        return doc_ids, [content or "" for content in contents]
+
+    @staticmethod
+    def _map_reranked_results(
+        candidate_doc_ids: list[int | str], rerank_results: list[RerankResult]
+    ) -> tuple[list[int | str], list[str], list[float]]:
+        """Map reranker result indices back to candidate metadata."""
+        selected_doc_ids: list[int | str] = []
+        selected_contents: list[str] = []
+        selected_scores: list[float] = []
+        for rerank_result in rerank_results:
+            if rerank_result.index < 0 or rerank_result.index >= len(candidate_doc_ids):
+                msg = f"Reranker returned out-of-range candidate index: {rerank_result.index}"
+                raise ValueError(msg)
+            selected_doc_ids.append(candidate_doc_ids[rerank_result.index])
+            selected_contents.append(rerank_result.text)
+            selected_scores.append(float(rerank_result.score))
+        return selected_doc_ids, selected_contents, selected_scores
+
+    def _build_prompt(self, query: str, selected_contents: list[str]) -> str:
+        """Build the final DynamicRAG prompt."""
+        context = "\n\n".join(f"[{index + 1}] {content}" for index, content in enumerate(selected_contents))
+        return self.prompt_template.format(query=query, context=context or "(no evidence selected)")
+
+    async def _generate(self, query_id: int | str, top_k: int) -> GenerationResult:
+        """Generate with dynamic reranking and truncation."""
+        query_text = self._service.get_query_text(query_id)
+        fetch_k = max(top_k, self.candidate_top_k)
+        candidates = await self._retrieval_pipeline._retrieve_by_id(query_id, fetch_k)
+        candidate_doc_ids, candidate_contents = self._contents_from_results(candidates)
+        rerank_results = await self.reranker.arerank(query_text, candidate_contents, top_k=top_k)
+        selected_doc_ids, selected_contents, selected_scores = self._map_reranked_results(
+            candidate_doc_ids,
+            rerank_results,
+        )
+
+        prompt = self._build_prompt(query_text, selected_contents)
+        response = await self._llm.ainvoke(prompt)
+        tracker = TokenUsageTracker()
+        token_usage = tracker.record(response)
+        return GenerationResult(
+            text=self._extract_text(response),
+            token_usage=token_usage,
+            metadata={
+                "candidate_chunk_ids": candidate_doc_ids,
+                "selected_chunk_ids": selected_doc_ids,
+                "selected_scores": selected_scores,
+                "effective_top_k": len(selected_doc_ids),
+            },
+        )
+
+
+__all__ = [
+    "DEFAULT_DYNAMIC_RAG_PROMPT",
+    "DynamicRAGPipeline",
+    "DynamicRAGPipelineConfig",
+]

--- a/autorag_research/rerankers/__init__.py
+++ b/autorag_research/rerankers/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "BaseReranker",
     "CohereReranker",
     "ColBERTReranker",
+    "DynamicRAGReranker",
     "FlagEmbeddingLLMReranker",
     "FlagEmbeddingReranker",
     "FlashRankReranker",
@@ -27,6 +28,7 @@ __all__ = [
 # Mapping of class names to their module paths for lazy loading
 _RERANKER_MODULES: dict[str, str] = {
     "CohereReranker": "autorag_research.rerankers.cohere",
+    "DynamicRAGReranker": "autorag_research.rerankers.dynamic_rag",
     "ColBERTReranker": "autorag_research.rerankers.colbert",
     "FlagEmbeddingLLMReranker": "autorag_research.rerankers.flag_embedding_llm",
     "FlagEmbeddingReranker": "autorag_research.rerankers.flag_embedding",

--- a/autorag_research/rerankers/dynamic_rag.py
+++ b/autorag_research/rerankers/dynamic_rag.py
@@ -1,0 +1,86 @@
+"""DynamicRAG inference-time reranker.
+
+DynamicRAG dynamically reorders and truncates retrieved candidates before
+answer generation. This implementation provides an AutoRAG-compatible inference
+reranker: it can wrap an existing reranker for scoring, then applies a dynamic
+cut policy based on minimum score, score gap, and min/max retained documents.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from autorag_research.rerankers.base import BaseReranker, RerankResult
+
+
+class DynamicRAGReranker(BaseReranker):
+    """Reranker with DynamicRAG-style variable top-k truncation."""
+
+    model_name: str = Field(default="dynamic-rag", description="DynamicRAG reranker wrapper name.")
+    base_reranker: BaseReranker | None = Field(default=None, description="Optional underlying scorer/reranker.")
+    min_top_k: int = Field(default=1, ge=1, description="Minimum documents to keep.")
+    max_top_k: int | None = Field(default=None, description="Maximum documents to keep before requested top_k.")
+    score_drop_threshold: float | None = Field(
+        default=0.25,
+        description="Stop after min_top_k when adjacent score drop exceeds this threshold.",
+    )
+    min_score: float | None = Field(default=None, description="Stop after min_top_k when score falls below this value.")
+
+    def _score_documents(self, query: str, documents: list[str]) -> list[RerankResult]:
+        """Score documents with base reranker or deterministic order fallback."""
+        if self.base_reranker is not None:
+            return self.base_reranker.rerank(query, documents, top_k=len(documents))
+
+        return [
+            RerankResult(index=index, text=document, score=float(len(documents) - index))
+            for index, document in enumerate(documents)
+        ]
+
+    def _dynamic_cut(self, ranked_results: list[RerankResult], requested_top_k: int | None) -> int:
+        """Choose an effective cutoff from ranked results."""
+        if not ranked_results:
+            return 0
+
+        upper_bound = len(ranked_results)
+        if requested_top_k is not None:
+            upper_bound = min(upper_bound, requested_top_k)
+        if self.max_top_k is not None:
+            upper_bound = min(upper_bound, self.max_top_k)
+        upper_bound = max(1, upper_bound)
+        min_keep = min(self.min_top_k, upper_bound)
+
+        effective_k = upper_bound
+        for position in range(min_keep, upper_bound):
+            current_score = ranked_results[position].score
+            previous_score = ranked_results[position - 1].score
+            if self.min_score is not None and current_score < self.min_score:
+                effective_k = position
+                break
+            if self.score_drop_threshold is not None and previous_score - current_score >= self.score_drop_threshold:
+                effective_k = position
+                break
+
+        return max(min_keep, effective_k)
+
+    def rerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
+        """Rerank documents and return a dynamically truncated result list."""
+        if not documents:
+            return []
+        ranked_results = self._score_documents(query, documents)
+        ranked_results.sort(key=lambda result: result.score, reverse=True)
+        effective_k = self._dynamic_cut(ranked_results, top_k)
+        return ranked_results[:effective_k]
+
+    async def arerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
+        """Async rerank implementation."""
+        if not documents:
+            return []
+        if self.base_reranker is not None:
+            ranked_results = await self.base_reranker.arerank(query, documents, top_k=len(documents))
+            ranked_results.sort(key=lambda result: result.score, reverse=True)
+            effective_k = self._dynamic_cut(ranked_results, top_k)
+            return ranked_results[:effective_k]
+        return self.rerank(query, documents, top_k)
+
+
+__all__ = ["DynamicRAGReranker"]

--- a/autorag_research/rerankers/dynamic_rag.py
+++ b/autorag_research/rerankers/dynamic_rag.py
@@ -36,7 +36,9 @@ class DynamicRAGReranker(BaseReranker):
             for index, document in enumerate(documents)
         ]
 
-    def _dynamic_cut(self, ranked_results: list[RerankResult], requested_top_k: int | None) -> int:
+    def _dynamic_cut(
+        self, ranked_results: list[RerankResult], requested_top_k: int | None, *, allow_score_cut: bool
+    ) -> int:
         """Choose an effective cutoff from ranked results."""
         if not ranked_results:
             return 0
@@ -50,6 +52,9 @@ class DynamicRAGReranker(BaseReranker):
         min_keep = min(self.min_top_k, upper_bound)
 
         effective_k = upper_bound
+        if not allow_score_cut:
+            return effective_k
+
         for position in range(min_keep, upper_bound):
             current_score = ranked_results[position].score
             previous_score = ranked_results[position - 1].score
@@ -68,7 +73,7 @@ class DynamicRAGReranker(BaseReranker):
             return []
         ranked_results = self._score_documents(query, documents)
         ranked_results.sort(key=lambda result: result.score, reverse=True)
-        effective_k = self._dynamic_cut(ranked_results, top_k)
+        effective_k = self._dynamic_cut(ranked_results, top_k, allow_score_cut=self.base_reranker is not None)
         return ranked_results[:effective_k]
 
     async def arerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
@@ -78,7 +83,7 @@ class DynamicRAGReranker(BaseReranker):
         if self.base_reranker is not None:
             ranked_results = await self.base_reranker.arerank(query, documents, top_k=len(documents))
             ranked_results.sort(key=lambda result: result.score, reverse=True)
-            effective_k = self._dynamic_cut(ranked_results, top_k)
+            effective_k = self._dynamic_cut(ranked_results, top_k, allow_score_cut=self.base_reranker is not None)
             return ranked_results[:effective_k]
         return self.rerank(query, documents, top_k)
 

--- a/configs/pipelines/generation/dynamic_rag.yaml
+++ b/configs/pipelines/generation/dynamic_rag.yaml
@@ -1,0 +1,12 @@
+_target_: autorag_research.pipelines.generation.dynamic_rag.DynamicRAGPipelineConfig
+description: "DynamicRAG generation pipeline with dynamic rerank-and-cut evidence selection"
+name: dynamic_rag
+retrieval_pipeline_name: bm25
+llm: openai-gpt4o-mini
+reranker: dynamic_rag
+candidate_top_k: 20
+top_k: 8
+batch_size: 32
+max_concurrency: 4
+max_retries: 3
+retry_delay: 1.0

--- a/configs/reranker/dynamic_rag.yaml
+++ b/configs/reranker/dynamic_rag.yaml
@@ -1,0 +1,8 @@
+_target_: autorag_research.rerankers.dynamic_rag.DynamicRAGReranker
+model_name: dynamic-rag
+min_top_k: 1
+max_top_k: 8
+score_drop_threshold: 0.25
+min_score: null
+batch_size: 64
+max_concurrency: 10

--- a/configs/reranker/dynamic_rag.yaml
+++ b/configs/reranker/dynamic_rag.yaml
@@ -2,7 +2,7 @@ _target_: autorag_research.rerankers.dynamic_rag.DynamicRAGReranker
 model_name: dynamic-rag
 min_top_k: 1
 max_top_k: 8
-score_drop_threshold: 0.25
+score_drop_threshold: null
 min_score: null
 batch_size: 64
 max_concurrency: 10

--- a/tests/autorag_research/pipelines/generation/test_dynamic_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_dynamic_rag_pipeline.py
@@ -8,6 +8,7 @@ from langchain_core.language_models.fake import FakeListLLM
 
 from autorag_research.pipelines.generation.dynamic_rag import DynamicRAGPipeline, DynamicRAGPipelineConfig
 from autorag_research.rerankers.base import BaseReranker, RerankResult
+from autorag_research.rerankers.dynamic_rag import DynamicRAGReranker
 from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_retrieval_pipeline
 
 
@@ -104,6 +105,67 @@ class TestDynamicRAGPipeline:
                 retrieval_pipeline=create_mock_retrieval_pipeline(),
                 candidate_top_k=0,
             )
+
+    def test_pipeline_config_distinguishes_dynamic_rag_cut_policy(self):
+        llm = FakeListLLM(responses=["answer"])
+        retrieval_pipeline = create_mock_retrieval_pipeline(pipeline_id=77)
+        service = MagicMock()
+        conservative = _build_unit_pipeline(
+            llm,
+            retrieval_pipeline,
+            service,
+            reranker=DynamicRAGReranker(score_drop_threshold=0.10, min_top_k=1, max_top_k=8),
+        )
+        permissive = _build_unit_pipeline(
+            llm,
+            retrieval_pipeline,
+            service,
+            reranker=DynamicRAGReranker(score_drop_threshold=0.90, min_top_k=1, max_top_k=8),
+        )
+
+        conservative_config = conservative._get_pipeline_config()
+        permissive_config = permissive._get_pipeline_config()
+
+        assert conservative_config != permissive_config
+        assert conservative_config["reranker"]["score_drop_threshold"] == 0.10
+        assert permissive_config["reranker"]["score_drop_threshold"] == 0.90
+
+    def test_pipeline_config_records_dynamic_rag_base_reranker_identity(self):
+        llm = FakeListLLM(responses=["answer"])
+        retrieval_pipeline = create_mock_retrieval_pipeline(pipeline_id=77)
+        service = MagicMock()
+        base_reranker = FixedAsyncReranker(model_name="fixed-scorer", batch_size=7, results=[])
+        pipeline = _build_unit_pipeline(
+            llm,
+            retrieval_pipeline,
+            service,
+            reranker=DynamicRAGReranker(
+                base_reranker=base_reranker,
+                min_top_k=2,
+                max_top_k=6,
+                score_drop_threshold=0.30,
+                min_score=0.40,
+            ),
+        )
+
+        config = pipeline._get_pipeline_config()
+
+        assert config["reranker"] == {
+            "type": "DynamicRAGReranker",
+            "model_name": "dynamic-rag",
+            "batch_size": 64,
+            "max_concurrency": 10,
+            "base_reranker": {
+                "type": "FixedAsyncReranker",
+                "model_name": "fixed-scorer",
+                "batch_size": 7,
+                "max_concurrency": 10,
+            },
+            "min_top_k": 2,
+            "max_top_k": 6,
+            "score_drop_threshold": 0.30,
+            "min_score": 0.40,
+        }
 
     @pytest.mark.asyncio
     async def test_generate_retrieves_dynamic_reranks_and_answers(self):

--- a/tests/autorag_research/pipelines/generation/test_dynamic_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_dynamic_rag_pipeline.py
@@ -131,10 +131,12 @@ class TestDynamicRAGPipeline:
         retrieval_pipeline._retrieve_by_id.assert_awaited_once_with(1, 5)
         assert "second" in llm.ainvoke.await_args.args[0]
         assert result.text == "final answer"
-        assert result.metadata["candidate_chunk_ids"] == [1, 2]
-        assert result.metadata["selected_chunk_ids"] == [2]
-        assert result.metadata["selected_scores"] == [0.95]
-        assert result.metadata["effective_top_k"] == 1
+        metadata = result.metadata
+        assert metadata is not None
+        assert metadata["candidate_chunk_ids"] == [1, 2]
+        assert metadata["selected_chunk_ids"] == [2]
+        assert metadata["selected_scores"] == [0.95]
+        assert metadata["effective_top_k"] == 1
 
     @pytest.mark.asyncio
     async def test_generate_backfills_missing_contents(self):
@@ -150,4 +152,6 @@ class TestDynamicRAGPipeline:
         result = await pipeline._generate(1, top_k=1)
 
         service.get_chunk_contents.assert_called_once_with([5])
-        assert result.metadata["selected_chunk_ids"] == [5]
+        metadata = result.metadata
+        assert metadata is not None
+        assert metadata["selected_chunk_ids"] == [5]

--- a/tests/autorag_research/pipelines/generation/test_dynamic_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_dynamic_rag_pipeline.py
@@ -1,0 +1,153 @@
+"""Tests for DynamicRAG generation pipeline."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake import FakeListLLM
+
+from autorag_research.pipelines.generation.dynamic_rag import DynamicRAGPipeline, DynamicRAGPipelineConfig
+from autorag_research.rerankers.base import BaseReranker, RerankResult
+from tests.autorag_research.pipelines.pipeline_test_utils import create_mock_retrieval_pipeline
+
+
+class FixedAsyncReranker(BaseReranker):
+    """Async reranker with fixed output."""
+
+    results: list[RerankResult]
+
+    def rerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
+        return self.results[:top_k] if top_k is not None else self.results
+
+    async def arerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
+        return self.rerank(query, documents, top_k)
+
+
+def _mock_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.content = content
+    response.usage_metadata = {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
+    return response
+
+
+def _build_unit_pipeline(llm: Any, retrieval_pipeline: Any, service: Any, **kwargs: Any) -> DynamicRAGPipeline:
+    with patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None):
+        pipeline = DynamicRAGPipeline(
+            session_factory=MagicMock(),
+            name="dynamic_rag_unit",
+            llm=llm,
+            retrieval_pipeline=retrieval_pipeline,
+            **kwargs,
+        )
+    pipeline._llm = llm
+    pipeline._retrieval_pipeline = retrieval_pipeline
+    pipeline._service = service
+    pipeline.pipeline_id = 1
+    return pipeline
+
+
+class TestDynamicRAGPipelineConfig:
+    """Tests for DynamicRAGPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        config = DynamicRAGPipelineConfig(
+            name="dynamic_rag",
+            llm=FakeListLLM(responses=["answer"]),
+            retrieval_pipeline_name="bm25",
+        )
+
+        assert config.get_pipeline_class() == DynamicRAGPipeline
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        config = DynamicRAGPipelineConfig(
+            name="dynamic_rag",
+            llm=FakeListLLM(responses=["answer"]),
+            retrieval_pipeline_name="bm25",
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        retrieval_pipeline = create_mock_retrieval_pipeline(pipeline_id=55)
+        llm = FakeListLLM(responses=["answer"])
+        reranker = FixedAsyncReranker(results=[])
+        config = DynamicRAGPipelineConfig(
+            name="dynamic_rag",
+            llm=llm,
+            retrieval_pipeline_name="bm25",
+            reranker=reranker,
+            candidate_top_k=30,
+        )
+
+        config.inject_retrieval_pipeline(retrieval_pipeline)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["llm"] is llm
+        assert kwargs["retrieval_pipeline"] is retrieval_pipeline
+        assert kwargs["reranker"] is reranker
+        assert kwargs["candidate_top_k"] == 30
+
+
+class TestDynamicRAGPipeline:
+    """Tests for DynamicRAG generation behavior."""
+
+    def test_initialization_rejects_invalid_candidate_top_k(self):
+        with (
+            patch("autorag_research.pipelines.generation.base.BaseGenerationPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="candidate_top_k must be >= 1"),
+        ):
+            DynamicRAGPipeline(
+                session_factory=MagicMock(),
+                name="invalid_dynamic_rag",
+                llm=FakeListLLM(responses=["answer"]),
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                candidate_top_k=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_retrieves_dynamic_reranks_and_answers(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(return_value=_mock_response("final answer"))
+        retrieval_pipeline = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 1, "score": 0.7, "content": "first"},
+                {"doc_id": 2, "score": 0.6, "content": "second"},
+            ]
+        )
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        reranker = FixedAsyncReranker(results=[RerankResult(index=1, text="second", score=0.95)])
+        pipeline = _build_unit_pipeline(
+            llm,
+            retrieval_pipeline,
+            service,
+            reranker=reranker,
+            candidate_top_k=5,
+        )
+
+        result = await pipeline._generate(1, top_k=2)
+
+        retrieval_pipeline._retrieve_by_id.assert_awaited_once_with(1, 5)
+        assert "second" in llm.ainvoke.await_args.args[0]
+        assert result.text == "final answer"
+        assert result.metadata["candidate_chunk_ids"] == [1, 2]
+        assert result.metadata["selected_chunk_ids"] == [2]
+        assert result.metadata["selected_scores"] == [0.95]
+        assert result.metadata["effective_top_k"] == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_backfills_missing_contents(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(return_value=_mock_response("answer"))
+        retrieval_pipeline = create_mock_retrieval_pipeline(default_results=[{"doc_id": 5, "score": 0.7}])
+        service = MagicMock()
+        service.get_query_text.return_value = "Question?"
+        service.get_chunk_contents.return_value = ["Fetched content."]
+        reranker = FixedAsyncReranker(results=[RerankResult(index=0, text="Fetched content.", score=0.8)])
+        pipeline = _build_unit_pipeline(llm, retrieval_pipeline, service, reranker=reranker, candidate_top_k=1)
+
+        result = await pipeline._generate(1, top_k=1)
+
+        service.get_chunk_contents.assert_called_once_with([5])
+        assert result.metadata["selected_chunk_ids"] == [5]

--- a/tests/autorag_research/rerankers/test_dynamic_rag.py
+++ b/tests/autorag_research/rerankers/test_dynamic_rag.py
@@ -1,0 +1,51 @@
+"""Tests for DynamicRAG reranker."""
+
+from autorag_research.rerankers.base import BaseReranker, RerankResult
+from autorag_research.rerankers.dynamic_rag import DynamicRAGReranker
+
+
+class FixedReranker(BaseReranker):
+    """Fixed-score reranker for tests."""
+
+    scores: list[float]
+
+    def rerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
+        results = [RerankResult(index=index, text=document, score=self.scores[index]) for index, document in enumerate(documents)]
+        results.sort(key=lambda result: result.score, reverse=True)
+        return results[:top_k] if top_k is not None else results
+
+    async def arerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
+        return self.rerank(query, documents, top_k)
+
+
+def test_dynamic_rag_reranker_cuts_on_score_drop():
+    reranker = DynamicRAGReranker(
+        base_reranker=FixedReranker(scores=[0.95, 0.9, 0.4, 0.39]),
+        min_top_k=2,
+        score_drop_threshold=0.25,
+    )
+
+    results = reranker.rerank("query", ["a", "b", "c", "d"], top_k=4)
+
+    assert [result.text for result in results] == ["a", "b"]
+
+
+def test_dynamic_rag_reranker_respects_min_top_k():
+    reranker = DynamicRAGReranker(
+        base_reranker=FixedReranker(scores=[0.9, 0.1, 0.0]),
+        min_top_k=2,
+        score_drop_threshold=0.2,
+        min_score=0.2,
+    )
+
+    results = reranker.rerank("query", ["a", "b", "c"], top_k=3)
+
+    assert [result.text for result in results] == ["a", "b"]
+
+
+def test_dynamic_rag_reranker_fallback_preserves_order_scores():
+    reranker = DynamicRAGReranker(min_top_k=1, score_drop_threshold=None, max_top_k=2)
+
+    results = reranker.rerank("query", ["a", "b", "c"], top_k=3)
+
+    assert [(result.index, result.text, result.score) for result in results] == [(0, "a", 3.0), (1, "b", 2.0)]

--- a/tests/autorag_research/rerankers/test_dynamic_rag.py
+++ b/tests/autorag_research/rerankers/test_dynamic_rag.py
@@ -1,5 +1,9 @@
 """Tests for DynamicRAG reranker."""
 
+from pathlib import Path
+
+import yaml
+
 from autorag_research.rerankers.base import BaseReranker, RerankResult
 from autorag_research.rerankers.dynamic_rag import DynamicRAGReranker
 
@@ -10,7 +14,10 @@ class FixedReranker(BaseReranker):
     scores: list[float]
 
     def rerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
-        results = [RerankResult(index=index, text=document, score=self.scores[index]) for index, document in enumerate(documents)]
+        results = [
+            RerankResult(index=index, text=document, score=self.scores[index])
+            for index, document in enumerate(documents)
+        ]
         results.sort(key=lambda result: result.score, reverse=True)
         return results[:top_k] if top_k is not None else results
 
@@ -49,3 +56,29 @@ def test_dynamic_rag_reranker_fallback_preserves_order_scores():
     results = reranker.rerank("query", ["a", "b", "c"], top_k=3)
 
     assert [(result.index, result.text, result.score) for result in results] == [(0, "a", 3.0), (1, "b", 2.0)]
+
+
+def test_dynamic_rag_default_config_keeps_requested_fallback_pool():
+    config = yaml.safe_load(Path("configs/reranker/dynamic_rag.yaml").read_text())
+    reranker = DynamicRAGReranker(
+        min_top_k=config["min_top_k"],
+        max_top_k=config["max_top_k"],
+        score_drop_threshold=config["score_drop_threshold"],
+        min_score=config["min_score"],
+    )
+
+    documents = [f"doc-{index}" for index in range(20)]
+    results = reranker.rerank("query", documents, top_k=8)
+
+    assert len(results) == 8
+    assert [result.index for result in results] == list(range(8))
+
+
+def test_dynamic_rag_fallback_ignores_score_drop_policy_without_base_reranker():
+    reranker = DynamicRAGReranker(min_top_k=1, max_top_k=8, score_drop_threshold=0.25)
+
+    documents = [f"doc-{index}" for index in range(20)]
+    results = reranker.rerank("query", documents, top_k=8)
+
+    assert len(results) == 8
+    assert [result.index for result in results] == list(range(8))


### PR DESCRIPTION
## Summary
- Adds a DynamicRAG reranker that wraps an optional base reranker and applies variable top-k truncation using min keep, max keep, score drop, and min-score policies.
- Adds a DynamicRAG generation pipeline that retrieves a candidate pool, dynamically reranks/cuts evidence, and generates from the selected context.
- Adds reranker and generation YAML configs, exports, and focused tests.

## Scope
- Implements the DynamicRAG inference/evaluation integration suitable for AutoRAG-Research.
- Does not reproduce original DynamicRAG behavior-cloning/RL training with generator feedback.

## Validation
- uv run pytest tests/autorag_research/rerankers/test_dynamic_rag.py tests/autorag_research/pipelines/generation/test_dynamic_rag_pipeline.py -q
- make check

Closes #176

<!-- dani:stage=implementation;job=4d7aea0c90aa07afa15fdabc53ab3e0f;issue=176 -->
