### PR TITLE
Feature/#240

### DIFF
--- a/autorag_research/data/registry.py
+++ b/autorag_research/data/registry.py
@@ -118,6 +118,10 @@ def register_ingestor(
 
 def _validate_ingestor_name_and_aliases(name: str, aliases: tuple[str, ...]) -> None:
     """Ensure canonical ingestor names and aliases remain globally unambiguous."""
+    if name in _INGESTOR_REGISTRY:
+        msg = f"Ingestor canonical name conflicts with registered ingestor: {name}"
+        raise ValueError(msg)
+
     if name in _INGESTOR_ALIASES:
         msg = f"Ingestor canonical name conflicts with an existing alias: {name}"
         raise ValueError(msg)

--- a/autorag_research/data/registry.py
+++ b/autorag_research/data/registry.py
@@ -119,8 +119,13 @@ def register_ingestor(
 def _validate_ingestor_name_and_aliases(name: str, aliases: tuple[str, ...], cls: type | None = None) -> None:
     """Ensure canonical ingestor names and aliases remain globally unambiguous."""
     if name in _INGESTOR_REGISTRY:
-        # Allow idempotent re-registration of the same class (e.g. importlib.reload)
-        if cls is not None and _INGESTOR_REGISTRY[name].ingestor_class is cls:
+        # Allow idempotent re-registration of the same class (e.g. importlib.reload).
+        # After reload the class object is new, so compare by qualified name.
+        existing_cls = _INGESTOR_REGISTRY[name].ingestor_class
+        if cls is not None and (
+            existing_cls is cls
+            or f"{existing_cls.__module__}.{existing_cls.__qualname__}" == f"{cls.__module__}.{cls.__qualname__}"
+        ):
             return
         msg = f"Ingestor canonical name conflicts with registered ingestor: {name}"
         raise ValueError(msg)

--- a/autorag_research/data/registry.py
+++ b/autorag_research/data/registry.py
@@ -99,7 +99,7 @@ def register_ingestor(
     """
 
     def decorator(cls):
-        _validate_ingestor_name_and_aliases(name, aliases)
+        _validate_ingestor_name_and_aliases(name, aliases, cls)
         params = _extract_params_from_init(cls)
         _INGESTOR_REGISTRY[name] = IngestorMeta(
             name=name,
@@ -116,9 +116,12 @@ def register_ingestor(
     return decorator
 
 
-def _validate_ingestor_name_and_aliases(name: str, aliases: tuple[str, ...]) -> None:
+def _validate_ingestor_name_and_aliases(name: str, aliases: tuple[str, ...], cls: type | None = None) -> None:
     """Ensure canonical ingestor names and aliases remain globally unambiguous."""
     if name in _INGESTOR_REGISTRY:
+        # Allow idempotent re-registration of the same class (e.g. importlib.reload)
+        if cls is not None and _INGESTOR_REGISTRY[name].ingestor_class is cls:
+            return
         msg = f"Ingestor canonical name conflicts with registered ingestor: {name}"
         raise ValueError(msg)
 

--- a/autorag_research/data/registry.py
+++ b/autorag_research/data/registry.py
@@ -99,6 +99,7 @@ def register_ingestor(
     """
 
     def decorator(cls):
+        _validate_ingestor_name_and_aliases(name, aliases)
         params = _extract_params_from_init(cls)
         _INGESTOR_REGISTRY[name] = IngestorMeta(
             name=name,
@@ -113,6 +114,28 @@ def register_ingestor(
         return cls
 
     return decorator
+
+
+def _validate_ingestor_name_and_aliases(name: str, aliases: tuple[str, ...]) -> None:
+    """Ensure canonical ingestor names and aliases remain globally unambiguous."""
+    if name in _INGESTOR_ALIASES:
+        msg = f"Ingestor canonical name conflicts with an existing alias: {name}"
+        raise ValueError(msg)
+
+    duplicate_aliases = {alias for alias in aliases if aliases.count(alias) > 1}
+    if duplicate_aliases:
+        msg = f"Ingestor aliases contain duplicates: {sorted(duplicate_aliases)}"
+        raise ValueError(msg)
+
+    registered_name_conflicts = set(aliases) & (set(_INGESTOR_REGISTRY) | {name})
+    if registered_name_conflicts:
+        msg = f"Ingestor aliases conflict with registered ingestors: {sorted(registered_name_conflicts)}"
+        raise ValueError(msg)
+
+    alias_conflicts = set(aliases) & set(_INGESTOR_ALIASES)
+    if alias_conflicts:
+        msg = f"Ingestor aliases conflict with existing aliases: {sorted(alias_conflicts)}"
+        raise ValueError(msg)
 
 
 def _extract_params_from_init(cls) -> list[ParamMeta]:

--- a/autorag_research/orm/repository/base.py
+++ b/autorag_research/orm/repository/base.py
@@ -569,17 +569,25 @@ class BaseEmbeddingRepository(GenericRepository[T]):
             stmt = stmt.limit(limit)
         return list(self.session.execute(stmt).scalars().all())
 
-    def get_without_embeddings(self, limit: int | None = None, offset: int | None = None) -> list[T]:
+    def get_without_embeddings(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        exclude_ids: set[int | str] | None = None,
+    ) -> list[T]:
         """Retrieve entities that do not have embeddings.
 
         Args:
             limit: Maximum number of results to return.
             offset: Number of results to skip.
+            exclude_ids: Entity IDs to omit from the result set.
 
         Returns:
             List of entities without embeddings.
         """
         stmt = select(self.model_cls).where(self.model_cls.embedding.is_(None))  # ty: ignore[possibly-missing-attribute]
+        if exclude_ids:
+            stmt = stmt.where(self.model_cls.id.not_in(exclude_ids))  # ty: ignore[possibly-missing-attribute]
         return self._execute_with_offset_limit(stmt, limit, offset)
 
     def get_with_embeddings(self, limit: int | None = None, offset: int | None = None) -> list[T]:
@@ -595,17 +603,25 @@ class BaseEmbeddingRepository(GenericRepository[T]):
         stmt = select(self.model_cls).where(self.model_cls.embedding.is_not(None))  # ty: ignore[possibly-missing-attribute]
         return self._execute_with_offset_limit(stmt, limit, offset)
 
-    def get_without_multi_embeddings(self, limit: int | None = None, offset: int | None = None) -> list[T]:
+    def get_without_multi_embeddings(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        exclude_ids: set[int | str] | None = None,
+    ) -> list[T]:
         """Retrieve entities that do not have multi-vector embeddings.
 
         Args:
             limit: Maximum number of results to return.
             offset: Number of results to skip.
+            exclude_ids: Entity IDs to omit from the result set.
 
         Returns:
             List of entities without multi-vector embeddings.
         """
         stmt = select(self.model_cls).where(self.model_cls.embeddings.is_(None))  # ty: ignore[possibly-missing-attribute]
+        if exclude_ids:
+            stmt = stmt.where(self.model_cls.id.not_in(exclude_ids))  # ty: ignore[possibly-missing-attribute]
         return self._execute_with_offset_limit(stmt, limit, offset)
 
     def get_with_multi_embeddings(self, limit: int | None = None, offset: int | None = None) -> list[T]:

--- a/autorag_research/orm/service/base_ingestion.py
+++ b/autorag_research/orm/service/base_ingestion.py
@@ -445,7 +445,11 @@ class BaseIngestionService(BaseService, ABC):
         batch_size: int,
         failed_ids: set[int | str],
     ) -> list[tuple[int | str, Any]]:
-        """Fetch the next batch of entities without embeddings, excluding `failed_ids` in the repository query."""
+        """Fetch the next batch of entities without embeddings, excluding `failed_ids` in the repository query.
+
+        Repositories used by embedding ingestion must accept the `exclude_ids` keyword so broad per-run embedding
+        failures do not require growing `limit` values and Python-side failed-prefix filtering.
+        """
         with self._create_uow() as uow:
             repository = getattr(uow, repo_attr, None)
             if repository is None:

--- a/autorag_research/orm/service/base_ingestion.py
+++ b/autorag_research/orm/service/base_ingestion.py
@@ -445,20 +445,16 @@ class BaseIngestionService(BaseService, ABC):
         batch_size: int,
         failed_ids: set[int | str],
     ) -> list[tuple[int | str, Any]]:
-        """Fetch the next batch of entities without embeddings, excluding `failed_ids`.
-
-        Over-fetches by `len(failed_ids)` so already-failed rows do not starve
-        the batch when they appear at the head of the database ordering.
-        """
+        """Fetch the next batch of entities without embeddings, excluding `failed_ids` in the repository query."""
         with self._create_uow() as uow:
             repository = getattr(uow, repo_attr, None)
             if repository is None:
                 raise RepositoryNotSupportedError(repo_attr, type(uow).__name__)
             fetch_method = getattr(repository, fetch_method_name)
-            entities = fetch_method(limit=batch_size + len(failed_ids))
+            entities = fetch_method(limit=batch_size, exclude_ids=failed_ids)
             if not entities:
                 return []
-            return [(e.id, getattr(e, data_attr)) for e in entities if e.id not in failed_ids]
+            return [(e.id, getattr(e, data_attr)) for e in entities]
 
     def _embed_batch(
         self,

--- a/tests/autorag_research/data/test_registry.py
+++ b/tests/autorag_research/data/test_registry.py
@@ -256,6 +256,23 @@ class TestRegisterIngestor:
             registry_module._INGESTOR_REGISTRY.pop("test_duplicate_alias_target", None)
             registry_module._INGESTOR_ALIASES.pop("test-duplicate-alias", None)
 
+    def test_register_ingestor_rejects_duplicate_aliases_in_single_registration(self):
+        """Aliases should be unique within a single ingestor registration."""
+        import autorag_research.data.registry as registry_module
+
+        with pytest.raises(ValueError, match="aliases contain duplicates"):
+
+            @register_ingestor(
+                name="test_duplicate_aliases_single_registration",
+                description="Test",
+                aliases=("test-duplicate-alias-single", "test-duplicate-alias-single"),
+            )
+            class TestDuplicateAliasesSingleRegistrationIngestor:
+                pass
+
+        assert "test_duplicate_aliases_single_registration" not in registry_module._INGESTOR_REGISTRY
+        assert "test-duplicate-alias-single" not in registry_module._INGESTOR_ALIASES
+
     def test_register_ingestor_rejects_canonical_name_that_matches_alias(self):
         """Canonical names should not be allowed to shadow existing aliases."""
         import autorag_research.data.registry as registry_module

--- a/tests/autorag_research/data/test_registry.py
+++ b/tests/autorag_research/data/test_registry.py
@@ -4,6 +4,8 @@ from enum import Enum
 from typing import Literal
 from unittest.mock import patch
 
+import pytest
+
 from autorag_research.data.registry import (
     IngestorMeta,
     ParamMeta,
@@ -194,6 +196,93 @@ class TestRegisterIngestor:
         # Cleanup
         del registry_module._INGESTOR_REGISTRY["test_ingestor_alias"]
         del registry_module._INGESTOR_ALIASES["test-ingestor-alias"]
+
+    def test_register_ingestor_rejects_alias_that_matches_canonical_name(self):
+        """Aliases should not be allowed to shadow existing canonical ingestors."""
+        import autorag_research.data.registry as registry_module
+
+        @register_ingestor(name="test_canonical_collision_base", description="Test")
+        class TestCanonicalCollisionBaseIngestor:
+            pass
+
+        try:
+            with pytest.raises(ValueError, match="aliases conflict with registered ingestors"):
+
+                @register_ingestor(
+                    name="test_canonical_collision_target",
+                    description="Test",
+                    aliases=("test_canonical_collision_base",),
+                )
+                class TestCanonicalCollisionTargetIngestor:
+                    pass
+
+            base_meta = get_ingestor("test_canonical_collision_base")
+            assert base_meta is not None
+            assert base_meta.name == "test_canonical_collision_base"
+            assert "test_canonical_collision_target" not in registry_module._INGESTOR_REGISTRY
+        finally:
+            registry_module._INGESTOR_REGISTRY.pop("test_canonical_collision_base", None)
+            registry_module._INGESTOR_REGISTRY.pop("test_canonical_collision_target", None)
+
+    def test_register_ingestor_rejects_duplicate_alias(self):
+        """Aliases should be globally unique across registered ingestors."""
+        import autorag_research.data.registry as registry_module
+
+        @register_ingestor(
+            name="test_duplicate_alias_base",
+            description="Test",
+            aliases=("test-duplicate-alias",),
+        )
+        class TestDuplicateAliasBaseIngestor:
+            pass
+
+        try:
+            with pytest.raises(ValueError, match="aliases conflict with existing aliases"):
+
+                @register_ingestor(
+                    name="test_duplicate_alias_target",
+                    description="Test",
+                    aliases=("test-duplicate-alias",),
+                )
+                class TestDuplicateAliasTargetIngestor:
+                    pass
+
+            alias_meta = get_ingestor("test-duplicate-alias")
+            assert alias_meta is not None
+            assert alias_meta.name == "test_duplicate_alias_base"
+            assert "test_duplicate_alias_target" not in registry_module._INGESTOR_REGISTRY
+        finally:
+            registry_module._INGESTOR_REGISTRY.pop("test_duplicate_alias_base", None)
+            registry_module._INGESTOR_REGISTRY.pop("test_duplicate_alias_target", None)
+            registry_module._INGESTOR_ALIASES.pop("test-duplicate-alias", None)
+
+    def test_register_ingestor_rejects_canonical_name_that_matches_alias(self):
+        """Canonical names should not be allowed to shadow existing aliases."""
+        import autorag_research.data.registry as registry_module
+
+        @register_ingestor(
+            name="test_canonical_after_alias_base",
+            description="Test",
+            aliases=("test-canonical-after-alias",),
+        )
+        class TestCanonicalAfterAliasBaseIngestor:
+            pass
+
+        try:
+            with pytest.raises(ValueError, match="canonical name conflicts with an existing alias"):
+
+                @register_ingestor(name="test-canonical-after-alias", description="Test")
+                class TestCanonicalAfterAliasTargetIngestor:
+                    pass
+
+            alias_meta = get_ingestor("test-canonical-after-alias")
+            assert alias_meta is not None
+            assert alias_meta.name == "test_canonical_after_alias_base"
+            assert "test-canonical-after-alias" not in registry_module._INGESTOR_REGISTRY
+        finally:
+            registry_module._INGESTOR_REGISTRY.pop("test_canonical_after_alias_base", None)
+            registry_module._INGESTOR_REGISTRY.pop("test-canonical-after-alias", None)
+            registry_module._INGESTOR_ALIASES.pop("test-canonical-after-alias", None)
 
 
 class TestExtractParamsFromInit:

--- a/tests/autorag_research/data/test_registry.py
+++ b/tests/autorag_research/data/test_registry.py
@@ -284,6 +284,28 @@ class TestRegisterIngestor:
             registry_module._INGESTOR_REGISTRY.pop("test-canonical-after-alias", None)
             registry_module._INGESTOR_ALIASES.pop("test-canonical-after-alias", None)
 
+    def test_register_ingestor_rejects_duplicate_canonical_name(self):
+        """Canonical names should be globally unique and reject overwrites."""
+        import autorag_research.data.registry as registry_module
+
+        @register_ingestor(name="test_duplicate_canonical", description="Test")
+        class TestDuplicateCanonicalBaseIngestor:
+            pass
+
+        try:
+            with pytest.raises(ValueError, match="canonical name conflicts with registered ingestor"):
+
+                @register_ingestor(name="test_duplicate_canonical", description="Test")
+                class TestDuplicateCanonicalTargetIngestor:
+                    pass
+
+            canonical_meta = get_ingestor("test_duplicate_canonical")
+            assert canonical_meta is not None
+            assert canonical_meta.ingestor_class is TestDuplicateCanonicalBaseIngestor
+            assert canonical_meta.ingestor_class.__name__ == "TestDuplicateCanonicalBaseIngestor"
+        finally:
+            registry_module._INGESTOR_REGISTRY.pop("test_duplicate_canonical", None)
+
 
 class TestExtractParamsFromInit:
     """Tests for _extract_params_from_init function."""

--- a/tests/autorag_research/orm/service/test_base_ingestion.py
+++ b/tests/autorag_research/orm/service/test_base_ingestion.py
@@ -343,6 +343,31 @@ class TestBaseIngestionService:
                 uow.commit()
             _restore_unembedded_queries(service, snapshots)
 
+    def test_embed_all_queries_uses_bounded_server_side_failed_id_exclusion(self):
+        """Broad embedding failures must not grow fetch limits with failed-prefix over-fetching."""
+        service = FakeIngestionService([FakeEntity(item_id, f"query {item_id}") for item_id in range(1, 21)])
+
+        async def always_fail(_text: str) -> list[float]:
+            msg = "simulated provider outage"
+            raise RuntimeError(msg)
+
+        embedded = service.embed_all_queries(
+            always_fail,
+            batch_size=5,
+            max_concurrency=2,
+            bm25_tokenizer=None,
+        )
+
+        assert embedded == 0
+        assert service.repository.fetch_limits == [5, 5, 5, 5, 5]
+        assert service.repository.fetch_excluded_ids == [
+            set(),
+            {1, 2, 3, 4, 5},
+            {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+            {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+            {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+        ]
+
 
 def _snapshot_unembedded_queries(service: BaseIngestionService) -> list[int]:
     """Capture IDs of seed queries whose embedding is None.
@@ -364,3 +389,55 @@ def _restore_unembedded_queries(service: BaseIngestionService, ids: list[int]) -
             if entity is not None:
                 entity.embedding = None
         uow.commit()
+
+
+class FakeEntity:
+    def __init__(self, item_id: int, contents: str):
+        self.id = item_id
+        self.contents = contents
+
+
+class FakeEmbeddingRepository:
+    def __init__(self, entities: list[FakeEntity]):
+        self.entities = entities
+        self.fetch_limits: list[int | None] = []
+        self.fetch_excluded_ids: list[set[int | str]] = []
+
+    def count_without_embeddings(self) -> int:
+        return len(self.entities)
+
+    def get_without_embeddings(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        exclude_ids: set[int | str] | None = None,
+    ) -> list[FakeEntity]:
+        del offset
+        excluded = set() if exclude_ids is None else set(exclude_ids)
+        self.fetch_limits.append(limit)
+        self.fetch_excluded_ids.append(excluded)
+        entities = [entity for entity in self.entities if entity.id not in excluded]
+        return entities if limit is None else entities[:limit]
+
+
+class FakeUnitOfWork:
+    def __init__(self, repository: FakeEmbeddingRepository):
+        self.queries = repository
+
+    def __enter__(self) -> "FakeUnitOfWork":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+
+class FakeIngestionService(BaseIngestionService):
+    def __init__(self, entities: list[FakeEntity]):
+        super().__init__(session_factory=None)  # type: ignore[arg-type]
+        self.repository = FakeEmbeddingRepository(entities)
+
+    def _create_uow(self) -> FakeUnitOfWork:
+        return FakeUnitOfWork(self.repository)
+
+    def _get_schema_classes(self) -> dict[str, type]:
+        return {}


### PR DESCRIPTION
<!-- dani:stage=implementation;job=74de956a1e7744adba627af2d76fcf22;issue=240;pr=371 -->

## Summary
- reject registry alias collisions before mutation so aliases cannot shadow canonical ingestors, duplicate existing aliases, or later become shadowed by canonical names
- reject duplicate canonical ingestor registrations before mutation so canonical names cannot be silently overwritten
- preserve lookup-only Mr. TyDi alias behavior for `mrtydi`, `mr-tydi`, and `mr.tydi`
- bound per-run embedding failure retries by moving failed-ID exclusion into the repository query instead of growing fetch limits and filtering failed prefixes in Python
- documented the `exclude_ids` repository contract required by embedding ingestion fetches
- add TDD regression coverage for alias-vs-canonical, duplicate alias, duplicate aliases within one registration, canonical-after-alias, duplicate canonical conflicts, and broad all-failing embedding batches

## Verification
- TDD red step: the new duplicate-canonical collision test failed before implementation
- TDD red step: the three alias collision tests failed before the original implementation
- TDD red step: the new broad embedding failure regression failed before implementation with fetch limits `[5, 10, 15, 20, 25]`
- `uv run pytest tests/autorag_research/orm/service/test_base_ingestion.py::TestBaseIngestionService::test_embed_all_queries_uses_bounded_server_side_failed_id_exclusion -q` → passed
- `uv run pytest tests/autorag_research/orm/service/test_base_ingestion.py::TestBaseIngestionService::test_embed_all_queries_uses_bounded_server_side_failed_id_exclusion tests/autorag_research/data/test_registry.py::TestRegisterIngestor::test_register_ingestor_rejects_duplicate_canonical_name tests/autorag_research/data/test_registry.py::TestRegisterIngestor::test_register_ingestor_rejects_alias_that_matches_canonical_name tests/autorag_research/data/test_registry.py::TestRegisterIngestor::test_register_ingestor_rejects_duplicate_alias tests/autorag_research/data/test_registry.py::TestRegisterIngestor::test_register_ingestor_rejects_duplicate_aliases_in_single_registration tests/autorag_research/data/test_registry.py::TestRegisterIngestor::test_register_ingestor_rejects_canonical_name_that_matches_alias tests/autorag_research/data/test_registry.py::TestGetIngestor::test_mrtydi_common_name_aliases_resolve -q` → 7 passed
- runtime smoke check confirmed all-failing embedding batches keep fixed fetch limits `[5, 5, 5, 5, 5]` and request 25 rows total for 20 rows / batch size 5 instead of the prior 75-row triangular pattern
- runtime smoke check confirmed duplicate canonical rejection before mutation and original class preservation
- `uv run pytest tests/autorag_research/data/test_registry.py -q` → 46 passed
- runtime smoke check confirmed Mr. TyDi alias resolution, repo lookup, DB-name behavior, and all alias collision rejection paths
- `make check` → passed
- Ralph STANDARD architect verification → APPROVED
- Ralph scoped deslop pass completed with no edits needed; post-deslop targeted tests and `make check` stayed green

## Notes
- This follows up merged PR #367 / issue #240 review feedback and the PR #371 review requests to protect canonical registry names and avoid broad embedding-failure over-fetching.
- `make test` / full DB-backed service tests were not run because this environment cannot connect to Docker/PostgreSQL (`docker info` failed: Docker daemon socket `/Users/jeffrey/.docker/run/docker.sock` not present; direct DB-backed tests failed with PostgreSQL connection refused on localhost:5432).


