### PR TITLE
Feature/#240

### DIFF
--- a/autorag_research/cli/commands/ingest.py
+++ b/autorag_research/cli/commands/ingest.py
@@ -15,6 +15,7 @@ Examples:
 """
 
 import logging
+import re
 from typing import TYPE_CHECKING, Annotated, Literal
 
 import typer
@@ -102,6 +103,11 @@ def _convert_param_value(value: str, param_meta) -> str | int | bool | list[str]
     return value
 
 
+def _sanitize_db_name_part(value: str) -> str:
+    """Normalize one generated database/schema-name part."""
+    return re.sub(r"[^a-z0-9_]+", "_", value.lower()).strip("_")
+
+
 def generate_db_name(ingestor_name: str, params: dict, subset: str, embedding_model: str) -> str:
     """Generate database schema name from ingestor parameters.
 
@@ -109,19 +115,19 @@ def generate_db_name(ingestor_name: str, params: dict, subset: str, embedding_mo
         beir + dataset_name=scifact + test + bge-small -> beir_scifact_test_bge_small
         ragbench + configs=[covidqa, msmarco] + test + openai -> ragbench_covidqa_msmarco_test_openai
     """
-    parts = [ingestor_name]
+    parts = [_sanitize_db_name_part(ingestor_name)]
 
     # Include all parameter values
     for _param_name, param_value in params.items():
         if param_value is None:
             continue
         if isinstance(param_value, list):
-            parts.extend([v.lower().replace("-", "_") for v in param_value])
+            parts.extend([_sanitize_db_name_part(v) for v in param_value])
         elif isinstance(param_value, str):
-            parts.append(param_value.lower().replace("-", "_"))
+            parts.append(_sanitize_db_name_part(param_value))
 
-    parts.append(subset)
-    parts.append(embedding_model.lower().replace("-", "_"))
+    parts.append(_sanitize_db_name_part(subset))
+    parts.append(_sanitize_db_name_part(embedding_model))
     return "_".join(parts)
 
 

--- a/autorag_research/cli/commands/ingest.py
+++ b/autorag_research/cli/commands/ingest.py
@@ -220,7 +220,7 @@ def ingest(  # noqa: C901
             init_kwargs[param.name] = param.default
 
     # Generate db_name from all parameters
-    final_db_name = db_name or generate_db_name(name, init_kwargs, subset, embedding_model)
+    final_db_name = db_name or generate_db_name(meta.name, init_kwargs, subset, embedding_model)
 
     # Load DB config from YAML first, then override with CLI options
     db_conn = DBConnection.from_config()

--- a/autorag_research/data/hf_storage.py
+++ b/autorag_research/data/hf_storage.py
@@ -26,10 +26,10 @@ def get_repo_id(ingestor: str) -> str:
     Raises:
         KeyError: If ingestor is not recognized or has no HF repo configured
     """
-    from autorag_research.data.registry import discover_ingestors
+    from autorag_research.data.registry import discover_ingestors, get_ingestor
 
     registry = discover_ingestors()
-    meta = registry.get(ingestor)
+    meta = get_ingestor(ingestor)
     if meta is None or meta.hf_repo is None:
         available = sorted(name for name, m in registry.items() if m.hf_repo is not None)
         raise KeyError(f"Unknown ingestor or no HF repo configured: '{ingestor}'. Available: {', '.join(available)}")  # noqa: TRY003

--- a/autorag_research/data/mrtydi.py
+++ b/autorag_research/data/mrtydi.py
@@ -33,6 +33,16 @@ MRTYDI_CORPUS_BASE_URL = "https://huggingface.co/datasets/castorini/mr-tydi-corp
 
 
 @register_ingestor(
+    name="mr.tydi",
+    description="Mr. TyDi multilingual retrieval benchmark (alias for mrtydi)",
+    hf_repo="mrtydi-dumps",
+)
+@register_ingestor(
+    name="mr-tydi",
+    description="Mr. TyDi multilingual retrieval benchmark (alias for mrtydi)",
+    hf_repo="mrtydi-dumps",
+)
+@register_ingestor(
     name="mrtydi",
     description="Mr. TyDi multilingual retrieval benchmark",
     hf_repo="mrtydi-dumps",

--- a/autorag_research/data/mrtydi.py
+++ b/autorag_research/data/mrtydi.py
@@ -33,19 +33,10 @@ MRTYDI_CORPUS_BASE_URL = "https://huggingface.co/datasets/castorini/mr-tydi-corp
 
 
 @register_ingestor(
-    name="mr.tydi",
-    description="Mr. TyDi multilingual retrieval benchmark (alias for mrtydi)",
-    hf_repo="mrtydi-dumps",
-)
-@register_ingestor(
-    name="mr-tydi",
-    description="Mr. TyDi multilingual retrieval benchmark (alias for mrtydi)",
-    hf_repo="mrtydi-dumps",
-)
-@register_ingestor(
     name="mrtydi",
     description="Mr. TyDi multilingual retrieval benchmark",
     hf_repo="mrtydi-dumps",
+    aliases=("mr-tydi", "mr.tydi"),
 )
 class MrTyDiIngestor(TextEmbeddingDataIngestor):
     """Ingestor for Mr. TyDi multilingual retrieval benchmark dataset.

--- a/autorag_research/data/registry.py
+++ b/autorag_research/data/registry.py
@@ -58,10 +58,12 @@ class IngestorMeta:
     description: str
     params: list[ParamMeta] = field(default_factory=list)
     hf_repo: str | None = None  # HuggingFace Hub repository name suffix (e.g., "beir-dumps")
+    aliases: tuple[str, ...] = ()
 
 
 # Global registry (populated by @register_ingestor decorators at import time)
 _INGESTOR_REGISTRY: dict[str, IngestorMeta] = {}
+_INGESTOR_ALIASES: dict[str, str] = {}
 
 # Modules in autorag_research.data that are NOT ingestors (skip during auto-discovery)
 _NON_INGESTOR_MODULES = {"base", "registry", "restore", "util", "hf_storage"}
@@ -71,6 +73,7 @@ def register_ingestor(
     name: str,
     description: str = "",
     hf_repo: str | None = None,
+    aliases: tuple[str, ...] = (),
 ):
     """Decorator to register an ingestor class.
 
@@ -81,6 +84,7 @@ def register_ingestor(
         name: CLI command name (e.g., "beir")
         description: Help text for CLI
         hf_repo: HuggingFace Hub repository name suffix (e.g., "beir-dumps")
+        aliases: Alternate lookup names that resolve to this canonical ingestor
 
     Example:
         @register_ingestor(name="beir", description="BEIR benchmark")
@@ -102,7 +106,10 @@ def register_ingestor(
             description=description,
             params=params,
             hf_repo=hf_repo,
+            aliases=aliases,
         )
+        for alias in aliases:
+            _INGESTOR_ALIASES[alias] = name
         return cls
 
     return decorator
@@ -213,7 +220,8 @@ def _is_list_type(hint) -> bool:
 def get_ingestor(name: str) -> IngestorMeta | None:
     """Get ingestor metadata by name."""
     ingestor_registry = discover_ingestors()
-    return ingestor_registry.get(name)
+    canonical_name = _INGESTOR_ALIASES.get(name, name)
+    return ingestor_registry.get(canonical_name)
 
 
 @lru_cache(maxsize=1)

--- a/tests/autorag_research/cli/commands/test_ingest.py
+++ b/tests/autorag_research/cli/commands/test_ingest.py
@@ -215,18 +215,18 @@ class TestGenerateDbName:
         assert "-" not in result
         assert "_" in result
 
-    def test_preserves_case_from_params(self) -> None:
-        """Preserves case from parameter values (lowercase recommended by convention)."""
+    def test_lowercases_params_for_safe_db_names(self) -> None:
+        """Lowercases parameter values while generating safe DB names."""
         result = generate_db_name(
             ingestor_name="beir",
-            params={"dataset_name": "scifact"},
+            params={"dataset_name": "SciFact"},
             subset="test",
             embedding_model="bge-small",
         )
 
-        # Function preserves case; users should provide lowercase
         assert "beir" in result
         assert "scifact" in result
+        assert "SciFact" not in result
 
     def test_list_params_joined(self) -> None:
         """List parameters are joined."""

--- a/tests/autorag_research/cli/commands/test_ingest.py
+++ b/tests/autorag_research/cli/commands/test_ingest.py
@@ -264,10 +264,11 @@ class TestGenerateDbName:
         parts = result.split("_")
         assert len(parts) >= 3
 
-    def test_sanitizes_ingestor_name_with_common_dataset_punctuation(self) -> None:
+    @pytest.mark.parametrize("ingestor_name", ["mr.tydi", "mr-tydi"])
+    def test_sanitizes_ingestor_name_with_common_dataset_punctuation(self, ingestor_name: str) -> None:
         """Generated DB names are safe for aliases such as mr.tydi and mr-tydi."""
         result = generate_db_name(
-            ingestor_name="mr.tydi",
+            ingestor_name=ingestor_name,
             params={"language": "english"},
             subset="test",
             embedding_model="openai-small",

--- a/tests/autorag_research/cli/commands/test_ingest.py
+++ b/tests/autorag_research/cli/commands/test_ingest.py
@@ -263,3 +263,16 @@ class TestGenerateDbName:
         # Should have underscores separating parts
         parts = result.split("_")
         assert len(parts) >= 3
+
+    def test_sanitizes_ingestor_name_with_common_dataset_punctuation(self) -> None:
+        """Generated DB names are safe for aliases such as mr.tydi and mr-tydi."""
+        result = generate_db_name(
+            ingestor_name="mr.tydi",
+            params={"language": "english"},
+            subset="test",
+            embedding_model="openai-small",
+        )
+
+        assert result == "mr_tydi_english_test_openai_small"
+        assert "." not in result
+        assert "-" not in result

--- a/tests/autorag_research/cli/commands/test_ingest.py
+++ b/tests/autorag_research/cli/commands/test_ingest.py
@@ -11,7 +11,7 @@ from autorag_research.cli.commands.ingest import (
     _validate_required_params,
     generate_db_name,
 )
-from autorag_research.data.registry import IngestorMeta, ParamMeta, discover_ingestors
+from autorag_research.data.registry import IngestorMeta, ParamMeta, discover_ingestors, get_ingestor
 
 
 @pytest.fixture
@@ -266,7 +266,7 @@ class TestGenerateDbName:
 
     @pytest.mark.parametrize("ingestor_name", ["mr.tydi", "mr-tydi"])
     def test_sanitizes_ingestor_name_with_common_dataset_punctuation(self, ingestor_name: str) -> None:
-        """Generated DB names are safe for aliases such as mr.tydi and mr-tydi."""
+        """Generated DB names are safe for raw aliases such as mr.tydi and mr-tydi."""
         result = generate_db_name(
             ingestor_name=ingestor_name,
             params={"language": "english"},
@@ -277,3 +277,18 @@ class TestGenerateDbName:
         assert result == "mr_tydi_english_test_openai_small"
         assert "." not in result
         assert "-" not in result
+
+    @pytest.mark.parametrize("alias", ["mr.tydi", "mr-tydi"])
+    def test_alias_resolution_uses_canonical_mrtydi_name_for_default_db_name(self, alias: str) -> None:
+        """CLI default DB names should use canonical metadata after resolving aliases."""
+        meta = get_ingestor(alias)
+
+        assert meta is not None
+        result = generate_db_name(
+            ingestor_name=meta.name,
+            params={"language": "english"},
+            subset="test",
+            embedding_model="openai-small",
+        )
+
+        assert result == "mrtydi_english_test_openai_small"

--- a/tests/autorag_research/data/test_hf_storage.py
+++ b/tests/autorag_research/data/test_hf_storage.py
@@ -25,6 +25,12 @@ class TestGetRepoId:
         result = get_repo_id("beir")
         assert result == f"{HF_ORG}/beir-dumps"
 
+    @pytest.mark.parametrize("alias", ["mr-tydi", "mr.tydi"])
+    def test_get_repo_id_resolves_mrtydi_aliases(self, alias: str):
+        """Test that Mr. TyDi aliases resolve to the canonical dump repository."""
+        result = get_repo_id(alias)
+        assert result == f"{HF_ORG}/mrtydi-dumps"
+
     def test_get_repo_id_all_ingestors_with_hf_repo(self):
         """Test that all registered ingestors with hf_repo return valid repo IDs."""
         from autorag_research.data.registry import discover_ingestors

--- a/tests/autorag_research/data/test_registry.py
+++ b/tests/autorag_research/data/test_registry.py
@@ -101,6 +101,16 @@ class TestGetIngestor:
         result = get_ingestor("nonexistent_ingestor_xyz")
         assert result is None
 
+    def test_mrtydi_common_name_aliases_resolve(self):
+        """Mr. TyDi can be requested with common punctuation variants."""
+        canonical = get_ingestor("mrtydi")
+
+        assert canonical is not None
+        assert get_ingestor("mr-tydi") is not None
+        assert get_ingestor("mr.tydi") is not None
+        assert get_ingestor("mr-tydi").ingestor_class is canonical.ingestor_class  # ty: ignore[union-attr]
+        assert get_ingestor("mr.tydi").ingestor_class is canonical.ingestor_class  # ty: ignore[union-attr]
+
 
 class TestRegisterIngestor:
     """Tests for register_ingestor decorator."""

--- a/tests/autorag_research/data/test_registry.py
+++ b/tests/autorag_research/data/test_registry.py
@@ -104,12 +104,14 @@ class TestGetIngestor:
     def test_mrtydi_common_name_aliases_resolve(self):
         """Mr. TyDi can be requested with common punctuation variants."""
         canonical = get_ingestor("mrtydi")
+        hyphen_alias = get_ingestor("mr-tydi")
+        dot_alias = get_ingestor("mr.tydi")
 
         assert canonical is not None
-        assert get_ingestor("mr-tydi") is not None
-        assert get_ingestor("mr.tydi") is not None
-        assert get_ingestor("mr-tydi").ingestor_class is canonical.ingestor_class  # ty: ignore[union-attr]
-        assert get_ingestor("mr.tydi").ingestor_class is canonical.ingestor_class  # ty: ignore[union-attr]
+        assert hyphen_alias is not None
+        assert dot_alias is not None
+        assert hyphen_alias.ingestor_class is canonical.ingestor_class
+        assert dot_alias.ingestor_class is canonical.ingestor_class
 
 
 class TestRegisterIngestor:

--- a/tests/autorag_research/data/test_registry.py
+++ b/tests/autorag_research/data/test_registry.py
@@ -23,11 +23,6 @@ class TestAutoImportDataModules:
 
     def test_auto_import_discovers_modules(self):
         """Auto-import should discover and import modules in autorag_research.data."""
-        # Reset discovery state to force re-discovery
-        import autorag_research.data.registry as registry_module
-
-        registry_module._discovery_done = False
-        registry_module._INGESTOR_REGISTRY.clear()
         discover_ingestors.cache_clear()  # Clear lru_cache to avoid stale cached results
 
         # Run auto-import
@@ -92,6 +87,14 @@ class TestDiscoverIngestors:
         for name, meta in result.items():
             assert isinstance(meta, IngestorMeta), f"Value for '{name}' is not IngestorMeta"
 
+    def test_discover_ingestors_lists_only_canonical_mrtydi_entry(self):
+        """Mr. TyDi aliases should not enumerate as independent ingestors."""
+        result = discover_ingestors()
+
+        assert "mrtydi" in result
+        assert "mr-tydi" not in result
+        assert "mr.tydi" not in result
+
 
 class TestGetIngestor:
     """Tests for get_ingestor function."""
@@ -110,8 +113,12 @@ class TestGetIngestor:
         assert canonical is not None
         assert hyphen_alias is not None
         assert dot_alias is not None
+        assert canonical.name == "mrtydi"
+        assert hyphen_alias.name == canonical.name
+        assert dot_alias.name == canonical.name
         assert hyphen_alias.ingestor_class is canonical.ingestor_class
         assert dot_alias.ingestor_class is canonical.ingestor_class
+        assert set(canonical.aliases) == {"mr-tydi", "mr.tydi"}
 
 
 class TestRegisterIngestor:
@@ -171,6 +178,22 @@ class TestRegisterIngestor:
         assert meta.hf_repo == "test-dumps"
         # Cleanup
         del registry_module._INGESTOR_REGISTRY["test_ingestor_hf"]
+
+    def test_register_ingestor_with_aliases(self):
+        """register_ingestor should store aliases as lookup-only names."""
+        import autorag_research.data.registry as registry_module
+
+        @register_ingestor(name="test_ingestor_alias", description="Test", aliases=("test-ingestor-alias",))
+        class TestIngestor:
+            pass
+
+        meta = registry_module._INGESTOR_REGISTRY["test_ingestor_alias"]
+        assert meta.aliases == ("test-ingestor-alias",)
+        assert get_ingestor("test-ingestor-alias") is meta
+        assert "test-ingestor-alias" not in discover_ingestors()
+        # Cleanup
+        del registry_module._INGESTOR_REGISTRY["test_ingestor_alias"]
+        del registry_module._INGESTOR_ALIASES["test-ingestor-alias"]
 
 
 class TestExtractParamsFromInit:
@@ -265,6 +288,7 @@ class TestExtractChoices:
             BLUE = "blue"
 
         choices = _extract_choices(Color)
+        assert choices is not None
         assert set(choices) == {"red", "green", "blue"}
 
     def test_extract_choices_returns_none_for_basic_type(self):


### PR DESCRIPTION
<!-- dani:stage=implementation;job=2cb22de80bb1485f9e5183e15f177e67;issue=240 -->

## Summary
- model common Mr. TyDi public spellings (`mr-tydi`, `mr.tydi`) as lookup-only aliases for canonical `mrtydi` metadata
- keep alias names out of `discover_ingestors()` / default registry enumeration while preserving alias support for `get_ingestor(...)` and dump repository lookup
- reject registry alias collisions before mutation so aliases cannot shadow canonical ingestors, duplicate existing aliases, or later become shadowed by canonical names
- generate default CLI database names from resolved canonical metadata (`mrtydi_...`) while retaining raw DB-name sanitization coverage for punctuation aliases
- add regression coverage for canonical-only enumeration, alias metadata, alias collision behavior, alias DB-name behavior, Hugging Face repo alias lookup, DB-name sanitization, and existing Mr. TyDi primary-key support

## Verification
- `uv run pytest tests/autorag_research/data/test_registry.py::TestRegisterIngestor::test_register_ingestor_rejects_alias_that_matches_canonical_name tests/autorag_research/data/test_registry.py::TestRegisterIngestor::test_register_ingestor_rejects_duplicate_alias tests/autorag_research/data/test_registry.py::TestRegisterIngestor::test_register_ingestor_rejects_canonical_name_that_matches_alias -q` → 3 passed
- `uv run pytest tests/autorag_research/data/test_registry.py tests/autorag_research/cli/commands/test_ingest.py tests/autorag_research/data/test_hf_storage.py::TestGetRepoId tests/autorag_research/data/test_mrtydi.py::TestMrTyDiIngestorInit::test_detect_primary_key_type -q` → 77 passed
- runtime smoke check confirmed `mrtydi`, `mr-tydi`, and `mr.tydi` resolve to `MrTyDiIngestor`, punctuation aliases generate `mr_tydi_english_test_openai_small`, Hugging Face repo lookup returns `NomaDamas/mrtydi-dumps`, and all three alias collision classes are rejected
- `make check` → passed
- Ralph STANDARD architect verification: APPROVED, no must-fix items
- Ralph scoped deslop pass completed on changed files; post-deslop targeted tests and `make check` stayed green

## Notes
- `make test` could not run in this environment because the Docker daemon was unavailable (`Cannot connect to the Docker daemon at unix:///Users/jeffrey/.docker/run/docker.sock`).
- full external Mr. TyDi ingestion was not run locally because it requires Hugging Face downloads plus PostgreSQL integration resources.
