### PR TITLE
Feature/#86

### DIFF
--- a/autorag_research/pipelines/retrieval/__init__.py
+++ b/autorag_research/pipelines/retrieval/__init__.py
@@ -26,6 +26,10 @@ from autorag_research.pipelines.retrieval.question_decomposition import (
     QuestionDecompositionRetrievalPipeline,
     QuestionDecompositionRetrievalPipelineConfig,
 )
+from autorag_research.pipelines.retrieval.rerank import (
+    RerankRetrievalPipeline,
+    RerankRetrievalPipelineConfig,
+)
 from autorag_research.pipelines.retrieval.retro_star import (
     RetroStarPipelineConfig,
     RetroStarRetrievalPipeline,
@@ -53,6 +57,8 @@ __all__ = [
     "QueryRewriteRetrievalPipeline",
     "QuestionDecompositionRetrievalPipeline",
     "QuestionDecompositionRetrievalPipelineConfig",
+    "RerankRetrievalPipeline",
+    "RerankRetrievalPipelineConfig",
     "RetroStarPipelineConfig",
     "RetroStarRetrievalPipeline",
     "VectorSearchPipelineConfig",

--- a/autorag_research/pipelines/retrieval/base.py
+++ b/autorag_research/pipelines/retrieval/base.py
@@ -15,6 +15,15 @@ from autorag_research.pipelines.base import BasePipeline
 logger = logging.getLogger("AutoRAG-Research")
 
 
+def get_retrieval_pipeline_config(pipeline: object) -> dict[str, Any]:
+    """Return a retrieval pipeline config when the object exposes one."""
+    get_config = getattr(pipeline, "_get_pipeline_config", None)
+    if not callable(get_config):
+        return {}
+    config = get_config()
+    return config if isinstance(config, dict) else {}
+
+
 class BaseRetrievalPipeline(BasePipeline, ABC):
     """Abstract base class for all retrieval pipelines.
 

--- a/autorag_research/pipelines/retrieval/bm25.py
+++ b/autorag_research/pipelines/retrieval/bm25.py
@@ -132,6 +132,7 @@ class BM25RetrievalPipeline(BaseRetrievalPipeline):
         """Return BM25 pipeline configuration."""
         return {
             "type": "bm25",
+            "retrieval_unit": "chunk",
             "tokenizer": self.tokenizer,
             "index_name": self.index_name,
         }

--- a/autorag_research/pipelines/retrieval/hybrid.py
+++ b/autorag_research/pipelines/retrieval/hybrid.py
@@ -14,7 +14,7 @@ from typing import Any, Literal
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
 from autorag_research.pipelines.retrieval.loader import RetrievalPipelineLoader
 from autorag_research.util import (
     normalize_dbsf,
@@ -358,6 +358,16 @@ class HybridRetrievalPipeline(BaseRetrievalPipeline, ABC):
             name,
         )
 
+    def _get_combined_retrieval_unit(self) -> str | None:
+        """Return the shared retrieval unit when both wrapped pipelines declare the same one."""
+        config_1 = get_retrieval_pipeline_config(self._retrieval_pipeline_1)
+        config_2 = get_retrieval_pipeline_config(self._retrieval_pipeline_2)
+        retrieval_unit_1 = config_1.get("retrieval_unit")
+        retrieval_unit_2 = config_2.get("retrieval_unit")
+        if retrieval_unit_1 == retrieval_unit_2:
+            return retrieval_unit_1
+        return "mixed"
+
     @abstractmethod
     def _fuse_results(
         self,
@@ -495,6 +505,7 @@ class HybridRRFRetrievalPipeline(HybridRetrievalPipeline):
         """Return Hybrid RRF pipeline configuration."""
         return {
             "type": "hybrid_rrf",
+            "retrieval_unit": self._get_combined_retrieval_unit(),
             "retrieval_pipeline_1": self._retrieval_pipeline_1.name,
             "retrieval_pipeline_2": self._retrieval_pipeline_2.name,
             "rrf_k": self.rrf_k,
@@ -588,6 +599,7 @@ class HybridCCRetrievalPipeline(HybridRetrievalPipeline):
         """Return Hybrid CC pipeline configuration."""
         config = {
             "type": "hybrid_cc",
+            "retrieval_unit": self._get_combined_retrieval_unit(),
             "retrieval_pipeline_1": self._retrieval_pipeline_1.name,
             "retrieval_pipeline_2": self._retrieval_pipeline_2.name,
             "weight": self.weight,

--- a/autorag_research/pipelines/retrieval/hyde.py
+++ b/autorag_research/pipelines/retrieval/hyde.py
@@ -159,6 +159,7 @@ class HyDERetrievalPipeline(BaseRetrievalPipeline):
         """
         return {
             "type": "hyde",
+            "retrieval_unit": "chunk",
             "prompt_template": self.prompt_template,
         }
 

--- a/autorag_research/pipelines/retrieval/power_of_noise.py
+++ b/autorag_research/pipelines/retrieval/power_of_noise.py
@@ -15,7 +15,7 @@ from typing import Any, Literal, cast
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
 from autorag_research.pipelines.retrieval.hybrid import HybridRetrievalPipeline
 
 NoiseOrder = Literal["retrieved_first", "noise_first", "interleave"]
@@ -99,8 +99,10 @@ class PowerOfNoiseRetrievalPipeline(BaseRetrievalPipeline):
 
     def _get_pipeline_config(self) -> dict[str, Any]:
         """Return pipeline configuration for persistence."""
+        wrapped_config = get_retrieval_pipeline_config(self._base_retrieval_pipeline)
         return {
             "type": "power_of_noise",
+            "retrieval_unit": wrapped_config.get("retrieval_unit"),
             "base_retrieval_pipeline": self._base_retrieval_pipeline.name,
             "noise_count": self.noise_count,
             "noise_ratio": self.noise_ratio,

--- a/autorag_research/pipelines/retrieval/query_rewrite.py
+++ b/autorag_research/pipelines/retrieval/query_rewrite.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.injection import health_check_llm
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
 
 logger = logging.getLogger("AutoRAG-Research")
 
@@ -97,9 +97,11 @@ class QueryRewriteRetrievalPipeline(BaseRetrievalPipeline):
         model_name = getattr(self.llm, "model_name", None)
         if model_name is None or not isinstance(model_name, str):
             model_name = type(self.llm).__name__
+        wrapped_config = get_retrieval_pipeline_config(self._retrieval_pipeline)
 
         return {
             "type": "query_rewrite",
+            "retrieval_unit": wrapped_config.get("retrieval_unit"),
             "prompt_template": self.prompt_template,
             "retrieval_pipeline_id": getattr(self._retrieval_pipeline, "pipeline_id", None),
             "wrapped_pipeline_type": type(self._retrieval_pipeline).__name__,

--- a/autorag_research/pipelines/retrieval/question_decomposition.py
+++ b/autorag_research/pipelines/retrieval/question_decomposition.py
@@ -8,7 +8,7 @@ from langchain_core.language_models import BaseLanguageModel
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
 from autorag_research.rerankers.base import BaseReranker
 
 DEFAULT_DECOMPOSITION_PROMPT = """You are decomposing a question for retrieval-augmented generation.
@@ -101,8 +101,10 @@ class QuestionDecompositionRetrievalPipeline(BaseRetrievalPipeline):
         super().__init__(session_factory, name, schema)
 
     def _get_pipeline_config(self) -> dict[str, Any]:
+        wrapped_config = get_retrieval_pipeline_config(self._inner_retrieval_pipeline)
         return {
             "type": "question_decomposition",
+            "retrieval_unit": wrapped_config.get("retrieval_unit"),
             "max_subquestions": self.max_subquestions,
             "fetch_k_multiplier": self.fetch_k_multiplier,
             "decomposition_prompt_template": self._decomposition_prompt_template,

--- a/autorag_research/pipelines/retrieval/rerank.py
+++ b/autorag_research/pipelines/retrieval/rerank.py
@@ -1,9 +1,9 @@
-"""Retriever-reranker retrieval pipeline for AutoRAG-Research.
+"""Text retriever-reranker retrieval pipeline for AutoRAG-Research.
 
-This pipeline wraps any existing retrieval pipeline, fetches a larger candidate
-set, and reranks those candidate texts with a configured reranker. It keeps the
-standard retrieval pipeline interface so generation pipelines can compose with
-it by referencing the configured pipeline name.
+This pipeline wraps an existing text chunk retrieval pipeline, fetches a larger
+candidate set, and reranks those candidate texts with a configured reranker. It
+keeps the standard retrieval pipeline interface so generation pipelines can
+compose with it by referencing the configured pipeline name.
 """
 
 from __future__ import annotations
@@ -18,10 +18,35 @@ from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
 from autorag_research.rerankers.base import BaseReranker, RerankResult
 
+TEXT_RETRIEVAL_UNIT = "chunk"
+
+
+def _get_wrapped_pipeline_config(pipeline: BaseRetrievalPipeline) -> dict[str, Any]:
+    """Return the wrapped pipeline config when it is available as a dict."""
+    get_config = getattr(pipeline, "_get_pipeline_config", None)
+    if not callable(get_config):
+        return {}
+
+    config = get_config()
+    return config if isinstance(config, dict) else {}
+
+
+def _validate_text_retrieval_pipeline(pipeline: BaseRetrievalPipeline) -> None:
+    """Reject wrapped pipelines whose persisted results are not text chunks."""
+    config = _get_wrapped_pipeline_config(pipeline)
+    retrieval_unit = config.get("retrieval_unit", TEXT_RETRIEVAL_UNIT)
+    if retrieval_unit != TEXT_RETRIEVAL_UNIT:
+        pipeline_type = config.get("type", type(pipeline).__name__)
+        msg = (
+            "RerankRetrievalPipeline only supports text chunk retrieval pipelines "
+            f"(retrieval_unit='chunk'); got retrieval_unit={retrieval_unit!r} from {pipeline_type!r}."
+        )
+        raise ValueError(msg)
+
 
 @dataclass(kw_only=True)
 class RerankRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
-    """Configuration for the retriever-reranker retrieval wrapper."""
+    """Configuration for the text chunk retriever-reranker retrieval wrapper."""
 
     retrieval_pipeline_name: str
     reranker: str | BaseReranker
@@ -37,7 +62,8 @@ class RerankRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
         super().__setattr__(name, value)
 
     def inject_retrieval_pipeline(self, pipeline: BaseRetrievalPipeline) -> None:
-        """Inject the wrapped retrieval pipeline instance."""
+        """Inject the wrapped text chunk retrieval pipeline instance."""
+        _validate_text_retrieval_pipeline(pipeline)
         self._retrieval_pipeline = pipeline
 
     def get_pipeline_class(self) -> type[RerankRetrievalPipeline]:
@@ -58,7 +84,7 @@ class RerankRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
 
 
 class RerankRetrievalPipeline(BaseRetrievalPipeline):
-    """Generic retriever → reranker retrieval wrapper."""
+    """Text chunk retriever → reranker retrieval wrapper."""
 
     def __init__(
         self,
@@ -74,7 +100,7 @@ class RerankRetrievalPipeline(BaseRetrievalPipeline):
         Args:
             session_factory: SQLAlchemy sessionmaker for database connections.
             name: Name for this pipeline.
-            retrieval_pipeline: Wrapped first-stage retrieval pipeline.
+            retrieval_pipeline: Wrapped first-stage text chunk retrieval pipeline.
             reranker: Reranker used to rescore candidate texts.
             candidate_top_k: Number of first-stage candidates to fetch before reranking.
             schema: Optional dynamic schema namespace.
@@ -82,6 +108,7 @@ class RerankRetrievalPipeline(BaseRetrievalPipeline):
         if candidate_top_k < 1:
             msg = "candidate_top_k must be >= 1"
             raise ValueError(msg)
+        _validate_text_retrieval_pipeline(retrieval_pipeline)
 
         self._retrieval_pipeline = retrieval_pipeline
         self.reranker = reranker
@@ -93,6 +120,7 @@ class RerankRetrievalPipeline(BaseRetrievalPipeline):
         """Return rerank pipeline configuration for storage."""
         return {
             "type": "rerank",
+            "retrieval_unit": TEXT_RETRIEVAL_UNIT,
             "candidate_top_k": self.candidate_top_k,
             "reranker_model": getattr(self.reranker, "model_name", type(self.reranker).__name__),
             "retrieval_pipeline_id": getattr(self._retrieval_pipeline, "pipeline_id", None),

--- a/autorag_research/pipelines/retrieval/rerank.py
+++ b/autorag_research/pipelines/retrieval/rerank.py
@@ -1,0 +1,179 @@
+"""Retriever-reranker retrieval pipeline for AutoRAG-Research.
+
+This pipeline wraps any existing retrieval pipeline, fetches a larger candidate
+set, and reranks those candidate texts with a configured reranker. It keeps the
+standard retrieval pipeline interface so generation pipelines can compose with
+it by referencing the configured pipeline name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.config import BaseRetrievalPipelineConfig
+from autorag_research.injection import health_check_reranker
+from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.rerankers.base import BaseReranker, RerankResult
+
+
+@dataclass(kw_only=True)
+class RerankRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
+    """Configuration for the retriever-reranker retrieval wrapper."""
+
+    retrieval_pipeline_name: str
+    reranker: str | BaseReranker
+    candidate_top_k: int = 50
+    _retrieval_pipeline: BaseRetrievalPipeline | None = field(default=None, repr=False)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Auto-convert string reranker config names to reranker instances."""
+        if name == "reranker" and isinstance(value, str):
+            from autorag_research.injection import load_reranker
+
+            value = load_reranker(value)
+            health_check_reranker(value)
+        super().__setattr__(name, value)
+
+    def inject_retrieval_pipeline(self, pipeline: BaseRetrievalPipeline) -> None:
+        """Inject the wrapped retrieval pipeline instance."""
+        self._retrieval_pipeline = pipeline
+
+    def get_pipeline_class(self) -> type[RerankRetrievalPipeline]:
+        """Return the RerankRetrievalPipeline class."""
+        return RerankRetrievalPipeline
+
+    def get_pipeline_kwargs(self) -> dict[str, Any]:
+        """Return kwargs for RerankRetrievalPipeline constructor."""
+        if self._retrieval_pipeline is None:
+            msg = f"Retrieval pipeline '{self.retrieval_pipeline_name}' not injected"
+            raise ValueError(msg)
+
+        return {
+            "retrieval_pipeline": self._retrieval_pipeline,
+            "reranker": self.reranker,
+            "candidate_top_k": self.candidate_top_k,
+        }
+
+
+class RerankRetrievalPipeline(BaseRetrievalPipeline):
+    """Generic retriever → reranker retrieval wrapper."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker[Session],
+        name: str,
+        retrieval_pipeline: BaseRetrievalPipeline,
+        reranker: BaseReranker,
+        candidate_top_k: int = 50,
+        schema: Any | None = None,
+    ):
+        """Initialize the rerank retrieval pipeline.
+
+        Args:
+            session_factory: SQLAlchemy sessionmaker for database connections.
+            name: Name for this pipeline.
+            retrieval_pipeline: Wrapped first-stage retrieval pipeline.
+            reranker: Reranker used to rescore candidate texts.
+            candidate_top_k: Number of first-stage candidates to fetch before reranking.
+            schema: Optional dynamic schema namespace.
+        """
+        if candidate_top_k < 1:
+            msg = "candidate_top_k must be >= 1"
+            raise ValueError(msg)
+
+        self._retrieval_pipeline = retrieval_pipeline
+        self.reranker = reranker
+        self.candidate_top_k = candidate_top_k
+
+        super().__init__(session_factory, name, schema)
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        """Return rerank pipeline configuration for storage."""
+        return {
+            "type": "rerank",
+            "candidate_top_k": self.candidate_top_k,
+            "reranker_model": getattr(self.reranker, "model_name", type(self.reranker).__name__),
+            "retrieval_pipeline_id": getattr(self._retrieval_pipeline, "pipeline_id", None),
+            "wrapped_pipeline_type": type(self._retrieval_pipeline).__name__,
+        }
+
+    def _ensure_candidate_contents(self, candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Backfill missing candidate contents from the chunk table."""
+        missing_ids = [candidate["doc_id"] for candidate in candidates if not candidate.get("content")]
+        if not missing_ids:
+            return candidates
+
+        with RetrievalUnitOfWork(self.session_factory, self._schema) as uow:
+            chunks = uow.chunks.get_by_ids(missing_ids)
+
+        contents_by_id = {chunk.id: chunk.contents for chunk in chunks}
+        enriched_candidates: list[dict[str, Any]] = []
+        for candidate in candidates:
+            enriched_candidate = dict(candidate)
+            if not enriched_candidate.get("content"):
+                enriched_candidate["content"] = contents_by_id.get(candidate["doc_id"], "")
+            enriched_candidates.append(enriched_candidate)
+
+        return enriched_candidates
+
+    @staticmethod
+    def _map_rerank_result(candidate: dict[str, Any], rerank_result: RerankResult) -> dict[str, Any]:
+        """Map one reranker result back to the standard retrieval result format."""
+        return {
+            "doc_id": candidate["doc_id"],
+            "score": float(rerank_result.score),
+            "content": rerank_result.text,
+        }
+
+    def _map_rerank_results(
+        self,
+        candidates: list[dict[str, Any]],
+        rerank_results: list[RerankResult],
+    ) -> list[dict[str, Any]]:
+        """Map reranker output indexes back to wrapped retrieval candidates."""
+        mapped_results: list[dict[str, Any]] = []
+        for rerank_result in rerank_results:
+            if rerank_result.index < 0 or rerank_result.index >= len(candidates):
+                msg = f"Reranker returned out-of-range candidate index: {rerank_result.index}"
+                raise ValueError(msg)
+            mapped_results.append(self._map_rerank_result(candidates[rerank_result.index], rerank_result))
+        return mapped_results
+
+    async def _rerank_candidates(
+        self,
+        query_text: str,
+        candidates: list[dict[str, Any]],
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        """Rerank candidate contents and return standard retrieval results."""
+        documents = [str(candidate.get("content") or "") for candidate in candidates]
+        rerank_results = await self.reranker.arerank(query_text, documents, top_k=top_k)
+        return self._map_rerank_results(candidates, rerank_results)
+
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        """Fetch query text by ID, then rerank wrapped retrieval candidates."""
+        query_texts = self._service.fetch_query_texts([query_id])
+        if not query_texts:
+            return []
+
+        return await self._retrieve_by_text(query_texts[0], top_k)
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        """Retrieve first-stage candidates from the wrapped pipeline, then rerank them."""
+        candidate_top_k = max(top_k, self.candidate_top_k)
+        candidates = await self._retrieval_pipeline.retrieve(query_text, candidate_top_k)
+        if not candidates:
+            return []
+
+        enriched_candidates = self._ensure_candidate_contents(candidates)
+        return await self._rerank_candidates(query_text, enriched_candidates, top_k)
+
+
+__all__ = [
+    "RerankRetrievalPipeline",
+    "RerankRetrievalPipelineConfig",
+]

--- a/autorag_research/pipelines/retrieval/rerank.py
+++ b/autorag_research/pipelines/retrieval/rerank.py
@@ -15,28 +15,24 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
 from autorag_research.rerankers.base import BaseReranker, RerankResult
 
 TEXT_RETRIEVAL_UNIT = "chunk"
 
 
-def _get_wrapped_pipeline_config(pipeline: BaseRetrievalPipeline) -> dict[str, Any]:
-    """Return the wrapped pipeline config when it is available as a dict."""
-    get_config = getattr(pipeline, "_get_pipeline_config", None)
-    if not callable(get_config):
-        return {}
-
-    config = get_config()
-    return config if isinstance(config, dict) else {}
-
-
 def _validate_text_retrieval_pipeline(pipeline: BaseRetrievalPipeline) -> None:
     """Reject wrapped pipelines whose persisted results are not text chunks."""
-    config = _get_wrapped_pipeline_config(pipeline)
-    retrieval_unit = config.get("retrieval_unit", TEXT_RETRIEVAL_UNIT)
+    config = get_retrieval_pipeline_config(pipeline)
+    retrieval_unit = config.get("retrieval_unit")
+    pipeline_type = config.get("type", type(pipeline).__name__)
+    if retrieval_unit is None:
+        msg = (
+            "RerankRetrievalPipeline only supports text chunk retrieval pipelines; "
+            f"wrapped pipeline {pipeline_type!r} must declare retrieval_unit='chunk'."
+        )
+        raise ValueError(msg)
     if retrieval_unit != TEXT_RETRIEVAL_UNIT:
-        pipeline_type = config.get("type", type(pipeline).__name__)
         msg = (
             "RerankRetrievalPipeline only supports text chunk retrieval pipelines "
             f"(retrieval_unit='chunk'); got retrieval_unit={retrieval_unit!r} from {pipeline_type!r}."

--- a/autorag_research/pipelines/retrieval/rerank.py
+++ b/autorag_research/pipelines/retrieval/rerank.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
-from autorag_research.injection import health_check_reranker
 from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
 from autorag_research.rerankers.base import BaseReranker, RerankResult
@@ -35,7 +34,6 @@ class RerankRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
             from autorag_research.injection import load_reranker
 
             value = load_reranker(value)
-            health_check_reranker(value)
         super().__setattr__(name, value)
 
     def inject_retrieval_pipeline(self, pipeline: BaseRetrievalPipeline) -> None:
@@ -111,11 +109,17 @@ class RerankRetrievalPipeline(BaseRetrievalPipeline):
             chunks = uow.chunks.get_by_ids(missing_ids)
 
         contents_by_id = {chunk.id: chunk.contents for chunk in chunks}
+        unresolved_ids = sorted({doc_id for doc_id in missing_ids if doc_id not in contents_by_id}, key=str)
+        if unresolved_ids:
+            missing_ids_text = ", ".join(str(doc_id) for doc_id in unresolved_ids)
+            msg = f"Missing chunk content for candidate doc_ids: {missing_ids_text}"
+            raise ValueError(msg)
+
         enriched_candidates: list[dict[str, Any]] = []
         for candidate in candidates:
             enriched_candidate = dict(candidate)
             if not enriched_candidate.get("content"):
-                enriched_candidate["content"] = contents_by_id.get(candidate["doc_id"], "")
+                enriched_candidate["content"] = contents_by_id[candidate["doc_id"]]
             enriched_candidates.append(enriched_candidate)
 
         return enriched_candidates

--- a/autorag_research/pipelines/retrieval/retro_star.py
+++ b/autorag_research/pipelines/retrieval/retro_star.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.injection import health_check_llm
 from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
 from autorag_research.util import truncate_texts
 
 DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION = (
@@ -236,9 +236,11 @@ class RetroStarRetrievalPipeline(BaseRetrievalPipeline):
         model_name = getattr(self.llm, "model_name", None)
         if model_name is None or not isinstance(model_name, str):
             model_name = type(self.llm).__name__
+        wrapped_config = get_retrieval_pipeline_config(self._retrieval_pipeline)
 
         return {
             "type": "retro_star",
+            "retrieval_unit": wrapped_config.get("retrieval_unit"),
             "candidate_top_k": self.candidate_top_k,
             "prompt_template": self.prompt_template,
             "relevance_definition": self.relevance_definition,

--- a/autorag_research/pipelines/retrieval/vector_search.py
+++ b/autorag_research/pipelines/retrieval/vector_search.py
@@ -148,6 +148,7 @@ class VectorSearchRetrievalPipeline(BaseRetrievalPipeline):
         """
         return {
             "type": "vector_search",
+            "retrieval_unit": "chunk",
             "search_mode": self.search_mode,
         }
 

--- a/configs/pipelines/retrieval/rerank.yaml
+++ b/configs/pipelines/retrieval/rerank.yaml
@@ -1,5 +1,5 @@
 _target_: autorag_research.pipelines.retrieval.rerank.RerankRetrievalPipelineConfig
-description: "Retriever → Reranker wrapper retrieval pipeline"
+description: "Text chunk retriever → reranker wrapper retrieval pipeline"
 name: rerank
 retrieval_pipeline_name: bm25
 reranker: sentence_transformer

--- a/configs/pipelines/retrieval/rerank.yaml
+++ b/configs/pipelines/retrieval/rerank.yaml
@@ -1,0 +1,11 @@
+_target_: autorag_research.pipelines.retrieval.rerank.RerankRetrievalPipelineConfig
+description: "Retriever → Reranker wrapper retrieval pipeline"
+name: rerank
+retrieval_pipeline_name: bm25
+reranker: sentence_transformer
+candidate_top_k: 50
+top_k: 10
+batch_size: 128
+max_concurrency: 16
+max_retries: 3
+retry_delay: 1.0

--- a/tests/autorag_research/pipelines/pipeline_test_utils.py
+++ b/tests/autorag_research/pipelines/pipeline_test_utils.py
@@ -433,6 +433,7 @@ def create_mock_retrieval_pipeline(
     """
     mock = MagicMock()
     mock.pipeline_id = pipeline_id
+    mock._get_pipeline_config.return_value = {"type": "mock", "retrieval_unit": "chunk"}
 
     if default_results is not None:
         mock.retrieve = AsyncMock(return_value=default_results)

--- a/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
@@ -25,7 +25,7 @@ from tests.autorag_research.pipelines.pipeline_test_utils import (
 
 class _FakeLeafRetrievalPipeline(BaseRetrievalPipeline):
     def _get_pipeline_config(self) -> dict[str, Any]:
-        return {"type": "fake_leaf"}
+        return {"type": "fake_leaf", "retrieval_unit": "chunk"}
 
     async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
         return []
@@ -48,6 +48,7 @@ class _FakeWrapperRetrievalPipeline(BaseRetrievalPipeline):
     def _get_pipeline_config(self) -> dict[str, Any]:
         return {
             "type": "fake_wrapper",
+            "retrieval_unit": self.inner_retrieval_pipeline._get_pipeline_config().get("retrieval_unit"),
             "inner_pipeline_name": self.inner_retrieval_pipeline.name,
         }
 
@@ -123,6 +124,7 @@ def base_pipeline_stub() -> SimpleNamespace:
                 {"doc_id": 3, "score": 0.8, "content": "Chunk 2-1"},
             ]
         ),
+        _get_pipeline_config=lambda: {"type": "vector_search", "retrieval_unit": "chunk"},
     )
 
 
@@ -296,6 +298,7 @@ class TestPowerOfNoiseRetrievalPipeline:
 
         assert pipeline._get_pipeline_config() == {
             "type": "power_of_noise",
+            "retrieval_unit": "chunk",
             "base_retrieval_pipeline": "vector_search",
             "noise_count": 2,
             "noise_ratio": 0.5,

--- a/tests/autorag_research/pipelines/retrieval/test_question_decomposition_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_question_decomposition_pipeline.py
@@ -50,6 +50,7 @@ def mock_inner_pipeline():
     mock._retrieve_by_id = AsyncMock(return_value=[])
     mock._retrieve_by_text = AsyncMock(return_value=[])
     mock.retrieve = AsyncMock(return_value=[])
+    mock._get_pipeline_config.return_value = {"type": "mock", "retrieval_unit": "chunk"}
     return mock
 
 
@@ -206,6 +207,7 @@ class TestQuestionDecompositionRetrievalPipeline:
         config = pipeline._get_pipeline_config()
         assert config == {
             "type": "question_decomposition",
+            "retrieval_unit": "chunk",
             "max_subquestions": 3,
             "fetch_k_multiplier": 2,
             "decomposition_prompt_template": DEFAULT_DECOMPOSITION_PROMPT,

--- a/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
@@ -92,6 +92,18 @@ class TestRerankRetrievalPipelineConfig:
         assert kwargs["reranker"] is reranker
         assert kwargs["candidate_top_k"] == 25
 
+    def test_inject_retrieval_pipeline_rejects_image_chunk_pipeline(self):
+        wrapped_retrieval = create_mock_retrieval_pipeline(pipeline_id=77)
+        wrapped_retrieval._get_pipeline_config.return_value = {"type": "heaven", "retrieval_unit": "image_chunk"}
+        config = RerankRetrievalPipelineConfig(
+            name="rerank",
+            retrieval_pipeline_name="heaven",
+            reranker=FakeReranker(),
+        )
+
+        with pytest.raises(ValueError, match="only supports text chunk retrieval pipelines"):
+            config.inject_retrieval_pipeline(wrapped_retrieval)
+
     @pytest.mark.api
     def test_string_reranker_conversion(self):
         with (
@@ -146,6 +158,36 @@ class TestRerankRetrievalPipeline:
         assert config["candidate_top_k"] == 50
         assert config["reranker_model"] == "fake-reranker"
         assert config["retrieval_pipeline_id"] == 123
+        assert config["retrieval_unit"] == "chunk"
+
+    def test_pipeline_config_declares_text_chunk_retrieval_unit_without_database(self, session_factory):
+        with patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None):
+            pipeline = RerankRetrievalPipeline(
+                session_factory=session_factory,
+                name="rerank_config",
+                retrieval_pipeline=create_mock_retrieval_pipeline(pipeline_id=123),
+                reranker=FakeReranker(model_name="fake-reranker"),
+                candidate_top_k=50,
+            )
+
+        config = pipeline._get_pipeline_config()
+
+        assert config["retrieval_unit"] == "chunk"
+
+    def test_creation_rejects_image_chunk_wrapped_pipeline(self, session_factory):
+        wrapped_retrieval = create_mock_retrieval_pipeline()
+        wrapped_retrieval._get_pipeline_config.return_value = {"type": "heaven", "retrieval_unit": "image_chunk"}
+
+        with (
+            patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="only supports text chunk retrieval pipelines"),
+        ):
+            RerankRetrievalPipeline(
+                session_factory=session_factory,
+                name="rerank_image_chunk",
+                retrieval_pipeline=wrapped_retrieval,
+                reranker=FakeReranker(),
+            )
 
     @pytest.mark.asyncio
     async def test_retrieve_by_text_reranks_wrapped_candidates(

--- a/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
@@ -94,7 +94,12 @@ class TestRerankRetrievalPipelineConfig:
 
     @pytest.mark.api
     def test_string_reranker_conversion(self):
-        with patch("autorag_research.injection.load_reranker") as mock_load:
+        with (
+            patch("autorag_research.injection.load_reranker") as mock_load,
+            patch(
+                "autorag_research.pipelines.retrieval.rerank.health_check_reranker", create=True
+            ) as mock_health_check,
+        ):
             mock_reranker = MagicMock()
             mock_load.return_value = mock_reranker
 
@@ -105,6 +110,7 @@ class TestRerankRetrievalPipelineConfig:
             )
 
             mock_load.assert_called_once_with("mock")
+            mock_health_check.assert_not_called()
             assert config.reranker is mock_reranker
 
 
@@ -206,6 +212,34 @@ class TestRerankRetrievalPipeline:
         await pipeline._retrieve_by_text("query text", top_k=2)
 
         reranker.arerank.assert_awaited_once_with("query text", chunk_contents, top_k=2)
+
+    def test_missing_candidate_content_requires_existing_chunk(self, session_factory):
+        wrapped_retrieval = create_mock_retrieval_pipeline()
+
+        with patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None):
+            pipeline = RerankRetrievalPipeline(
+                session_factory=session_factory,
+                name="rerank_missing_content",
+                retrieval_pipeline=wrapped_retrieval,
+                reranker=FakeReranker(),
+                candidate_top_k=2,
+            )
+        pipeline.session_factory = session_factory
+        pipeline._schema = None
+
+        mock_uow = MagicMock()
+        mock_uow.chunks.get_by_ids.return_value = []
+        mock_uow_context = MagicMock()
+        mock_uow_context.__enter__.return_value = mock_uow
+        mock_uow_context.__exit__.return_value = None
+
+        with (
+            patch("autorag_research.pipelines.retrieval.rerank.RetrievalUnitOfWork", return_value=mock_uow_context),
+            pytest.raises(ValueError, match="Missing chunk content for candidate doc_ids: 999"),
+        ):
+            pipeline._ensure_candidate_contents([{"doc_id": 999, "score": 0.9}])
+
+        mock_uow.chunks.get_by_ids.assert_called_once_with([999])
 
     @pytest.mark.asyncio
     async def test_retrieve_by_id_fetches_query_text_then_reranks(

--- a/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
@@ -104,6 +104,21 @@ class TestRerankRetrievalPipelineConfig:
         with pytest.raises(ValueError, match="only supports text chunk retrieval pipelines"):
             config.inject_retrieval_pipeline(wrapped_retrieval)
 
+    def test_inject_retrieval_pipeline_rejects_missing_retrieval_unit(self):
+        wrapped_retrieval = create_mock_retrieval_pipeline(pipeline_id=77)
+        wrapped_retrieval._get_pipeline_config.return_value = {
+            "type": "query_rewrite",
+            "wrapped_pipeline_type": "HEAVENRetrievalPipeline",
+        }
+        config = RerankRetrievalPipelineConfig(
+            name="rerank",
+            retrieval_pipeline_name="query_rewrite_heaven",
+            reranker=FakeReranker(),
+        )
+
+        with pytest.raises(ValueError, match="must declare retrieval_unit='chunk'"):
+            config.inject_retrieval_pipeline(wrapped_retrieval)
+
     @pytest.mark.api
     def test_string_reranker_conversion(self):
         with (
@@ -185,6 +200,24 @@ class TestRerankRetrievalPipeline:
             RerankRetrievalPipeline(
                 session_factory=session_factory,
                 name="rerank_image_chunk",
+                retrieval_pipeline=wrapped_retrieval,
+                reranker=FakeReranker(),
+            )
+
+    def test_creation_rejects_wrapper_chain_without_explicit_text_retrieval_unit(self, session_factory):
+        wrapped_retrieval = create_mock_retrieval_pipeline()
+        wrapped_retrieval._get_pipeline_config.return_value = {
+            "type": "query_rewrite",
+            "wrapped_pipeline_type": "HEAVENRetrievalPipeline",
+        }
+
+        with (
+            patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="must declare retrieval_unit='chunk'"),
+        ):
+            RerankRetrievalPipeline(
+                session_factory=session_factory,
+                name="rerank_missing_retrieval_unit",
                 retrieval_pipeline=wrapped_retrieval,
                 reranker=FakeReranker(),
             )

--- a/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
@@ -1,0 +1,286 @@
+"""Tests for the generic retriever-reranker retrieval pipeline."""
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import Field
+from sqlalchemy.orm import Session, sessionmaker
+
+from autorag_research.orm.repository.chunk import ChunkRepository
+from autorag_research.orm.repository.chunk_retrieved_result import ChunkRetrievedResultRepository
+from autorag_research.orm.repository.query import QueryRepository
+from autorag_research.pipelines.retrieval.rerank import RerankRetrievalPipeline, RerankRetrievalPipelineConfig
+from autorag_research.rerankers.base import BaseReranker, RerankResult
+from tests.autorag_research.pipelines.pipeline_test_utils import (
+    PipelineTestConfig,
+    PipelineTestVerifier,
+    create_mock_retrieval_pipeline,
+)
+
+
+class FakeReranker(BaseReranker):
+    """Deterministic test reranker that scores documents by exact text."""
+
+    scores_by_text: dict[str, float] = Field(default_factory=dict)
+
+    def rerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
+        results = [
+            RerankResult(index=index, text=document, score=self.scores_by_text.get(document, 0.0))
+            for index, document in enumerate(documents)
+        ]
+        results.sort(key=lambda result: result.score, reverse=True)
+        return results[:top_k] if top_k is not None else results
+
+    async def arerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[RerankResult]:
+        return self.rerank(query, documents, top_k)
+
+
+@pytest.fixture
+def cleanup_pipeline_results(session_factory: sessionmaker[Session]):
+    """Cleanup fixture that deletes rerank pipeline results after test."""
+    created_pipeline_ids: list[int] = []
+
+    yield created_pipeline_ids
+
+    session = session_factory()
+    try:
+        result_repo = ChunkRetrievedResultRepository(session)
+        for pipeline_id in created_pipeline_ids:
+            result_repo.delete_by_pipeline(pipeline_id)
+        session.commit()
+    finally:
+        session.close()
+
+
+class TestRerankRetrievalPipelineConfig:
+    """Tests for RerankRetrievalPipelineConfig."""
+
+    def test_get_pipeline_class(self):
+        config = RerankRetrievalPipelineConfig(
+            name="rerank",
+            retrieval_pipeline_name="bm25",
+            reranker=FakeReranker(),
+        )
+
+        assert config.get_pipeline_class() == RerankRetrievalPipeline
+
+    def test_get_pipeline_kwargs_requires_injected_retrieval_pipeline(self):
+        config = RerankRetrievalPipelineConfig(
+            name="rerank",
+            retrieval_pipeline_name="bm25",
+            reranker=FakeReranker(),
+        )
+
+        with pytest.raises(ValueError, match="not injected"):
+            config.get_pipeline_kwargs()
+
+    def test_get_pipeline_kwargs_after_injection(self):
+        wrapped_retrieval = create_mock_retrieval_pipeline(pipeline_id=77)
+        reranker = FakeReranker(scores_by_text={"doc": 1.0})
+        config = RerankRetrievalPipelineConfig(
+            name="rerank",
+            retrieval_pipeline_name="bm25",
+            reranker=reranker,
+            candidate_top_k=25,
+        )
+
+        config.inject_retrieval_pipeline(wrapped_retrieval)
+        kwargs = config.get_pipeline_kwargs()
+
+        assert kwargs["retrieval_pipeline"] is wrapped_retrieval
+        assert kwargs["reranker"] is reranker
+        assert kwargs["candidate_top_k"] == 25
+
+    @pytest.mark.api
+    def test_string_reranker_conversion(self):
+        with patch("autorag_research.injection.load_reranker") as mock_load:
+            mock_reranker = MagicMock()
+            mock_load.return_value = mock_reranker
+
+            config = RerankRetrievalPipelineConfig(
+                name="rerank",
+                retrieval_pipeline_name="bm25",
+                reranker="mock",
+            )
+
+            mock_load.assert_called_once_with("mock")
+            assert config.reranker is mock_reranker
+
+
+class TestRerankRetrievalPipeline:
+    """Tests for RerankRetrievalPipeline."""
+
+    def test_creation_rejects_invalid_candidate_top_k(self, session_factory):
+        with (
+            patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="candidate_top_k must be >= 1"),
+        ):
+            RerankRetrievalPipeline(
+                session_factory=session_factory,
+                name="rerank_invalid_candidate_top_k",
+                retrieval_pipeline=create_mock_retrieval_pipeline(),
+                reranker=FakeReranker(),
+                candidate_top_k=0,
+            )
+
+    def test_pipeline_config(self, session_factory, cleanup_pipeline_results: list[int]):
+        pipeline = RerankRetrievalPipeline(
+            session_factory=session_factory,
+            name="rerank_config",
+            retrieval_pipeline=create_mock_retrieval_pipeline(pipeline_id=123),
+            reranker=FakeReranker(model_name="fake-reranker"),
+            candidate_top_k=50,
+        )
+        cleanup_pipeline_results.append(cast("int", pipeline.pipeline_id))
+
+        config = pipeline._get_pipeline_config()
+
+        assert config["type"] == "rerank"
+        assert config["candidate_top_k"] == 50
+        assert config["reranker_model"] == "fake-reranker"
+        assert config["retrieval_pipeline_id"] == 123
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_reranks_wrapped_candidates(
+        self, session_factory, cleanup_pipeline_results: list[int]
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 1, "score": 0.99, "content": "first document"},
+                {"doc_id": 2, "score": 0.40, "content": "second document"},
+            ]
+        )
+        reranker = FakeReranker(scores_by_text={"first document": 0.2, "second document": 0.9})
+        pipeline = RerankRetrievalPipeline(
+            session_factory=session_factory,
+            name="rerank_by_text",
+            retrieval_pipeline=wrapped_retrieval,
+            reranker=reranker,
+            candidate_top_k=2,
+        )
+        cleanup_pipeline_results.append(cast("int", pipeline.pipeline_id))
+
+        results = await pipeline._retrieve_by_text("original query", top_k=1)
+
+        wrapped_retrieval.retrieve.assert_awaited_once_with("original query", 2)
+        assert results == [{"doc_id": 2, "score": 0.9, "content": "second document"}]
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_backfills_missing_candidate_content(
+        self,
+        session_factory,
+        cleanup_pipeline_results: list[int],
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 1, "score": 0.9},
+                {"doc_id": 2, "score": 0.8},
+            ]
+        )
+
+        session = session_factory()
+        try:
+            chunk_repo = ChunkRepository(session)
+            chunk_contents = [chunk.contents for chunk in chunk_repo.get_by_ids([1, 2])]
+        finally:
+            session.close()
+
+        reranker = MagicMock()
+        reranker.model_name = "recording-reranker"
+        reranker.arerank = AsyncMock(
+            return_value=[
+                RerankResult(index=1, text=chunk_contents[1], score=0.75),
+                RerankResult(index=0, text=chunk_contents[0], score=0.55),
+            ]
+        )
+        pipeline = RerankRetrievalPipeline(
+            session_factory=session_factory,
+            name="rerank_backfill_content",
+            retrieval_pipeline=wrapped_retrieval,
+            reranker=reranker,
+            candidate_top_k=2,
+        )
+        cleanup_pipeline_results.append(cast("int", pipeline.pipeline_id))
+
+        await pipeline._retrieve_by_text("query text", top_k=2)
+
+        reranker.arerank.assert_awaited_once_with("query text", chunk_contents, top_k=2)
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_id_fetches_query_text_then_reranks(
+        self,
+        session_factory,
+        cleanup_pipeline_results: list[int],
+    ):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 3, "score": 0.88, "content": "doc"}]
+        )
+        pipeline = RerankRetrievalPipeline(
+            session_factory=session_factory,
+            name="rerank_by_id",
+            retrieval_pipeline=wrapped_retrieval,
+            reranker=FakeReranker(scores_by_text={"doc": 0.88}),
+        )
+        cleanup_pipeline_results.append(cast("int", pipeline.pipeline_id))
+
+        results = await pipeline._retrieve_by_id(1, top_k=2)
+
+        wrapped_retrieval.retrieve.assert_awaited_once()
+        assert results == [{"doc_id": 3, "score": 0.88, "content": "doc"}]
+
+    @pytest.mark.asyncio
+    async def test_retrieve_by_text_rejects_out_of_range_reranker_index(self, session_factory):
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[{"doc_id": 1, "score": 0.9, "content": "doc"}]
+        )
+        reranker = MagicMock()
+        reranker.arerank = AsyncMock(return_value=[RerankResult(index=5, text="doc", score=1.0)])
+
+        with patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None):
+            pipeline = RerankRetrievalPipeline(
+                session_factory=session_factory,
+                name="rerank_bad_index",
+                retrieval_pipeline=wrapped_retrieval,
+                reranker=reranker,
+            )
+
+        with pytest.raises(ValueError, match="out-of-range candidate index"):
+            await pipeline._retrieve_by_text("query text", top_k=1)
+
+    def test_run_full_pipeline(self, session_factory, cleanup_pipeline_results: list[int]):
+        session = session_factory()
+        try:
+            query_count = QueryRepository(session).count()
+        finally:
+            session.close()
+
+        wrapped_retrieval = create_mock_retrieval_pipeline(
+            default_results=[
+                {"doc_id": 1, "score": 0.91, "content": "Content 1"},
+                {"doc_id": 2, "score": 0.83, "content": "Content 2"},
+            ]
+        )
+        pipeline = RerankRetrievalPipeline(
+            session_factory=session_factory,
+            name="rerank_full_run",
+            retrieval_pipeline=wrapped_retrieval,
+            reranker=FakeReranker(scores_by_text={"Content 1": 0.8, "Content 2": 0.6}),
+            candidate_top_k=2,
+        )
+        cleanup_pipeline_results.append(cast("int", pipeline.pipeline_id))
+
+        result = pipeline.run(top_k=2)
+
+        verifier = PipelineTestVerifier(
+            result,
+            cast("int", pipeline.pipeline_id),
+            session_factory,
+            PipelineTestConfig(
+                pipeline_type="retrieval",
+                expected_total_queries=query_count,
+                expected_min_results=0,
+                check_persistence=True,
+            ),
+        )
+        verifier.verify_all()


