### PR TITLE
Feature/#370

### DIFF
--- a/autorag_research/orm/service/base_pipeline.py
+++ b/autorag_research/orm/service/base_pipeline.py
@@ -24,6 +24,10 @@ class BasePipelineService(BaseService, ABC):
     The UoW returned by _create_uow() must expose a `pipelines` property (PipelineRepository).
     """
 
+    def _validate_existing_pipeline_config(self, name: str, existing_config: dict, new_config: dict) -> None:
+        """Validate service-specific config invariants before reusing an existing pipeline."""
+        return None
+
     def get_or_create_pipeline(self, name: str, config: dict, *, strict: bool = False) -> tuple[int | str, bool]:
         """Get existing pipeline by name or create a new one.
 
@@ -47,6 +51,7 @@ class BasePipelineService(BaseService, ABC):
         with self._create_uow() as uow:
             existing = uow.pipelines.get_by_name(name)
             if existing is not None:
+                self._validate_existing_pipeline_config(name, existing.config, config)
                 if existing.config != config:
                     if strict:
                         raise ValueError(  # noqa: TRY003

--- a/autorag_research/orm/service/retrieval_pipeline.py
+++ b/autorag_research/orm/service/retrieval_pipeline.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 
 from autorag_research.orm.service.base_pipeline import BasePipelineService
 from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
+from autorag_research.retrieval_units import RetrievalUnit, require_retrieval_unit
 
 __all__ = ["RetrievalFunc", "RetrievalPipelineService"]
 
@@ -83,6 +84,69 @@ class RetrievalPipelineService(BasePipelineService):
     def _create_uow(self) -> RetrievalUnitOfWork:
         """Create a new RetrievalUnitOfWork instance."""
         return RetrievalUnitOfWork(self.session_factory, self._schema)
+
+    def _get_config_retrieval_unit(self, config: dict) -> RetrievalUnit:
+        """Return the persisted retrieval unit, defaulting legacy configs to text chunks."""
+        return require_retrieval_unit(config.get("retrieval_unit"), default="chunk") or "chunk"
+
+    def _validate_existing_pipeline_config(self, name: str, existing_config: dict, new_config: dict) -> None:
+        """Prevent one retrieval pipeline identity from changing persistence namespaces."""
+        existing_unit = self._get_config_retrieval_unit(existing_config)
+        new_unit = self._get_config_retrieval_unit(new_config)
+        if existing_unit != new_unit:
+            msg = (
+                f"Pipeline '{name}' retrieval_unit changed from '{existing_unit}' to '{new_unit}'. "
+                "Create a new pipeline name or clear old results before changing retrieval result namespaces."
+            )
+            raise ValueError(msg)
+
+    def get_or_create_pipeline(self, name: str, config: dict, *, strict: bool = False) -> tuple[int | str, bool]:
+        """Get or create a retrieval pipeline after validating its result namespace."""
+        self._get_config_retrieval_unit(config)
+        return super().get_or_create_pipeline(name=name, config=config, strict=strict)
+
+    def _reject_opposite_result_namespace(
+        self,
+        uow: RetrievalUnitOfWork,
+        pipeline_id: int | str,
+        result_repo_name: Literal["chunk_results", "image_chunk_results"],
+    ) -> None:
+        """Reject persistence when the same pipeline already has rows in the opposite result table."""
+        opposite_repo_name: Literal["chunk_results", "image_chunk_results"] = (
+            "image_chunk_results" if result_repo_name == "chunk_results" else "chunk_results"
+        )
+        opposite_results = getattr(uow, opposite_repo_name).get_by_pipeline(pipeline_id, limit=1)
+        if opposite_results:
+            opposite_unit = "image_chunk" if opposite_repo_name == "image_chunk_results" else "chunk"
+            target_unit = "image_chunk" if result_repo_name == "image_chunk_results" else "chunk"
+            msg = (
+                f"Pipeline {pipeline_id!r} already has {opposite_unit} results; "
+                f"refusing to persist {target_unit} results into the same pipeline identity."
+            )
+            raise ValueError(msg)
+
+    def _validate_pipeline_result_namespace(
+        self,
+        uow: RetrievalUnitOfWork,
+        pipeline_id: int | str,
+        result_repo_name: Literal["chunk_results", "image_chunk_results"],
+    ) -> None:
+        """Validate that persisted pipeline config matches the selected result namespace."""
+        pipeline = uow.pipelines.get_by_id(pipeline_id)
+        if pipeline is None:
+            return
+
+        configured_unit = self._get_config_retrieval_unit(pipeline.config)
+        target_unit = "image_chunk" if result_repo_name == "image_chunk_results" else "chunk"
+        if configured_unit == "mixed":
+            msg = f"Pipeline {pipeline_id!r} is configured for mixed results, which cannot be persisted directly."
+            raise ValueError(msg)
+        if configured_unit != target_unit:
+            msg = (
+                f"Pipeline {pipeline_id!r} is configured for {configured_unit} results; "
+                f"refusing to persist {target_unit} results into the same pipeline identity."
+            )
+            raise ValueError(msg)
 
     def _collect_retrieval_results(
         self,
@@ -194,6 +258,8 @@ class RetrievalPipelineService(BasePipelineService):
             )
 
             with self._create_uow() as uow:
+                self._validate_pipeline_result_namespace(uow, pipeline_id, result_repo_name)
+                self._reject_opposite_result_namespace(uow, pipeline_id, result_repo_name)
                 queries = uow.queries.get_all(limit=effective_batch_size, offset=offset)
                 if not queries:
                     break

--- a/autorag_research/pipelines/retrieval/__init__.py
+++ b/autorag_research/pipelines/retrieval/__init__.py
@@ -1,4 +1,4 @@
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, RetrievalUnit
 from autorag_research.pipelines.retrieval.bm25 import BM25PipelineConfig, BM25RetrievalPipeline
 from autorag_research.pipelines.retrieval.heaven import (
     HEAVENPipelineConfig,
@@ -59,6 +59,7 @@ __all__ = [
     "QuestionDecompositionRetrievalPipelineConfig",
     "RerankRetrievalPipeline",
     "RerankRetrievalPipelineConfig",
+    "RetrievalUnit",
     "RetroStarPipelineConfig",
     "RetroStarRetrievalPipeline",
     "VectorSearchPipelineConfig",

--- a/autorag_research/pipelines/retrieval/base.py
+++ b/autorag_research/pipelines/retrieval/base.py
@@ -5,7 +5,7 @@ Provides abstract base class for all retrieval pipelines.
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Literal, cast
 
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -13,6 +13,8 @@ from autorag_research.orm.service.retrieval_pipeline import RetrievalPipelineSer
 from autorag_research.pipelines.base import BasePipeline
 
 logger = logging.getLogger("AutoRAG-Research")
+
+RetrievalUnit = Literal["chunk", "image_chunk", "mixed"]
 
 
 def get_retrieval_pipeline_config(pipeline: object) -> dict[str, Any]:
@@ -22,6 +24,20 @@ def get_retrieval_pipeline_config(pipeline: object) -> dict[str, Any]:
         return {}
     config = get_config()
     return config if isinstance(config, dict) else {}
+
+
+def get_retrieval_pipeline_unit(pipeline: object) -> RetrievalUnit | None:
+    """Return the first-class retrieval unit exposed by a retrieval pipeline.
+
+    Prefer the typed ``retrieval_unit`` interface and only fall back to legacy
+    persisted config metadata for older or mocked pipeline-like objects.
+    """
+    retrieval_unit = getattr(pipeline, "retrieval_unit", None)
+    if isinstance(retrieval_unit, str):
+        return cast("RetrievalUnit", retrieval_unit)
+
+    config_unit = get_retrieval_pipeline_config(pipeline).get("retrieval_unit")
+    return cast("RetrievalUnit", config_unit) if isinstance(config_unit, str) else None
 
 
 class BaseRetrievalPipeline(BasePipeline, ABC):
@@ -37,6 +53,8 @@ class BaseRetrievalPipeline(BasePipeline, ABC):
     - `_retrieve_by_text()`: Async method for retrieval using raw query text
     - `_get_pipeline_config()`: Return the pipeline configuration dict
     """
+
+    retrieval_unit: RetrievalUnit | None = None
 
     def __init__(
         self,

--- a/autorag_research/pipelines/retrieval/base.py
+++ b/autorag_research/pipelines/retrieval/base.py
@@ -15,6 +15,14 @@ from autorag_research.pipelines.base import BasePipeline
 logger = logging.getLogger("AutoRAG-Research")
 
 RetrievalUnit = Literal["chunk", "image_chunk", "mixed"]
+VALID_RETRIEVAL_UNITS: set[str] = {"chunk", "image_chunk", "mixed"}
+
+
+def _coerce_retrieval_unit(value: object) -> RetrievalUnit | None:
+    """Return a valid retrieval unit or None for unknown values."""
+    if isinstance(value, str) and value in VALID_RETRIEVAL_UNITS:
+        return cast("RetrievalUnit", value)
+    return None
 
 
 def get_retrieval_pipeline_config(pipeline: object) -> dict[str, Any]:
@@ -33,11 +41,14 @@ def get_retrieval_pipeline_unit(pipeline: object) -> RetrievalUnit | None:
     persisted config metadata for older or mocked pipeline-like objects.
     """
     retrieval_unit = getattr(pipeline, "retrieval_unit", None)
+    typed_unit = _coerce_retrieval_unit(retrieval_unit)
+    if typed_unit is not None:
+        return typed_unit
     if isinstance(retrieval_unit, str):
-        return cast("RetrievalUnit", retrieval_unit)
+        return None
 
     config_unit = get_retrieval_pipeline_config(pipeline).get("retrieval_unit")
-    return cast("RetrievalUnit", config_unit) if isinstance(config_unit, str) else None
+    return _coerce_retrieval_unit(config_unit)
 
 
 class BaseRetrievalPipeline(BasePipeline, ABC):
@@ -173,7 +184,15 @@ class BaseRetrievalPipeline(BasePipeline, ABC):
             - total_results: Number of results stored
             - failed_queries: List of query IDs that failed after all retries
         """
-        return self._service.run_pipeline(
+        retrieval_unit = get_retrieval_pipeline_unit(self) or "chunk"
+        if retrieval_unit == "mixed":
+            msg = "Mixed retrieval_unit persistence is not supported; override run() with an explicit persistence path."
+            raise ValueError(msg)
+
+        run_pipeline = (
+            self._service.run_image_pipeline if retrieval_unit == "image_chunk" else self._service.run_pipeline
+        )
+        return run_pipeline(
             retrieval_func=self._retrieve_by_id,  # Use ID-based for batch processing
             pipeline_id=self.pipeline_id,
             top_k=top_k,

--- a/autorag_research/pipelines/retrieval/base.py
+++ b/autorag_research/pipelines/retrieval/base.py
@@ -5,24 +5,15 @@ Provides abstract base class for all retrieval pipelines.
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Literal, cast
+from typing import Any
 
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.orm.service.retrieval_pipeline import RetrievalPipelineService
 from autorag_research.pipelines.base import BasePipeline
+from autorag_research.retrieval_units import RetrievalUnit, require_retrieval_unit
 
 logger = logging.getLogger("AutoRAG-Research")
-
-RetrievalUnit = Literal["chunk", "image_chunk", "mixed"]
-VALID_RETRIEVAL_UNITS: set[str] = {"chunk", "image_chunk", "mixed"}
-
-
-def _coerce_retrieval_unit(value: object) -> RetrievalUnit | None:
-    """Return a valid retrieval unit or None for unknown values."""
-    if isinstance(value, str) and value in VALID_RETRIEVAL_UNITS:
-        return cast("RetrievalUnit", value)
-    return None
 
 
 def get_retrieval_pipeline_config(pipeline: object) -> dict[str, Any]:
@@ -41,14 +32,12 @@ def get_retrieval_pipeline_unit(pipeline: object) -> RetrievalUnit | None:
     persisted config metadata for older or mocked pipeline-like objects.
     """
     retrieval_unit = getattr(pipeline, "retrieval_unit", None)
-    typed_unit = _coerce_retrieval_unit(retrieval_unit)
+    typed_unit = require_retrieval_unit(retrieval_unit)
     if typed_unit is not None:
         return typed_unit
-    if isinstance(retrieval_unit, str):
-        return None
 
     config_unit = get_retrieval_pipeline_config(pipeline).get("retrieval_unit")
-    return _coerce_retrieval_unit(config_unit)
+    return require_retrieval_unit(config_unit)
 
 
 class BaseRetrievalPipeline(BasePipeline, ABC):

--- a/autorag_research/pipelines/retrieval/bm25.py
+++ b/autorag_research/pipelines/retrieval/bm25.py
@@ -98,6 +98,8 @@ class BM25RetrievalPipeline(BaseRetrievalPipeline):
         ```
     """
 
+    retrieval_unit = "chunk"
+
     def __init__(
         self,
         session_factory: sessionmaker[Session],
@@ -132,7 +134,7 @@ class BM25RetrievalPipeline(BaseRetrievalPipeline):
         """Return BM25 pipeline configuration."""
         return {
             "type": "bm25",
-            "retrieval_unit": "chunk",
+            "retrieval_unit": self.retrieval_unit,
             "tokenizer": self.tokenizer,
             "index_name": self.index_name,
         }

--- a/autorag_research/pipelines/retrieval/heaven.py
+++ b/autorag_research/pipelines/retrieval/heaven.py
@@ -142,6 +142,8 @@ class HEAVENPipelineConfig(BaseRetrievalPipelineConfig):
 class HEAVENRetrievalPipeline(BaseRetrievalPipeline):
     """Two-stage HEAVEN retrieval pipeline over ImageChunk records."""
 
+    retrieval_unit = "image_chunk"
+
     def __init__(
         self,
         session_factory: sessionmaker[Session],
@@ -180,7 +182,7 @@ class HEAVENRetrievalPipeline(BaseRetrievalPipeline):
         """Return HEAVEN pipeline configuration."""
         return {
             "type": "heaven",
-            "retrieval_unit": "image_chunk",
+            "retrieval_unit": self.retrieval_unit,
             "stage1_candidate_count": self.stage1_candidate_count,
             "stage2_refine_ratio": self.stage2_refine_ratio,
             "stage1_weight": self.stage1_weight,

--- a/autorag_research/pipelines/retrieval/hybrid.py
+++ b/autorag_research/pipelines/retrieval/hybrid.py
@@ -14,7 +14,11 @@ from typing import Any, Literal
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
+from autorag_research.pipelines.retrieval.base import (
+    BaseRetrievalPipeline,
+    RetrievalUnit,
+    get_retrieval_pipeline_unit,
+)
 from autorag_research.pipelines.retrieval.loader import RetrievalPipelineLoader
 from autorag_research.util import (
     normalize_dbsf,
@@ -358,12 +362,11 @@ class HybridRetrievalPipeline(BaseRetrievalPipeline, ABC):
             name,
         )
 
-    def _get_combined_retrieval_unit(self) -> str | None:
+    @property
+    def retrieval_unit(self) -> RetrievalUnit | None:
         """Return the shared retrieval unit when both wrapped pipelines declare the same one."""
-        config_1 = get_retrieval_pipeline_config(self._retrieval_pipeline_1)
-        config_2 = get_retrieval_pipeline_config(self._retrieval_pipeline_2)
-        retrieval_unit_1 = config_1.get("retrieval_unit")
-        retrieval_unit_2 = config_2.get("retrieval_unit")
+        retrieval_unit_1 = get_retrieval_pipeline_unit(self._retrieval_pipeline_1)
+        retrieval_unit_2 = get_retrieval_pipeline_unit(self._retrieval_pipeline_2)
         if retrieval_unit_1 == retrieval_unit_2:
             return retrieval_unit_1
         return "mixed"
@@ -505,7 +508,7 @@ class HybridRRFRetrievalPipeline(HybridRetrievalPipeline):
         """Return Hybrid RRF pipeline configuration."""
         return {
             "type": "hybrid_rrf",
-            "retrieval_unit": self._get_combined_retrieval_unit(),
+            "retrieval_unit": self.retrieval_unit,
             "retrieval_pipeline_1": self._retrieval_pipeline_1.name,
             "retrieval_pipeline_2": self._retrieval_pipeline_2.name,
             "rrf_k": self.rrf_k,
@@ -599,7 +602,7 @@ class HybridCCRetrievalPipeline(HybridRetrievalPipeline):
         """Return Hybrid CC pipeline configuration."""
         config = {
             "type": "hybrid_cc",
-            "retrieval_unit": self._get_combined_retrieval_unit(),
+            "retrieval_unit": self.retrieval_unit,
             "retrieval_pipeline_1": self._retrieval_pipeline_1.name,
             "retrieval_pipeline_2": self._retrieval_pipeline_2.name,
             "weight": self.weight,

--- a/autorag_research/pipelines/retrieval/hybrid.py
+++ b/autorag_research/pipelines/retrieval/hybrid.py
@@ -328,6 +328,7 @@ class HybridRetrievalPipeline(BaseRetrievalPipeline, ABC):
         self._retrieval_pipeline_1 = retrieval_pipeline_1
         self._retrieval_pipeline_2 = retrieval_pipeline_2
         self.fetch_k_multiplier = fetch_k_multiplier
+        self._validate_supported_retrieval_units()
 
         super().__init__(session_factory, name, schema)
 
@@ -370,6 +371,13 @@ class HybridRetrievalPipeline(BaseRetrievalPipeline, ABC):
         if retrieval_unit_1 == retrieval_unit_2:
             return retrieval_unit_1
         return "mixed"
+
+    def _validate_supported_retrieval_units(self) -> None:
+        """Reject mixed namespaces before raw doc_id fusion can collide IDs."""
+        retrieval_unit = self.retrieval_unit
+        if retrieval_unit == "mixed":
+            msg = "Mixed retrieval_unit hybrid pipelines are not supported until fused results carry entity namespaces."
+            raise ValueError(msg)
 
     @abstractmethod
     def _fuse_results(

--- a/autorag_research/pipelines/retrieval/hyde.py
+++ b/autorag_research/pipelines/retrieval/hyde.py
@@ -120,6 +120,8 @@ class HyDERetrievalPipeline(BaseRetrievalPipeline):
         ```
     """
 
+    retrieval_unit = "chunk"
+
     def __init__(
         self,
         session_factory: sessionmaker[Session],
@@ -159,7 +161,7 @@ class HyDERetrievalPipeline(BaseRetrievalPipeline):
         """
         return {
             "type": "hyde",
-            "retrieval_unit": "chunk",
+            "retrieval_unit": self.retrieval_unit,
             "prompt_template": self.prompt_template,
         }
 

--- a/autorag_research/pipelines/retrieval/power_of_noise.py
+++ b/autorag_research/pipelines/retrieval/power_of_noise.py
@@ -15,7 +15,11 @@ from typing import Any, Literal, cast
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
+from autorag_research.pipelines.retrieval.base import (
+    BaseRetrievalPipeline,
+    RetrievalUnit,
+    get_retrieval_pipeline_unit,
+)
 from autorag_research.pipelines.retrieval.hybrid import HybridRetrievalPipeline
 
 NoiseOrder = Literal["retrieved_first", "noise_first", "interleave"]
@@ -97,12 +101,15 @@ class PowerOfNoiseRetrievalPipeline(BaseRetrievalPipeline):
 
         super().__init__(session_factory, name, schema)
 
+    @property
+    def retrieval_unit(self) -> RetrievalUnit | None:
+        return get_retrieval_pipeline_unit(self._base_retrieval_pipeline)
+
     def _get_pipeline_config(self) -> dict[str, Any]:
         """Return pipeline configuration for persistence."""
-        wrapped_config = get_retrieval_pipeline_config(self._base_retrieval_pipeline)
         return {
             "type": "power_of_noise",
-            "retrieval_unit": wrapped_config.get("retrieval_unit"),
+            "retrieval_unit": self.retrieval_unit,
             "base_retrieval_pipeline": self._base_retrieval_pipeline.name,
             "noise_count": self.noise_count,
             "noise_ratio": self.noise_ratio,

--- a/autorag_research/pipelines/retrieval/power_of_noise.py
+++ b/autorag_research/pipelines/retrieval/power_of_noise.py
@@ -98,12 +98,23 @@ class PowerOfNoiseRetrievalPipeline(BaseRetrievalPipeline):
         self.noise_order = noise_order
         self.noise_mode = noise_mode
         self.seed = seed
+        self._validate_noise_retrieval_unit()
 
         super().__init__(session_factory, name, schema)
 
     @property
     def retrieval_unit(self) -> RetrievalUnit | None:
         return get_retrieval_pipeline_unit(self._base_retrieval_pipeline)
+
+    def _has_text_noise_enabled(self) -> bool:
+        """Return whether this wrapper will inject text chunk noise."""
+        return self.noise_count > 0 or (self.noise_ratio is not None and self.noise_ratio > 0)
+
+    def _validate_noise_retrieval_unit(self) -> None:
+        """Fail closed when text noise would be mixed into non-text results."""
+        if self._has_text_noise_enabled() and self.retrieval_unit != "chunk":
+            msg = "PowerOfNoiseRetrievalPipeline with text noise requires a text chunk retrieval pipeline."
+            raise ValueError(msg)
 
     def _get_pipeline_config(self) -> dict[str, Any]:
         """Return pipeline configuration for persistence."""

--- a/autorag_research/pipelines/retrieval/query_rewrite.py
+++ b/autorag_research/pipelines/retrieval/query_rewrite.py
@@ -19,7 +19,11 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.injection import health_check_llm
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
+from autorag_research.pipelines.retrieval.base import (
+    BaseRetrievalPipeline,
+    RetrievalUnit,
+    get_retrieval_pipeline_unit,
+)
 
 logger = logging.getLogger("AutoRAG-Research")
 
@@ -92,16 +96,19 @@ class QueryRewriteRetrievalPipeline(BaseRetrievalPipeline):
 
         super().__init__(session_factory, name, schema)
 
+    @property
+    def retrieval_unit(self) -> RetrievalUnit | None:
+        """Return the retrieval unit produced by the wrapped pipeline."""
+        return get_retrieval_pipeline_unit(self._retrieval_pipeline)
+
     def _get_pipeline_config(self) -> dict[str, Any]:
         """Return query rewrite pipeline configuration for storage."""
         model_name = getattr(self.llm, "model_name", None)
         if model_name is None or not isinstance(model_name, str):
             model_name = type(self.llm).__name__
-        wrapped_config = get_retrieval_pipeline_config(self._retrieval_pipeline)
-
         return {
             "type": "query_rewrite",
-            "retrieval_unit": wrapped_config.get("retrieval_unit"),
+            "retrieval_unit": self.retrieval_unit,
             "prompt_template": self.prompt_template,
             "retrieval_pipeline_id": getattr(self._retrieval_pipeline, "pipeline_id", None),
             "wrapped_pipeline_type": type(self._retrieval_pipeline).__name__,

--- a/autorag_research/pipelines/retrieval/question_decomposition.py
+++ b/autorag_research/pipelines/retrieval/question_decomposition.py
@@ -8,7 +8,11 @@ from langchain_core.language_models import BaseLanguageModel
 from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
+from autorag_research.pipelines.retrieval.base import (
+    BaseRetrievalPipeline,
+    RetrievalUnit,
+    get_retrieval_pipeline_unit,
+)
 from autorag_research.rerankers.base import BaseReranker
 
 DEFAULT_DECOMPOSITION_PROMPT = """You are decomposing a question for retrieval-augmented generation.
@@ -100,11 +104,14 @@ class QuestionDecompositionRetrievalPipeline(BaseRetrievalPipeline):
 
         super().__init__(session_factory, name, schema)
 
+    @property
+    def retrieval_unit(self) -> RetrievalUnit | None:
+        return get_retrieval_pipeline_unit(self._inner_retrieval_pipeline)
+
     def _get_pipeline_config(self) -> dict[str, Any]:
-        wrapped_config = get_retrieval_pipeline_config(self._inner_retrieval_pipeline)
         return {
             "type": "question_decomposition",
-            "retrieval_unit": wrapped_config.get("retrieval_unit"),
+            "retrieval_unit": self.retrieval_unit,
             "max_subquestions": self.max_subquestions,
             "fetch_k_multiplier": self.fetch_k_multiplier,
             "decomposition_prompt_template": self._decomposition_prompt_template,

--- a/autorag_research/pipelines/retrieval/rerank.py
+++ b/autorag_research/pipelines/retrieval/rerank.py
@@ -15,7 +15,11 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
+from autorag_research.pipelines.retrieval.base import (
+    BaseRetrievalPipeline,
+    get_retrieval_pipeline_config,
+    get_retrieval_pipeline_unit,
+)
 from autorag_research.rerankers.base import BaseReranker, RerankResult
 
 TEXT_RETRIEVAL_UNIT = "chunk"
@@ -24,7 +28,7 @@ TEXT_RETRIEVAL_UNIT = "chunk"
 def _validate_text_retrieval_pipeline(pipeline: BaseRetrievalPipeline) -> None:
     """Reject wrapped pipelines whose persisted results are not text chunks."""
     config = get_retrieval_pipeline_config(pipeline)
-    retrieval_unit = config.get("retrieval_unit")
+    retrieval_unit = get_retrieval_pipeline_unit(pipeline)
     pipeline_type = config.get("type", type(pipeline).__name__)
     if retrieval_unit is None:
         msg = (
@@ -81,6 +85,8 @@ class RerankRetrievalPipelineConfig(BaseRetrievalPipelineConfig):
 
 class RerankRetrievalPipeline(BaseRetrievalPipeline):
     """Text chunk retriever → reranker retrieval wrapper."""
+
+    retrieval_unit = TEXT_RETRIEVAL_UNIT
 
     def __init__(
         self,

--- a/autorag_research/pipelines/retrieval/retro_star.py
+++ b/autorag_research/pipelines/retrieval/retro_star.py
@@ -23,7 +23,11 @@ from sqlalchemy.orm import Session, sessionmaker
 from autorag_research.config import BaseRetrievalPipelineConfig
 from autorag_research.injection import health_check_llm
 from autorag_research.orm.uow.retrieval_uow import RetrievalUnitOfWork
-from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_config
+from autorag_research.pipelines.retrieval.base import (
+    BaseRetrievalPipeline,
+    RetrievalUnit,
+    get_retrieval_pipeline_unit,
+)
 from autorag_research.util import truncate_texts
 
 DEFAULT_RETRO_STAR_RELEVANCE_DEFINITION = (
@@ -231,16 +235,19 @@ class RetroStarRetrievalPipeline(BaseRetrievalPipeline):
 
         super().__init__(session_factory, name, schema)
 
+    @property
+    def retrieval_unit(self) -> RetrievalUnit | None:
+        """Return the retrieval unit produced by the wrapped pipeline."""
+        return get_retrieval_pipeline_unit(self._retrieval_pipeline)
+
     def _get_pipeline_config(self) -> dict[str, Any]:
         """Return RETRO* pipeline configuration for storage."""
         model_name = getattr(self.llm, "model_name", None)
         if model_name is None or not isinstance(model_name, str):
             model_name = type(self.llm).__name__
-        wrapped_config = get_retrieval_pipeline_config(self._retrieval_pipeline)
-
         return {
             "type": "retro_star",
-            "retrieval_unit": wrapped_config.get("retrieval_unit"),
+            "retrieval_unit": self.retrieval_unit,
             "candidate_top_k": self.candidate_top_k,
             "prompt_template": self.prompt_template,
             "relevance_definition": self.relevance_definition,

--- a/autorag_research/pipelines/retrieval/vector_search.py
+++ b/autorag_research/pipelines/retrieval/vector_search.py
@@ -113,6 +113,8 @@ class VectorSearchRetrievalPipeline(BaseRetrievalPipeline):
         ```
     """
 
+    retrieval_unit = "chunk"
+
     def __init__(
         self,
         session_factory: sessionmaker[Session],
@@ -148,7 +150,7 @@ class VectorSearchRetrievalPipeline(BaseRetrievalPipeline):
         """
         return {
             "type": "vector_search",
-            "retrieval_unit": "chunk",
+            "retrieval_unit": self.retrieval_unit,
             "search_mode": self.search_mode,
         }
 

--- a/autorag_research/retrieval_units.py
+++ b/autorag_research/retrieval_units.py
@@ -25,5 +25,5 @@ def require_retrieval_unit(value: object, *, default: RetrievalUnit | None = Non
     if isinstance(value, str):
         valid_values = ", ".join(sorted(VALID_RETRIEVAL_UNITS))
         msg = f"Invalid retrieval_unit '{value}'. Expected one of: {valid_values}."
-        raise ValueError(msg)
+        raise ValueError(msg)  # noqa: TRY004 - invalid retrieval_unit strings are invalid values, not types.
     return default

--- a/autorag_research/retrieval_units.py
+++ b/autorag_research/retrieval_units.py
@@ -1,0 +1,29 @@
+"""Shared retrieval-unit validation helpers."""
+
+from typing import Literal, cast
+
+RetrievalUnit = Literal["chunk", "image_chunk", "mixed"]
+VALID_RETRIEVAL_UNITS: frozenset[str] = frozenset({"chunk", "image_chunk", "mixed"})
+
+
+def coerce_retrieval_unit(value: object) -> RetrievalUnit | None:
+    """Return a valid retrieval unit or None for missing values."""
+    if value is None:
+        return None
+    if isinstance(value, str) and value in VALID_RETRIEVAL_UNITS:
+        return cast("RetrievalUnit", value)
+    return None
+
+
+def require_retrieval_unit(value: object, *, default: RetrievalUnit | None = None) -> RetrievalUnit | None:
+    """Return a valid retrieval unit, default missing values, and reject invalid explicit strings."""
+    unit = coerce_retrieval_unit(value)
+    if unit is not None:
+        return unit
+    if value is None:
+        return default
+    if isinstance(value, str):
+        valid_values = ", ".join(sorted(VALID_RETRIEVAL_UNITS))
+        msg = f"Invalid retrieval_unit '{value}'. Expected one of: {valid_values}."
+        raise ValueError(msg)
+    return default

--- a/tests/autorag_research/orm/service/test_retrieval_pipeline.py
+++ b/tests/autorag_research/orm/service/test_retrieval_pipeline.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import Session, sessionmaker
@@ -6,6 +7,36 @@ from sqlalchemy.orm import Session, sessionmaker
 from autorag_research.orm.repository.query import QueryRepository
 from autorag_research.orm.schema import Chunk
 from autorag_research.orm.service.retrieval_pipeline import RetrievalPipelineService
+
+
+class _FakeRetrievalUow:
+    def __init__(self, *, existing_pipeline=None, chunk_results=None, image_chunk_results=None):
+        self.pipelines = MagicMock()
+        self.pipelines.get_by_name.return_value = existing_pipeline
+        self.pipelines.get_by_id.return_value = existing_pipeline
+        self.chunk_results = MagicMock()
+        self.chunk_results.get_by_pipeline.return_value = chunk_results or []
+        self.image_chunk_results = MagicMock()
+        self.image_chunk_results.get_by_pipeline.return_value = image_chunk_results or []
+        self.queries = MagicMock()
+        self.queries.get_all.return_value = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def commit(self):
+        return None
+
+
+class _FakeRetrievalPipelineService(RetrievalPipelineService):
+    def __init__(self, fake_uow):
+        self._fake_uow = fake_uow
+
+    def _create_uow(self):
+        return self._fake_uow
 
 
 class TestRetrievalPipelineService:
@@ -111,6 +142,51 @@ class TestRetrievalPipelineService:
         with service._create_uow() as uow:
             results_after = uow.image_chunk_results.get_by_pipeline(pipeline_id)
             assert len(results_after) == 0
+
+    def test_get_or_create_pipeline_rejects_retrieval_unit_drift(self):
+        existing_pipeline = SimpleNamespace(id=7, config={"type": "existing", "retrieval_unit": "chunk"})
+        service = _FakeRetrievalPipelineService(_FakeRetrievalUow(existing_pipeline=existing_pipeline))
+
+        with pytest.raises(ValueError, match="retrieval_unit changed from 'chunk' to 'image_chunk'"):
+            service.get_or_create_pipeline(
+                name="same-name",
+                config={"type": "existing", "retrieval_unit": "image_chunk"},
+            )
+
+    def test_get_or_create_pipeline_rejects_invalid_retrieval_unit_config(self):
+        service = _FakeRetrievalPipelineService(_FakeRetrievalUow())
+
+        with pytest.raises(ValueError, match="Invalid retrieval_unit 'image_chunks'"):
+            service.get_or_create_pipeline(
+                name="invalid-unit",
+                config={"type": "existing", "retrieval_unit": "image_chunks"},
+            )
+
+    def test_run_image_pipeline_rejects_existing_chunk_results_for_same_pipeline_id(self, mock_retrieval_func):
+        service = _FakeRetrievalPipelineService(_FakeRetrievalUow(chunk_results=[SimpleNamespace(id=1)]))
+
+        with pytest.raises(ValueError, match="already has chunk results"):
+            service.run_image_pipeline(retrieval_func=mock_retrieval_func, pipeline_id=7)
+
+    def test_run_pipeline_rejects_existing_image_results_for_same_pipeline_id(self, mock_retrieval_func):
+        service = _FakeRetrievalPipelineService(_FakeRetrievalUow(image_chunk_results=[SimpleNamespace(id=1)]))
+
+        with pytest.raises(ValueError, match="already has image_chunk results"):
+            service.run_pipeline(retrieval_func=mock_retrieval_func, pipeline_id=7)
+
+    def test_run_pipeline_rejects_image_config_before_chunk_persistence(self, mock_retrieval_func):
+        existing_pipeline = SimpleNamespace(id=7, config={"type": "existing", "retrieval_unit": "image_chunk"})
+        service = _FakeRetrievalPipelineService(_FakeRetrievalUow(existing_pipeline=existing_pipeline))
+
+        with pytest.raises(ValueError, match="configured for image_chunk results"):
+            service.run_pipeline(retrieval_func=mock_retrieval_func, pipeline_id=7)
+
+    def test_run_image_pipeline_rejects_chunk_config_before_image_persistence(self, mock_retrieval_func):
+        existing_pipeline = SimpleNamespace(id=7, config={"type": "existing", "retrieval_unit": "chunk"})
+        service = _FakeRetrievalPipelineService(_FakeRetrievalUow(existing_pipeline=existing_pipeline))
+
+        with pytest.raises(ValueError, match="configured for chunk results"):
+            service.run_image_pipeline(retrieval_func=mock_retrieval_func, pipeline_id=7)
 
 
 class TestVectorSearchByEmbedding:

--- a/tests/autorag_research/pipelines/retrieval/test_base_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_base_pipeline.py
@@ -1,0 +1,66 @@
+"""Non-DB tests for base retrieval pipeline unit behavior."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline, get_retrieval_pipeline_unit
+
+
+class _RunDispatchPipeline(BaseRetrievalPipeline):
+    async def _retrieve_by_id(self, query_id: int | str, top_k: int) -> list[dict[str, Any]]:
+        return []
+
+    async def _retrieve_by_text(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        return []
+
+    def _get_pipeline_config(self) -> dict[str, Any]:
+        return {"type": "run_dispatch", "retrieval_unit": self.retrieval_unit}
+
+
+def _pipeline_with_service(retrieval_unit: str | None) -> _RunDispatchPipeline:
+    pipeline = _RunDispatchPipeline.__new__(_RunDispatchPipeline)
+    pipeline.retrieval_unit = retrieval_unit
+    pipeline.pipeline_id = 42
+    pipeline._service = MagicMock()
+    pipeline._service.run_pipeline.return_value = {"pipeline_id": 42, "total_queries": 1, "total_results": 1}
+    pipeline._service.run_image_pipeline.return_value = {"pipeline_id": 42, "total_queries": 1, "total_results": 1}
+    return pipeline
+
+
+def test_run_dispatches_image_unit_to_image_persistence():
+    pipeline = _pipeline_with_service("image_chunk")
+
+    result = pipeline.run(top_k=3, query_limit=2)
+
+    assert result == {"pipeline_id": 42, "total_queries": 1, "total_results": 1}
+    pipeline._service.run_image_pipeline.assert_called_once_with(
+        retrieval_func=pipeline._retrieve_by_id,
+        pipeline_id=42,
+        top_k=3,
+        batch_size=128,
+        max_concurrency=16,
+        max_retries=3,
+        retry_delay=1.0,
+        query_limit=2,
+    )
+    pipeline._service.run_pipeline.assert_not_called()
+
+
+def test_run_rejects_mixed_unit_until_mixed_persistence_exists():
+    pipeline = _pipeline_with_service("mixed")
+
+    with pytest.raises(ValueError, match="Mixed retrieval_unit persistence is not supported"):
+        pipeline.run()
+
+    pipeline._service.run_pipeline.assert_not_called()
+    pipeline._service.run_image_pipeline.assert_not_called()
+
+
+def test_get_retrieval_pipeline_unit_rejects_unknown_typed_value():
+    pipeline = MagicMock()
+    pipeline.retrieval_unit = "chunks"
+    pipeline._get_pipeline_config.return_value = {"retrieval_unit": "chunk"}
+
+    assert get_retrieval_pipeline_unit(pipeline) is None

--- a/tests/autorag_research/pipelines/retrieval/test_base_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_base_pipeline.py
@@ -63,4 +63,15 @@ def test_get_retrieval_pipeline_unit_rejects_unknown_typed_value():
     pipeline.retrieval_unit = "chunks"
     pipeline._get_pipeline_config.return_value = {"retrieval_unit": "chunk"}
 
-    assert get_retrieval_pipeline_unit(pipeline) is None
+    with pytest.raises(ValueError, match="Invalid retrieval_unit 'chunks'"):
+        get_retrieval_pipeline_unit(pipeline)
+
+
+def test_run_rejects_invalid_explicit_unit_before_persistence_dispatch():
+    pipeline = _pipeline_with_service("image_chunks")
+
+    with pytest.raises(ValueError, match="Invalid retrieval_unit 'image_chunks'"):
+        pipeline.run()
+
+    pipeline._service.run_pipeline.assert_not_called()
+    pipeline._service.run_image_pipeline.assert_not_called()

--- a/tests/autorag_research/pipelines/retrieval/test_hybrid_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_hybrid_pipeline.py
@@ -729,3 +729,28 @@ class TestHybridCCRetrievalPipeline:
 
         # With weight=1.0, doc_1 should be first (highest in pipeline_1)
         assert fused[0]["doc_id"] == 1
+
+
+class TestHybridRetrievalUnitValidation:
+    """Tests for fail-closed hybrid retrieval-unit handling."""
+
+    def test_rejects_mixed_text_and_image_units_before_fusion(self):
+        text_pipeline = MagicMock(name="text_pipeline")
+        text_pipeline.name = "text"
+        text_pipeline.retrieval_unit = "chunk"
+        text_pipeline._get_pipeline_config.return_value = {"type": "text", "retrieval_unit": "chunk"}
+        image_pipeline = MagicMock(name="image_pipeline")
+        image_pipeline.name = "image"
+        image_pipeline.retrieval_unit = "image_chunk"
+        image_pipeline._get_pipeline_config.return_value = {"type": "image", "retrieval_unit": "image_chunk"}
+
+        with (
+            patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None),
+            pytest.raises(ValueError, match="Mixed retrieval_unit hybrid pipelines are not supported"),
+        ):
+            HybridRRFRetrievalPipeline(
+                session_factory=MagicMock(),
+                name="mixed_hybrid",
+                retrieval_pipeline_1=text_pipeline,
+                retrieval_pipeline_2=image_pipeline,
+            )

--- a/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy import delete
@@ -430,3 +430,18 @@ class TestPowerOfNoiseRetrievalPipeline:
             ),
         )
         verifier.verify_all()
+
+    def test_creation_rejects_image_pipeline_when_text_noise_enabled(self):
+        image_pipeline = SimpleNamespace(
+            name="heaven",
+            retrieval_unit="image_chunk",
+            _get_pipeline_config=lambda: {"type": "heaven", "retrieval_unit": "image_chunk"},
+        )
+
+        with pytest.raises(ValueError, match="text chunk retrieval pipeline"):
+            PowerOfNoiseRetrievalPipeline(
+                session_factory=MagicMock(),
+                name="test_power_of_noise_image_with_text_noise",
+                base_retrieval_pipeline=image_pipeline,
+                noise_count=1,
+            )

--- a/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py
@@ -350,6 +350,7 @@ class TestPowerOfNoiseRetrievalPipeline:
         created_pipeline_ids, _ = cleanup_pipeline_results
         underfilled_base = SimpleNamespace(
             name="vector_search",
+            retrieval_unit="chunk",
             _retrieve_by_id=AsyncMock(return_value=[{"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"}]),
             _retrieve_by_text=AsyncMock(return_value=[{"doc_id": 2, "score": 0.9, "content": "Chunk 1-2"}]),
         )

--- a/tests/autorag_research/pipelines/retrieval/test_query_rewrite_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_query_rewrite_pipeline.py
@@ -116,6 +116,22 @@ class TestQueryRewriteRetrievalPipeline:
                 prompt_template="Rewrite without placeholder",
             )
 
+    def test_pipeline_config_propagates_typed_retrieval_unit_without_legacy_config(self):
+        wrapped_retrieval = create_mock_retrieval_pipeline()
+        wrapped_retrieval.retrieval_unit = "chunk"
+        wrapped_retrieval._get_pipeline_config.return_value = {"type": "typed_text_wrapper"}
+
+        with patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None):
+            pipeline = QueryRewriteRetrievalPipeline(
+                session_factory=MagicMock(),
+                name="query_rewrite_typed_unit",
+                llm=FakeListLLM(responses=["rewritten query"]),
+                retrieval_pipeline=wrapped_retrieval,
+            )
+
+        assert pipeline.retrieval_unit == "chunk"
+        assert pipeline._get_pipeline_config()["retrieval_unit"] == "chunk"
+
     @pytest.mark.asyncio
     async def test_rewrite_query_uses_prompt_template(self, session_factory, cleanup_pipeline_results: list[int]):
         llm = MagicMock()

--- a/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
+++ b/tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py
@@ -119,6 +119,33 @@ class TestRerankRetrievalPipelineConfig:
         with pytest.raises(ValueError, match="must declare retrieval_unit='chunk'"):
             config.inject_retrieval_pipeline(wrapped_retrieval)
 
+    def test_inject_retrieval_pipeline_accepts_typed_text_retrieval_unit(self):
+        wrapped_retrieval = create_mock_retrieval_pipeline(pipeline_id=77)
+        wrapped_retrieval.retrieval_unit = "chunk"
+        wrapped_retrieval._get_pipeline_config.return_value = {"type": "mock_without_legacy_unit"}
+        config = RerankRetrievalPipelineConfig(
+            name="rerank",
+            retrieval_pipeline_name="typed_text",
+            reranker=FakeReranker(),
+        )
+
+        config.inject_retrieval_pipeline(wrapped_retrieval)
+
+        assert config.get_pipeline_kwargs()["retrieval_pipeline"] is wrapped_retrieval
+
+    def test_inject_retrieval_pipeline_rejects_typed_image_unit_even_if_config_claims_text(self):
+        wrapped_retrieval = create_mock_retrieval_pipeline(pipeline_id=77)
+        wrapped_retrieval.retrieval_unit = "image_chunk"
+        wrapped_retrieval._get_pipeline_config.return_value = {"type": "conflicting", "retrieval_unit": "chunk"}
+        config = RerankRetrievalPipelineConfig(
+            name="rerank",
+            retrieval_pipeline_name="typed_image",
+            reranker=FakeReranker(),
+        )
+
+        with pytest.raises(ValueError, match=r"retrieval_unit='chunk'\); got retrieval_unit='image_chunk'"):
+            config.inject_retrieval_pipeline(wrapped_retrieval)
+
     @pytest.mark.api
     def test_string_reranker_conversion(self):
         with (
@@ -221,6 +248,21 @@ class TestRerankRetrievalPipeline:
                 retrieval_pipeline=wrapped_retrieval,
                 reranker=FakeReranker(),
             )
+
+    def test_creation_uses_typed_retrieval_unit_when_legacy_config_omits_it(self):
+        wrapped_retrieval = create_mock_retrieval_pipeline()
+        wrapped_retrieval.retrieval_unit = "chunk"
+        wrapped_retrieval._get_pipeline_config.return_value = {"type": "typed_text_wrapper"}
+
+        with patch("autorag_research.pipelines.retrieval.base.BaseRetrievalPipeline.__init__", return_value=None):
+            pipeline = RerankRetrievalPipeline(
+                session_factory=MagicMock(),
+                name="rerank_typed_unit",
+                retrieval_pipeline=wrapped_retrieval,
+                reranker=FakeReranker(),
+            )
+
+        assert pipeline.retrieval_unit == "chunk"
 
     @pytest.mark.asyncio
     async def test_retrieve_by_text_reranks_wrapped_candidates(


### PR DESCRIPTION
## Summary
- Dispatches typed image retrieval wrappers through image-result persistence during batch `run()` while keeping text pipelines on chunk persistence.
- Fails closed for unsupported `mixed` retrieval persistence and mixed hybrid pipelines until fused results carry entity namespaces.
- Validates retrieval-unit strings before treating typed or legacy metadata as valid units; invalid explicit strings now raise before any persistence dispatch.
- Preserves retrieval result namespace as a pipeline identity invariant by rejecting retrieval-unit drift, wrong direct service persistence, and opposite-table rows for the same `pipeline_id`.
- Prevents `PowerOfNoiseRetrievalPipeline` from combining text chunk noise with non-text retrieval results, while preserving text-retriever underfill regression coverage.
- Adds non-DB regression coverage for image dispatch, mixed rejection, invalid unit handling, hybrid mixed-unit rejection, PowerOfNoise non-text rejection, retrieval-unit drift, direct namespace mismatch, and opposite-table persistence guards.

## Validation
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_base_pipeline.py tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_get_or_create_pipeline_rejects_retrieval_unit_drift tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_get_or_create_pipeline_rejects_invalid_retrieval_unit_config tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_run_image_pipeline_rejects_existing_chunk_results_for_same_pipeline_id tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_run_pipeline_rejects_existing_image_results_for_same_pipeline_id tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_run_pipeline_rejects_image_config_before_chunk_persistence tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_run_image_pipeline_rejects_chunk_config_before_image_persistence -q` → 10 passed
- `uv run pytest tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipelineConfig tests/autorag_research/pipelines/retrieval/test_rerank_pipeline.py::TestRerankRetrievalPipeline::test_creation_uses_typed_retrieval_unit_when_legacy_config_omits_it tests/autorag_research/pipelines/retrieval/test_query_rewrite_pipeline.py::TestQueryRewriteRetrievalPipeline::test_pipeline_config_propagates_typed_retrieval_unit_without_legacy_config tests/autorag_research/pipelines/retrieval/test_base_pipeline.py tests/autorag_research/pipelines/retrieval/test_hybrid_pipeline.py::TestHybridRetrievalUnitValidation tests/autorag_research/pipelines/retrieval/test_power_of_noise_pipeline.py::TestPowerOfNoiseRetrievalPipeline::test_creation_rejects_image_pipeline_when_text_noise_enabled tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_get_or_create_pipeline_rejects_retrieval_unit_drift tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_get_or_create_pipeline_rejects_invalid_retrieval_unit_config tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_run_image_pipeline_rejects_existing_chunk_results_for_same_pipeline_id tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_run_pipeline_rejects_existing_image_results_for_same_pipeline_id tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_run_pipeline_rejects_image_config_before_chunk_persistence tests/autorag_research/orm/service/test_retrieval_pipeline.py::TestRetrievalPipelineService::test_run_image_pipeline_rejects_chunk_config_before_image_persistence -q` → 22 passed
- `uv run python` retrieval-unit dispatch and namespace mismatch smoke → passed
- `make check` → passed
- `make test` attempted; blocked by unavailable Docker daemon at `/Users/jeffrey/.docker/run/docker.sock` while starting PostgreSQL.
- Code-reviewer verification → APPROVE
- Architect verification → CLEAR

## Notes
- Follow-up to PR #372 / Issue #370.
- Branch `feature/#370` is open as PR #373 targeting `dev`; PR #372's `feature/#86` branch is also updated to the same head for the existing follow-up thread.