### PR DESCRIPTION
## Summary
- Adds a text-chunk `RerankRetrievalPipeline` wrapper that retrieves first-stage candidates from a configured text retrieval pipeline and reranks them with a configured `BaseReranker`.
- Enforces the text-only retrieval boundary fail-closed: wrapped pipelines must explicitly declare `retrieval_unit: "chunk"`, and wrapper pipelines propagate retrieval-unit metadata so nested image/non-text chains cannot be treated as text chunk results.
- Adds `configs/pipelines/retrieval/rerank.yaml` using BM25 + sentence-transformer reranker defaults.
- Exports the new pipeline/config and covers config injection, candidate over-fetching, result index mapping, content backfill, missing-content failures, direct and transitive text-only wrapped pipeline guards, ID/text retrieval, and run behavior in tests.

## Validation
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipelineConfig tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipeline::test_creation_rejects_invalid_candidate_top_k tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipeline::test_creation_rejects_image_chunk_wrapped_pipeline tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipeline::test_creation_rejects_wrapper_chain_without_explicit_text_retrieval_unit tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipeline::test_pipeline_config_declares_text_chunk_retrieval_unit_without_database tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipeline::test_retrieve_by_text_rejects_out_of_range_reranker_index tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipeline::test_missing_candidate_content_requires_existing_chunk -q` → 12 passed
- `make check` → passed
- `uv run python` fail-closed probe for `query_rewrite` metadata without `retrieval_unit` → raised `ValueError`
- Ralph architect verification → CLEAR

## Notes
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py -q` still cannot complete locally because PostgreSQL is unavailable: 12 passed, 5 failed from localhost:5432 connection refusal.
- `make docker-up && make docker-wait` could not start PostgreSQL because Docker daemon is unavailable (`Cannot connect to the Docker daemon at unix:///Users/jeffrey/.docker/run/docker.sock`).
- PR #370 branch is `feature/#86`; the same follow-up commit was also pushed to PR #357's existing branch `feature/#86-retriever-rerank-generation` per automation request.

Closes #86

<!-- dani:stage=implementation;job=fcf79bd8fec34f4fa6c5cb60f21b56c0;issue=86;pr=370 -->
