### PR TITLE
Functional fixes: ORM ingestion, retrieval verification, metrics & reporting

### DIFF
--- a/ai_instructions/utility_reference.md
+++ b/ai_instructions/utility_reference.md
@@ -17,6 +17,7 @@
 | `normalize_zscore(scores)` | Z-score standardization (mean=0, std=1), handles None |
 | `normalize_dbsf(scores)` | 3-sigma distribution-based score fusion, clips to [0,1] |
 | `run_with_concurrency_limit(items, async_func, max_concurrency)` | Async semaphore-based concurrency control |
+| `LoopBoundSemaphore(max_concurrency)` | Reusable semaphore that safely rebinds across event loops |
 | `to_async_func(func)` | Convert sync function to async via `asyncio.to_thread` |
 | `unpack_and_run(target_list, func)` | Flatten sublists, run func, regroup by original lengths |
 | `load_image(img)` | ImageType (str/Path/bytes/BytesIO) → PIL Image (RGB) |

--- a/autorag_research/data/crag.py
+++ b/autorag_research/data/crag.py
@@ -1,10 +1,13 @@
+import bz2
+import io
+import json
 import logging
 import re
+import urllib.request
 from html import unescape
 from html.parser import HTMLParser
 from typing import Any, Literal
 
-from datasets import load_dataset
 from langchain_core.embeddings import Embeddings
 
 from autorag_research.data.base import TextEmbeddingDataIngestor
@@ -21,6 +24,7 @@ CRAG_SUBSET_TO_SPLIT = {
     "test": 1,
 }
 DEFAULT_BATCH_SIZE = 100
+CRAG_MAX_CHUNK_CHARS = 8000
 
 
 class _HTMLTextExtractor(HTMLParser):
@@ -45,10 +49,13 @@ class _HTMLTextExtractor(HTMLParser):
         return _normalize_text(" ".join(self._parts))
 
 
-def _normalize_text(value: str | None) -> str:
-    if not value:
+def _normalize_text(value: Any | None) -> str:
+    if value is None:
         return ""
-    return re.sub(r"\s+", " ", unescape(value)).strip()
+    text = str(value)
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", unescape(text)).strip()
 
 
 def _resolve_subset(subset: str) -> int:
@@ -80,6 +87,18 @@ def _extract_page_text(page_result: str | None) -> str:
     return _normalize_text(stripped)
 
 
+def _iter_crag_examples() -> Any:
+    with (
+        urllib.request.urlopen(CRAG_DATA_URL) as response,  # noqa: S310
+        bz2.BZ2File(response) as compressed,
+        io.TextIOWrapper(compressed, encoding="utf-8") as text_stream,
+    ):
+        for line in text_stream:
+            stripped = line.strip()
+            if stripped:
+                yield json.loads(stripped)
+
+
 def _build_generation_gt(answer: str | None, alt_ans: list[str] | None) -> list[str] | None:
     deduped_answers: list[str] = []
     seen: set[str] = set()
@@ -109,7 +128,8 @@ def _format_search_result_contents(search_result: dict[str, Any]) -> str:
         ("Last Modified", last_modified),
         ("Content", content),
     ]
-    return "\n".join(f"{label}: {value}" for label, value in sections if value)
+    formatted = "\n".join(f"{label}: {value}" for label, value in sections if value)
+    return formatted[:CRAG_MAX_CHUNK_CHARS]
 
 
 @register_ingestor(
@@ -145,7 +165,7 @@ class CRAGIngestor(TextEmbeddingDataIngestor):
                 "min_corpus_cnt is ineffective for CRAG. Each query ships with its own search results rather than a shared corpus."
             )
 
-        dataset = load_dataset("json", data_files=CRAG_DATA_URL, split="train", streaming=True)
+        dataset = _iter_crag_examples()
 
         batch: list[dict[str, Any]] = []
         total_processed = 0

--- a/autorag_research/data/crag.py
+++ b/autorag_research/data/crag.py
@@ -25,6 +25,35 @@ CRAG_SUBSET_TO_SPLIT = {
 }
 DEFAULT_BATCH_SIZE = 100
 CRAG_MAX_CHUNK_CHARS = 8000
+CRAG_DOWNLOAD_TIMEOUT_SECONDS = 60
+CRAG_MAX_COMPRESSED_BYTES = 2_000_000_000
+CRAG_MAX_DECOMPRESSED_BYTES = 20_000_000_000
+CRAG_MAX_JSON_LINE_BYTES = 64 * 1024 * 1024
+CRAG_MAX_RECORDS = 1_000_000
+
+
+class _BoundedReader(io.RawIOBase):
+    """Limit bytes read from a streaming response."""
+
+    def __init__(self, stream: Any, max_bytes: int):
+        self._stream = stream
+        self._max_bytes = max_bytes
+        self._remaining = max_bytes
+
+    def read(self, size: int = -1) -> bytes:
+        if self._remaining == 0:
+            if self._stream.read(1):
+                msg = f"CRAG compressed download exceeds {self._max_bytes} bytes"
+                raise ValueError(msg)
+            return b""
+
+        read_size = self._remaining if size < 0 else min(size, self._remaining)
+        data = self._stream.read(read_size)
+        self._remaining -= len(data)
+        return data
+
+    def readable(self) -> bool:
+        return True
 
 
 class _HTMLTextExtractor(HTMLParser):
@@ -88,14 +117,29 @@ def _extract_page_text(page_result: str | None) -> str:
 
 
 def _iter_crag_examples() -> Any:
-    with (
-        urllib.request.urlopen(CRAG_DATA_URL) as response,  # noqa: S310
-        bz2.BZ2File(response) as compressed,
-        io.TextIOWrapper(compressed, encoding="utf-8") as text_stream,
-    ):
-        for line in text_stream:
-            stripped = line.strip()
-            if stripped:
+    with urllib.request.urlopen(CRAG_DATA_URL, timeout=CRAG_DOWNLOAD_TIMEOUT_SECONDS) as response:  # noqa: S310
+        compressed_bytes = _BoundedReader(response, CRAG_MAX_COMPRESSED_BYTES)
+        with bz2.BZ2File(compressed_bytes) as compressed:
+            total_decompressed_bytes = 0
+            record_count = 0
+
+            while line := compressed.readline(CRAG_MAX_JSON_LINE_BYTES + 1):
+                total_decompressed_bytes += len(line)
+                if total_decompressed_bytes > CRAG_MAX_DECOMPRESSED_BYTES:
+                    msg = f"CRAG decompressed stream exceeds {CRAG_MAX_DECOMPRESSED_BYTES} bytes"
+                    raise ValueError(msg)
+                if len(line) > CRAG_MAX_JSON_LINE_BYTES:
+                    msg = f"CRAG JSONL record exceeds {CRAG_MAX_JSON_LINE_BYTES} bytes"
+                    raise ValueError(msg)
+
+                stripped = line.strip()
+                if not stripped:
+                    continue
+
+                record_count += 1
+                if record_count > CRAG_MAX_RECORDS:
+                    msg = f"CRAG stream exceeds {CRAG_MAX_RECORDS} records"
+                    raise ValueError(msg)
                 yield json.loads(stripped)
 
 

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -1132,7 +1132,7 @@ def token_f1(metric_inputs: list[MetricInput]) -> list[float]:
     return _compute_generation_reference_scores(metric_inputs, _token_f1_score)
 
 
-@metric_loop(fields_to_check=["generation_gt", "generated_texts"])
+@metric_loop(fields_to_check=["generation_gt"])
 @with_embedding()
 def sem_score(
     metric_inputs: list[MetricInput],

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -204,7 +204,7 @@ def _calculate_response_relevancy_score(
     """RAGAS response relevancy core logic."""
     if all(question == "" for question in generated_questions):
         logger.warning("Invalid JSON response. Expected dictionary with key 'question'")
-        return float("nan")
+        return 0.0
 
     query_vector = np.asarray(embedding_model.embed_query(query)).reshape(1, -1)
     generated_vectors = np.asarray(embedding_model.embed_documents(generated_questions)).reshape(
@@ -1076,7 +1076,7 @@ def meteor(
     return result
 
 
-@metric_loop(fields_to_check=["generation_gt", "generated_texts"])
+@metric_loop(fields_to_check=["generation_gt"])
 def rouge(
     metric_inputs: list[MetricInput],
     rouge_type: str | None = "rougeL",
@@ -1117,13 +1117,13 @@ def rouge(
     return result
 
 
-@metric_loop(fields_to_check=["generation_gt", "generated_texts"])
+@metric_loop(fields_to_check=["generation_gt"])
 def exact_match(metric_inputs: list[MetricInput]) -> list[float]:
     """Compute SQuAD-style exact match for generation."""
     return _compute_generation_reference_scores(metric_inputs, _exact_match_score)
 
 
-@metric_loop(fields_to_check=["generation_gt", "generated_texts"])
+@metric_loop(fields_to_check=["generation_gt"])
 def token_f1(metric_inputs: list[MetricInput]) -> list[float]:
     """Compute SQuAD-style token F1 for generation."""
     return _compute_generation_reference_scores(metric_inputs, _token_f1_score)
@@ -1173,7 +1173,7 @@ def sem_score(
     return result
 
 
-@metric_loop(fields_to_check=["generation_gt", "generated_texts"])
+@metric_loop(fields_to_check=["generation_gt"])
 def bert_score(
     metric_inputs: list[MetricInput],
     lang: str = "en",

--- a/autorag_research/evaluation/metrics/generation.py
+++ b/autorag_research/evaluation/metrics/generation.py
@@ -121,7 +121,7 @@ def _compute_generation_reference_scores(
     """Compute best-reference scores for generation metric inputs."""
     scores = []
     for metric_input in metric_inputs:
-        generated_text = cast(str, metric_input.generated_texts)
+        generated_text = metric_input.generated_texts or ""
         generation_gt = cast(list[str], metric_input.generation_gt)
         scores.append(_score_generation_against_references(generated_text, generation_gt, scorer))
     return scores
@@ -1110,7 +1110,10 @@ def rouge(
     )
 
     result = [
-        rouge_instance.score_multi(metric_input.generation_gt, metric_input.generated_texts)[rouge_type].fmeasure
+        rouge_instance.score_multi(
+            cast(list[str], metric_input.generation_gt),
+            metric_input.generated_texts or "",
+        )[rouge_type].fmeasure
         for metric_input in metric_inputs
     ]
     del rouge_instance
@@ -1152,12 +1155,12 @@ def sem_score(
     if not isinstance(embedding_model, Embeddings):
         raise EmbeddingError
 
-    generations = [metric_input.generated_texts for metric_input in metric_inputs]
-    generation_gt = [metric_input.generation_gt for metric_input in metric_inputs]
+    generations = [metric_input.generated_texts or "" for metric_input in metric_inputs]
+    generation_gt = [cast(list[str], metric_input.generation_gt) for metric_input in metric_inputs]
 
     # Truncate texts to fit embedding model limit (Use tiktoken)
-    generations = truncate_texts(generations, max_tokens=truncate_length)  # ty: ignore
-    generation_gt = [truncate_texts(gen_gt, max_tokens=truncate_length) for gen_gt in generation_gt]  # ty: ignore
+    generations = truncate_texts(generations, max_tokens=truncate_length)
+    generation_gt = [truncate_texts(gen_gt, max_tokens=truncate_length) for gen_gt in generation_gt]
 
     embedded_pred: list[list[float]] = embedding_model.embed_documents(generations)
     embedded_gt: list[list[float]] = unpack_and_run(
@@ -1191,7 +1194,7 @@ def bert_score(
     Returns:
         A list of BERTScore F1 scores.
     """
-    generations = [metric_input.generated_texts for metric_input in metric_inputs]
+    generations = [metric_input.generated_texts or "" for metric_input in metric_inputs]
     generation_gt = [metric_input.generation_gt for metric_input in metric_inputs]
     evaluator = evaluate.load("bertscore")
 

--- a/autorag_research/evaluation/metrics/retrieval.py
+++ b/autorag_research/evaluation/metrics/retrieval.py
@@ -8,7 +8,7 @@ from autorag_research.evaluation.metrics.util import metric
 from autorag_research.schema import MetricInput
 
 
-@metric(fields_to_check=["retrieval_gt", "retrieved_ids"])
+@metric(fields_to_check=["retrieval_gt"])
 def retrieval_f1(metric_input: MetricInput) -> float:
     """Compute f1 score for retrieval.
 
@@ -26,7 +26,7 @@ def retrieval_f1(metric_input: MetricInput) -> float:
         return 2 * (recall_score * precision_score) / (recall_score + precision_score)
 
 
-@metric(fields_to_check=["retrieval_gt", "retrieved_ids"])
+@metric(fields_to_check=["retrieval_gt"])
 def retrieval_recall(metric_input: MetricInput) -> float:
     """Compute recall score for retrieval.
 
@@ -47,7 +47,7 @@ def retrieval_recall(metric_input: MetricInput) -> float:
     return recall
 
 
-@metric(fields_to_check=["retrieval_gt", "retrieved_ids"])
+@metric(fields_to_check=["retrieval_gt"])
 def retrieval_precision(metric_input: MetricInput) -> float:
     """Compute precision score for retrieval.
 
@@ -68,7 +68,7 @@ def retrieval_precision(metric_input: MetricInput) -> float:
     return precision
 
 
-@metric(fields_to_check=["retrieval_gt", "retrieved_ids"])
+@metric(fields_to_check=["retrieval_gt"])
 def retrieval_ndcg(metric_input: MetricInput) -> float:  # noqa: C901
     """Compute NDCG for multi-hop retrieval with AND-OR group semantics.
 
@@ -144,7 +144,7 @@ def retrieval_ndcg(metric_input: MetricInput) -> float:  # noqa: C901
     return dcg / idcg if idcg > 0 else 0.0
 
 
-@metric(fields_to_check=["retrieval_gt", "retrieved_ids"])
+@metric(fields_to_check=["retrieval_gt"])
 def retrieval_full_recall(metric_input: MetricInput) -> float:
     """Compute full recall (binary) for retrieval.
 
@@ -170,7 +170,7 @@ def retrieval_full_recall(metric_input: MetricInput) -> float:
     return 1.0
 
 
-@metric(fields_to_check=["retrieval_gt", "retrieved_ids"])
+@metric(fields_to_check=["retrieval_gt"])
 def retrieval_mrr(metric_input: MetricInput) -> float:
     """Compute MRR (Mean Reciprocal Rank) score for retrieval.
 
@@ -199,7 +199,7 @@ def retrieval_mrr(metric_input: MetricInput) -> float:
     return sum(rr_list) / len(gt_sets) if rr_list else 0.0
 
 
-@metric(fields_to_check=["retrieval_gt", "retrieved_ids"])
+@metric(fields_to_check=["retrieval_gt"])
 def retrieval_map(metric_input: MetricInput) -> float:
     """Compute MAP (Mean Average Precision) score for retrieval.
 

--- a/autorag_research/executor.py
+++ b/autorag_research/executor.py
@@ -412,8 +412,17 @@ class Executor:
                 # Run pipeline
                 run_result = pipeline.run(**config.get_run_kwargs())
 
-                # Verify completion
-                if self._verify_pipeline_completion(pipeline_id, config.pipeline_type):
+                # Verify completion. A retrieval pipeline may legitimately return
+                # zero documents for some queries (e.g. BM25 with no lexical match);
+                # such queries are processed but leave no result rows, so strict
+                # row-presence verification would fail forever. When the run itself
+                # completed with no failed queries, accept it as complete.
+                verified = self._verify_pipeline_completion(pipeline_id, config.pipeline_type)
+                if not verified and config.pipeline_type == PipelineType.RETRIEVAL:
+                    failed = run_result.get("failed_queries") if isinstance(run_result, dict) else None
+                    if not failed:
+                        verified = True
+                if verified:
                     logger.info(
                         f"Pipeline '{config.name}' completed successfully "
                         f"(pipeline_id={pipeline_id}, "

--- a/autorag_research/executor.py
+++ b/autorag_research/executor.py
@@ -418,9 +418,10 @@ class Executor:
                 # row-presence verification would fail forever. When the run itself
                 # completed with no failed queries, accept it as complete.
                 verified = self._verify_pipeline_completion(pipeline_id, config.pipeline_type)
-                if not verified and config.pipeline_type == PipelineType.RETRIEVAL:
-                    failed = run_result.get("failed_queries") if isinstance(run_result, dict) else None
-                    if not failed:
+                if not verified and config.pipeline_type == PipelineType.RETRIEVAL and isinstance(run_result, dict):
+                    failed_queries = run_result.get("failed_queries")
+                    total_queries = run_result.get("total_queries")
+                    if failed_queries == [] and isinstance(total_queries, int) and total_queries > 0:
                         verified = True
                 if verified:
                     logger.info(

--- a/autorag_research/orm/connection.py
+++ b/autorag_research/orm/connection.py
@@ -331,9 +331,16 @@ class DBConnection:
             raise FileNotFoundError
 
         if create:
-            from autorag_research.orm.util import create_database
+            from autorag_research.orm.util import create_database, install_vector_extensions
 
             create_database(
+                host=self.host,
+                port=self.port,
+                user=self.username,
+                password=self.password,
+                database=self.database,
+            )
+            install_vector_extensions(
                 host=self.host,
                 port=self.port,
                 user=self.username,

--- a/autorag_research/orm/repository/base.py
+++ b/autorag_research/orm/repository/base.py
@@ -17,6 +17,10 @@ T = TypeVar("T")
 
 logger = logging.getLogger("AutoRAG-Research")
 
+# Max rows per multi-row INSERT. Keeps total bound parameters well under
+# PostgreSQL's 65535 limit even for wide tables (e.g. 500 rows x ~20 cols).
+_BULK_INSERT_CHUNK = 500
+
 
 def _sanitize_text_value(value: Any) -> Any:
     """Remove NUL bytes from string values for PostgreSQL compatibility.
@@ -141,9 +145,15 @@ class GenericRepository(Generic[T]):
         # Sanitize all string values to remove NUL bytes for PostgreSQL compatibility
         sanitized_items = [_sanitize_dict(item) for item in items]
 
-        stmt = insert(self.model_cls).values(sanitized_items).returning(self.model_cls.id)  # ty: ignore[possibly-missing-attribute]
-        result = self.session.execute(stmt)
-        return [row[0] for row in result]
+        # Insert in sub-batches so a single multi-row INSERT never exceeds
+        # PostgreSQL's 65535 bound-parameter limit for large corpora.
+        inserted_ids: list[Any] = []
+        for start in range(0, len(sanitized_items), _BULK_INSERT_CHUNK):
+            chunk = sanitized_items[start : start + _BULK_INSERT_CHUNK]
+            stmt = insert(self.model_cls).values(chunk).returning(self.model_cls.id)  # ty: ignore[possibly-missing-attribute]
+            result = self.session.execute(stmt)
+            inserted_ids.extend(row[0] for row in result)
+        return inserted_ids
 
     def add_bulk_skip_duplicates(self, items: list[dict]) -> list[Any]:
         """Memory-efficient bulk insert that skips rows with duplicate primary keys.
@@ -168,11 +178,16 @@ class GenericRepository(Generic[T]):
             return []
 
         sanitized_items = [_sanitize_dict(item) for item in items]
-        stmt = (
-            insert(self.model_cls).values(sanitized_items).on_conflict_do_nothing().returning(self.model_cls.id)  # ty: ignore[possibly-missing-attribute]
-        )
-        result = self.session.execute(stmt)
-        return [row[0] for row in result]
+
+        inserted_ids: list[Any] = []
+        for start in range(0, len(sanitized_items), _BULK_INSERT_CHUNK):
+            chunk = sanitized_items[start : start + _BULK_INSERT_CHUNK]
+            stmt = (
+                insert(self.model_cls).values(chunk).on_conflict_do_nothing().returning(self.model_cls.id)  # ty: ignore[possibly-missing-attribute]
+            )
+            result = self.session.execute(stmt)
+            inserted_ids.extend(row[0] for row in result)
+        return inserted_ids
 
     def get_by_id(self, _id: Any) -> T | None:
         """Retrieve an entity by its primary key.

--- a/autorag_research/orm/service/base_ingestion.py
+++ b/autorag_research/orm/service/base_ingestion.py
@@ -41,7 +41,7 @@ logger = logging.getLogger("AutoRAG-Research")
 ENTITY_CONFIG: dict[str, tuple[str, str, str, bool]] = {
     "query": ("queries", "contents", "queries", False),
     "chunk": ("chunks", "contents", "chunks", False),
-    "image_chunk": ("image_chunks", "content", "image chunks", True),
+    "image_chunk": ("image_chunks", "contents", "image chunks", True),
 }
 
 

--- a/autorag_research/pipelines/generation/main_rag.py
+++ b/autorag_research/pipelines/generation/main_rag.py
@@ -5,7 +5,6 @@ Uses three LLM agents to collaboratively filter retrieved documents through
 adaptive thresholding and probabilistic scoring.
 """
 
-import asyncio
 import logging
 from dataclasses import dataclass, field
 from statistics import mean, stdev
@@ -19,9 +18,10 @@ from autorag_research.orm.service.generation_pipeline import GenerationResult
 from autorag_research.pipelines.generation.base import BaseGenerationPipeline
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
 from autorag_research.schema import GENERATION_CONTEXT_CHUNK_ID_KEY
-from autorag_research.util import TokenUsageTracker
+from autorag_research.util import LoopBoundSemaphore, TokenUsageTracker, run_with_concurrency_limit
 
 logger = logging.getLogger("AutoRAG-Research")
+
 
 # Agent-1 (Predictor) prompts
 DEFAULT_PREDICTOR_SYSTEM_PROMPT = """You are an accurate and reliable AI assistant that can answer questions with the help of external documents. You should only provide the correct answer without repeating the question and instruction."""
@@ -90,6 +90,7 @@ class MAINRAGPipelineConfig(BaseGenerationPipelineConfig):
     """
 
     std_multiplier: float = 0.0
+    agent_max_concurrency: int = 4
     predictor_system_prompt: str = field(default=DEFAULT_PREDICTOR_SYSTEM_PROMPT)
     predictor_user_prompt: str = field(default=DEFAULT_PREDICTOR_USER_PROMPT)
     judge_system_prompt: str = field(default=DEFAULT_JUDGE_SYSTEM_PROMPT)
@@ -111,6 +112,7 @@ class MAINRAGPipelineConfig(BaseGenerationPipelineConfig):
             "llm": self.llm,
             "retrieval_pipeline": self._retrieval_pipeline,
             "std_multiplier": self.std_multiplier,
+            "agent_max_concurrency": self.agent_max_concurrency,
             "predictor_system_prompt": self.predictor_system_prompt,
             "predictor_user_prompt": self.predictor_user_prompt,
             "judge_system_prompt": self.judge_system_prompt,
@@ -237,6 +239,7 @@ class MAINRAGPipeline(BaseGenerationPipeline):
         llm: BaseLanguageModel,
         retrieval_pipeline: BaseRetrievalPipeline,
         std_multiplier: float = 0.0,
+        agent_max_concurrency: int = 4,
         predictor_system_prompt: str = DEFAULT_PREDICTOR_SYSTEM_PROMPT,
         predictor_user_prompt: str = DEFAULT_PREDICTOR_USER_PROMPT,
         judge_system_prompt: str = DEFAULT_JUDGE_SYSTEM_PROMPT,
@@ -257,6 +260,7 @@ class MAINRAGPipeline(BaseGenerationPipeline):
                 threshold = mean - n * std. Default 0.0 means threshold = mean.
                 Higher values are more permissive (lower threshold).
                 Negative values are more aggressive (higher threshold).
+            agent_max_concurrency: Maximum concurrent agent calls across this pipeline instance.
             predictor_system_prompt: System prompt for Agent-1 (Predictor).
             predictor_user_prompt: User prompt template for Agent-1.
                 Must contain {document} and {query} placeholders.
@@ -271,6 +275,11 @@ class MAINRAGPipeline(BaseGenerationPipeline):
         # Store custom attributes BEFORE super().__init__()
         # because _get_pipeline_config() is called in parent init
         self._std_multiplier = std_multiplier
+        if agent_max_concurrency < 1:
+            msg = "agent_max_concurrency must be at least 1"
+            raise ValueError(msg)
+        self._agent_max_concurrency = agent_max_concurrency
+        self._agent_limiter = LoopBoundSemaphore(agent_max_concurrency)
         self._predictor_system_prompt = predictor_system_prompt
         self._predictor_user_prompt = predictor_user_prompt
         self._judge_system_prompt = judge_system_prompt
@@ -285,6 +294,7 @@ class MAINRAGPipeline(BaseGenerationPipeline):
         return {
             "type": "main_rag",
             "std_multiplier": self._std_multiplier,
+            "agent_max_concurrency": self._agent_max_concurrency,
             "predictor_system_prompt": self._predictor_system_prompt,
             "predictor_user_prompt": self._predictor_user_prompt,
             "judge_system_prompt": self._judge_system_prompt,
@@ -323,7 +333,8 @@ class MAINRAGPipeline(BaseGenerationPipeline):
             SystemMessage(content=system_prompt),
             HumanMessage(content=user_prompt.format(**format_kwargs)),
         ]
-        return await self._llm.ainvoke(messages)
+        async with self._agent_limiter.get():
+            return await self._llm.ainvoke(messages)
 
     async def _aagent_predict(self, query: str, document: str) -> tuple[str, Any]:
         """Async version of Agent-1 (Predictor).
@@ -497,17 +508,30 @@ class MAINRAGPipeline(BaseGenerationPipeline):
             )
 
         # ==================== Phase 2: Agent-1 (Predictor) ====================
-        predictor_results = await asyncio.gather(*(self._aagent_predict(query, doc) for doc in chunk_contents))
+        predictor_results = await run_with_concurrency_limit(
+            items=chunk_contents,
+            async_func=lambda document: self._aagent_predict(query, document),
+            max_concurrency=self._agent_max_concurrency,
+            error_message="MAIN-RAG predictor failed",
+            raise_on_error=True,
+        )
         candidate_answers = [answer for answer, _response in predictor_results]
         for _answer, response in predictor_results:
             tracker.record(response)
 
         # ==================== Phase 3: Agent-2 (Judge) ====================
-        judge_results = await asyncio.gather(
-            *(
-                self._aagent_judge(query, doc, answer)
-                for doc, answer in zip(chunk_contents, candidate_answers, strict=True)
-            )
+        judge_inputs = list(zip(chunk_contents, candidate_answers, strict=True))
+
+        async def judge_document(item: tuple[str, str]) -> tuple[float, Any]:
+            document, answer = item
+            return await self._aagent_judge(query, document, answer)
+
+        judge_results = await run_with_concurrency_limit(
+            items=judge_inputs,
+            async_func=judge_document,
+            max_concurrency=self._agent_max_concurrency,
+            error_message="MAIN-RAG judge failed",
+            raise_on_error=True,
         )
         relevance_scores = [score for score, _response in judge_results]
         for _score, response in judge_results:

--- a/autorag_research/pipelines/generation/main_rag.py
+++ b/autorag_research/pipelines/generation/main_rag.py
@@ -5,6 +5,7 @@ Uses three LLM agents to collaboratively filter retrieved documents through
 adaptive thresholding and probabilistic scoring.
 """
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from statistics import mean, stdev
@@ -353,10 +354,10 @@ class MAINRAGPipeline(BaseGenerationPipeline):
         Returns:
             Tuple of (relevance_score, raw_response).
 
-        Raises:
-            LogprobsNotSupportedError: If LLM does not support logprobs.
+        Notes:
+            When provider logprobs are unavailable, the judge falls back to the
+            binary text score returned by calculate_binary_logprob_score().
         """
-        from autorag_research.exceptions import LogprobsNotSupportedError
 
         response = await self._ainvoke_llm(
             self._judge_system_prompt,
@@ -369,7 +370,7 @@ class MAINRAGPipeline(BaseGenerationPipeline):
         score, used_logprobs = calculate_binary_logprob_score(response)
 
         if not used_logprobs:
-            raise LogprobsNotSupportedError(self.name)
+            logger.debug("MAIN-RAG judge response did not include logprobs; using text fallback score")
 
         return score, response
 
@@ -496,17 +497,20 @@ class MAINRAGPipeline(BaseGenerationPipeline):
             )
 
         # ==================== Phase 2: Agent-1 (Predictor) ====================
-        candidate_answers: list[str] = []
-        for doc in chunk_contents:
-            answer, response = await self._aagent_predict(query, doc)
-            candidate_answers.append(answer)
+        predictor_results = await asyncio.gather(*(self._aagent_predict(query, doc) for doc in chunk_contents))
+        candidate_answers = [answer for answer, _response in predictor_results]
+        for _answer, response in predictor_results:
             tracker.record(response)
 
         # ==================== Phase 3: Agent-2 (Judge) ====================
-        relevance_scores: list[float] = []
-        for doc, answer in zip(chunk_contents, candidate_answers, strict=True):
-            score, response = await self._aagent_judge(query, doc, answer)
-            relevance_scores.append(score)
+        judge_results = await asyncio.gather(
+            *(
+                self._aagent_judge(query, doc, answer)
+                for doc, answer in zip(chunk_contents, candidate_answers, strict=True)
+            )
+        )
+        relevance_scores = [score for score, _response in judge_results]
+        for _score, response in judge_results:
             tracker.record(response)
 
         # ==================== Phase 4: Adaptive Filtering ====================

--- a/autorag_research/pipelines/generation/spd_rag.py
+++ b/autorag_research/pipelines/generation/spd_rag.py
@@ -1,6 +1,5 @@
 """SPD-RAG (Sub-Agent Per Document) Pipeline for AutoRAG-Research."""
 
-import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -12,9 +11,10 @@ from autorag_research.config import BaseGenerationPipelineConfig
 from autorag_research.orm.service.generation_pipeline import GenerationResult
 from autorag_research.pipelines.generation.base import BaseGenerationPipeline
 from autorag_research.pipelines.retrieval.base import BaseRetrievalPipeline
-from autorag_research.util import TokenUsageTracker
+from autorag_research.util import LoopBoundSemaphore, TokenUsageTracker, run_with_concurrency_limit
 
 logger = logging.getLogger("AutoRAG-Research")
+
 
 DEFAULT_SUB_AGENT_SYSTEM_PROMPT = """You are a focused document analyst. Your task is to answer the given question using ONLY the provided document. If the document does not contain relevant information, state that clearly. Provide a concise, specific answer based solely on the document's content."""
 
@@ -60,6 +60,7 @@ class SPDRAGPipelineConfig(BaseGenerationPipelineConfig):
     synthesis_user_prompt: str = field(default=DEFAULT_SYNTHESIS_USER_PROMPT)
     max_synthesis_tokens: int = 4000
     synthesis_batch_size: int = 3
+    agent_max_concurrency: int = 4
 
     def get_pipeline_class(self) -> type["SPDRAGPipeline"]:
         """Return the SPD-RAG pipeline class."""
@@ -82,6 +83,7 @@ class SPDRAGPipelineConfig(BaseGenerationPipelineConfig):
             "synthesis_user_prompt": self.synthesis_user_prompt,
             "max_synthesis_tokens": self.max_synthesis_tokens,
             "synthesis_batch_size": self.synthesis_batch_size,
+            "agent_max_concurrency": self.agent_max_concurrency,
         }
 
 
@@ -102,9 +104,13 @@ class SPDRAGPipeline(BaseGenerationPipeline):
         synthesis_user_prompt: str = DEFAULT_SYNTHESIS_USER_PROMPT,
         max_synthesis_tokens: int = 4000,
         synthesis_batch_size: int = 3,
+        agent_max_concurrency: int = 4,
         schema: Any | None = None,
     ) -> None:
         """Initialize SPD-RAG pipeline."""
+        if agent_max_concurrency < 1:
+            msg = "agent_max_concurrency must be at least 1"
+            raise ValueError(msg)
         self._sub_agent_system_prompt = sub_agent_system_prompt
         self._sub_agent_user_prompt = sub_agent_user_prompt
         self._coordinator_system_prompt = coordinator_system_prompt
@@ -113,6 +119,8 @@ class SPDRAGPipeline(BaseGenerationPipeline):
         self._synthesis_user_prompt = synthesis_user_prompt
         self._max_synthesis_tokens = max_synthesis_tokens
         self._synthesis_batch_size = synthesis_batch_size
+        self._agent_max_concurrency = agent_max_concurrency
+        self._agent_limiter = LoopBoundSemaphore(agent_max_concurrency)
 
         super().__init__(session_factory, name, llm, retrieval_pipeline, schema)
 
@@ -128,6 +136,7 @@ class SPDRAGPipeline(BaseGenerationPipeline):
             "synthesis_user_prompt": self._synthesis_user_prompt,
             "max_synthesis_tokens": self._max_synthesis_tokens,
             "synthesis_batch_size": self._synthesis_batch_size,
+            "agent_max_concurrency": self._agent_max_concurrency,
         }
 
     async def _ainvoke_llm(self, system_prompt: str, user_prompt: str, **format_kwargs: Any) -> Any:
@@ -138,7 +147,8 @@ class SPDRAGPipeline(BaseGenerationPipeline):
             SystemMessage(content=system_prompt),
             HumanMessage(content=user_prompt.format(**format_kwargs)),
         ]
-        return await self._llm.ainvoke(messages)
+        async with self._agent_limiter.get():
+            return await self._llm.ainvoke(messages)
 
     async def _sub_agent_generate(self, query: str, document: str) -> tuple[str, Any]:
         """Generate a partial answer from a single document."""
@@ -218,8 +228,12 @@ class SPDRAGPipeline(BaseGenerationPipeline):
         retrieval_scores = [result["score"] for result in retrieved]
         chunk_contents = self._service.get_chunk_contents(chunk_ids)
 
-        sub_agent_results = await asyncio.gather(
-            *(self._sub_agent_generate(query, document) for document in chunk_contents)
+        sub_agent_results = await run_with_concurrency_limit(
+            items=chunk_contents,
+            async_func=lambda document: self._sub_agent_generate(query, document),
+            max_concurrency=self._agent_max_concurrency,
+            error_message="SPD-RAG sub-agent failed",
+            raise_on_error=True,
         )
         partial_answers: list[dict[str, Any]] = []
         for chunk_id, document, (partial_answer, response) in zip(
@@ -235,15 +249,19 @@ class SPDRAGPipeline(BaseGenerationPipeline):
             })
             tracker.record(response)
 
-        coordinator_results = await asyncio.gather(
-            *(
-                self._coordinator_evaluate(
-                    query,
-                    partial_answer["partial_answer"],
-                    partial_answer["content"],
-                )
-                for partial_answer in partial_answers
+        async def evaluate_partial_answer(partial_answer: dict[str, Any]) -> tuple[bool, Any]:
+            return await self._coordinator_evaluate(
+                query,
+                partial_answer["partial_answer"],
+                partial_answer["content"],
             )
+
+        coordinator_results = await run_with_concurrency_limit(
+            items=partial_answers,
+            async_func=evaluate_partial_answer,
+            max_concurrency=self._agent_max_concurrency,
+            error_message="SPD-RAG coordinator failed",
+            raise_on_error=True,
         )
         relevant_answers: list[dict[str, Any]] = []
         for partial_answer, (is_relevant, response) in zip(partial_answers, coordinator_results, strict=True):

--- a/autorag_research/pipelines/generation/spd_rag.py
+++ b/autorag_research/pipelines/generation/spd_rag.py
@@ -1,5 +1,6 @@
 """SPD-RAG (Sub-Agent Per Document) Pipeline for AutoRAG-Research."""
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -217,9 +218,16 @@ class SPDRAGPipeline(BaseGenerationPipeline):
         retrieval_scores = [result["score"] for result in retrieved]
         chunk_contents = self._service.get_chunk_contents(chunk_ids)
 
+        sub_agent_results = await asyncio.gather(
+            *(self._sub_agent_generate(query, document) for document in chunk_contents)
+        )
         partial_answers: list[dict[str, Any]] = []
-        for chunk_id, document in zip(chunk_ids, chunk_contents, strict=True):
-            partial_answer, response = await self._sub_agent_generate(query, document)
+        for chunk_id, document, (partial_answer, response) in zip(
+            chunk_ids,
+            chunk_contents,
+            sub_agent_results,
+            strict=True,
+        ):
             partial_answers.append({
                 "doc_id": chunk_id,
                 "content": document,
@@ -227,13 +235,18 @@ class SPDRAGPipeline(BaseGenerationPipeline):
             })
             tracker.record(response)
 
-        relevant_answers: list[dict[str, Any]] = []
-        for partial_answer in partial_answers:
-            is_relevant, response = await self._coordinator_evaluate(
-                query,
-                partial_answer["partial_answer"],
-                partial_answer["content"],
+        coordinator_results = await asyncio.gather(
+            *(
+                self._coordinator_evaluate(
+                    query,
+                    partial_answer["partial_answer"],
+                    partial_answer["content"],
+                )
+                for partial_answer in partial_answers
             )
+        )
+        relevant_answers: list[dict[str, Any]] = []
+        for partial_answer, (is_relevant, response) in zip(partial_answers, coordinator_results, strict=True):
             tracker.record(response)
             if is_relevant:
                 relevant_answers.append(partial_answer)

--- a/autorag_research/reporting/scope.py
+++ b/autorag_research/reporting/scope.py
@@ -1,0 +1,95 @@
+"""Experiment-scoped leaderboard configuration."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
+
+from autorag_research.cli.config_resolver import ConfigResolver
+from autorag_research.cli.utils import get_config_dir
+
+MetricType = Literal["retrieval", "generation"]
+
+
+@dataclass(frozen=True)
+class LeaderboardScope:
+    """Experiment-defined database, pipeline, and metric allowlists."""
+
+    db_name: str
+    pipeline_names: dict[str, tuple[str, ...]]
+    metric_names: dict[str, tuple[str, ...]]
+
+
+def scope_filters(
+    scope: LeaderboardScope | None,
+    metric_type: MetricType,
+) -> tuple[tuple[str, ...] | None, tuple[str, ...] | None]:
+    """Return pipeline and metric allowlists for one metric type."""
+    if scope is None:
+        return None, None
+    return scope.pipeline_names.get(metric_type, ()), scope.metric_names.get(metric_type, ())
+
+
+def scope_metric_types(scope: LeaderboardScope | None) -> list[MetricType]:
+    """Return metric types that have both pipelines and metrics configured."""
+    return [
+        metric_type
+        for metric_type in ("retrieval", "generation")
+        if scope is None or (scope.pipeline_names.get(metric_type) and scope.metric_names.get(metric_type))
+    ]
+
+
+def initial_scope_metric_type(scope: LeaderboardScope | None) -> MetricType:
+    """Return the initial metric type for a scoped leaderboard."""
+    metric_types = scope_metric_types(scope)
+    return metric_types[0] if metric_types else "retrieval"
+
+
+def _config_references(config: DictConfig, section: str, metric_type: MetricType) -> list[str]:
+    """Return normalized config references for one experiment section and type."""
+    section_config = config.get(section, {})
+    references = section_config.get(metric_type, []) if isinstance(section_config, DictConfig) else []
+    if isinstance(references, str):
+        return [references]
+    return [str(reference) for reference in references]
+
+
+def load_leaderboard_scope(config_name: str) -> LeaderboardScope:
+    """Load leaderboard allowlists from an experiment YAML config."""
+    config_dir = get_config_dir()
+    experiment_path = config_dir / f"{config_name}.yaml"
+    if not experiment_path.exists():
+        raise FileNotFoundError(f"Config file not found: {experiment_path}")  # noqa: TRY003
+
+    experiment_config = OmegaConf.load(experiment_path)
+    if not isinstance(experiment_config, DictConfig):
+        raise TypeError(f"Experiment config must be a YAML mapping: {experiment_path}")  # noqa: TRY003
+
+    db_name = experiment_config.get("db_name")
+    if not db_name:
+        raise ValueError(f"Experiment config must define db_name: {experiment_path}")  # noqa: TRY003
+
+    resolver = ConfigResolver(config_dir=config_dir)
+    pipeline_names: dict[str, tuple[str, ...]] = {}
+    metric_names: dict[str, tuple[str, ...]] = {}
+    for metric_type in ("retrieval", "generation"):
+        pipeline_references = _config_references(experiment_config, "pipelines", metric_type)
+        resolved_pipeline_names = []
+        for reference in pipeline_references:
+            pipeline_config = resolver.resolve_config(["pipelines", metric_type], reference)
+            resolved_pipeline_names.append(str(pipeline_config.get("name", reference)))
+        pipeline_names[metric_type] = tuple(resolved_pipeline_names)
+
+        metric_references = _config_references(experiment_config, "metrics", metric_type)
+        resolved_metric_names = []
+        for reference in metric_references:
+            metric_config = resolver.resolve_config(["metrics", metric_type], reference)
+            resolved_metric_names.append(str(instantiate(metric_config).get_metric_name()))
+        metric_names[metric_type] = tuple(resolved_metric_names)
+
+    return LeaderboardScope(
+        db_name=str(db_name),
+        pipeline_names=pipeline_names,
+        metric_names=metric_names,
+    )

--- a/autorag_research/reporting/service.py
+++ b/autorag_research/reporting/service.py
@@ -162,7 +162,7 @@ class ReportingService:
         return self._pg_query(db_name, sql)["name"].tolist()
 
     def get_pipeline_type(self, db_name: str, pipeline_name: str) -> Literal["retrieval", "generation"] | None:
-        """Get the metric type associated with a pipeline's evaluated results.
+        """Get a pipeline's execution type from persisted results.
 
         Args:
             db_name: Name of the PostgreSQL database.
@@ -174,13 +174,18 @@ class ReportingService:
         escaped_name = self._escape_sql_value(pipeline_name)
         sql = f"""
             {self._metric_scores_cte()}
-            SELECT m.type as pipeline_type
+            SELECT CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM executor_result e WHERE e.pipeline_id = p.id
+                ) OR BOOL_OR(m.type = 'generation')
+                THEN 'generation'
+                ELSE 'retrieval'
+            END AS pipeline_type
             FROM metric_scores s
             JOIN pipeline p ON s.pipeline_id = p.id
             JOIN metric m ON s.metric_id = m.id
             WHERE p.name = '{escaped_name}'
-            GROUP BY m.type
-            ORDER BY COUNT(*) DESC, m.type
+            GROUP BY p.id
             LIMIT 1
             """  # noqa: S608
         result = self._pg_query(db_name, sql)

--- a/autorag_research/reporting/service.py
+++ b/autorag_research/reporting/service.py
@@ -62,6 +62,38 @@ class ReportingService:
         """Escape a string value for safe embedding in SQL by doubling single quotes."""
         return value.replace("'", "''")
 
+    @staticmethod
+    def _metric_scores_cte() -> str:
+        """Return canonical aggregate metric scores with legacy summary fallback.
+
+        Evaluation results are persisted per query. Summary rows are retained for
+        legacy databases, but only supply a pipeline/metric pair when no evaluated
+        rows exist for that pair.
+        """
+        return """
+            WITH metric_scores AS (
+                SELECT
+                    pipeline_id,
+                    metric_id,
+                    AVG(metric_result) AS metric_result,
+                    NULL::DOUBLE PRECISION AS execution_time
+                FROM evaluation_result
+                GROUP BY pipeline_id, metric_id
+                UNION ALL
+                SELECT
+                    s.pipeline_id,
+                    s.metric_id,
+                    s.metric_result,
+                    s.execution_time
+                FROM summary s
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM evaluation_result e
+                    WHERE e.pipeline_id = s.pipeline_id AND e.metric_id = s.metric_id
+                )
+            )
+        """
+
     def _pg_query(self, db_name: str, sql: str) -> pd.DataFrame:
         """Execute a raw SQL query against PostgreSQL via DuckDB's postgres_query().
 
@@ -96,12 +128,13 @@ class ReportingService:
         order = "ASC" if ascending else "DESC"
         escaped_metric = self._escape_sql_value(metric_name)
         sql = f"""
+            {self._metric_scores_cte()}
             SELECT
                 ROW_NUMBER() OVER (ORDER BY s.metric_result {order}) as rank,
                 p.name as pipeline,
                 s.metric_result as score,
                 s.execution_time as time_ms
-            FROM summary s
+            FROM metric_scores s
             JOIN pipeline p ON s.pipeline_id = p.id
             JOIN metric m ON s.metric_id = m.id
             WHERE m.name = '{escaped_metric}'
@@ -119,23 +152,36 @@ class ReportingService:
         Returns:
             List of pipeline names.
         """
-        return self._pg_query(db_name, "SELECT name FROM pipeline")["name"].tolist()
+        sql = f"""
+            {self._metric_scores_cte()}
+            SELECT DISTINCT p.name
+            FROM metric_scores s
+            JOIN pipeline p ON s.pipeline_id = p.id
+            ORDER BY p.name
+            """  # noqa: S608
+        return self._pg_query(db_name, sql)["name"].tolist()
 
     def get_pipeline_type(self, db_name: str, pipeline_name: str) -> Literal["retrieval", "generation"] | None:
-        """Get the type of a pipeline from its config.
+        """Get the metric type associated with a pipeline's evaluated results.
 
         Args:
             db_name: Name of the PostgreSQL database.
             pipeline_name: Name of the pipeline.
 
         Returns:
-            Pipeline type ('retrieval' or 'generation'), or None if not found.
+            Pipeline type ('retrieval' or 'generation'), or None if no results exist.
         """
         escaped_name = self._escape_sql_value(pipeline_name)
         sql = f"""
-            SELECT config->>'pipeline_type' as pipeline_type
-            FROM pipeline
-            WHERE name = '{escaped_name}'
+            {self._metric_scores_cte()}
+            SELECT m.type as pipeline_type
+            FROM metric_scores s
+            JOIN pipeline p ON s.pipeline_id = p.id
+            JOIN metric m ON s.metric_id = m.id
+            WHERE p.name = '{escaped_name}'
+            GROUP BY m.type
+            ORDER BY COUNT(*) DESC, m.type
+            LIMIT 1
             """  # noqa: S608
         result = self._pg_query(db_name, sql)
         if result.empty or result["pipeline_type"].iloc[0] is None:
@@ -151,7 +197,14 @@ class ReportingService:
         Returns:
             List of metric names.
         """
-        return self._pg_query(db_name, "SELECT name FROM metric")["name"].tolist()
+        sql = f"""
+            {self._metric_scores_cte()}
+            SELECT DISTINCT m.name
+            FROM metric_scores s
+            JOIN metric m ON s.metric_id = m.id
+            ORDER BY m.name
+            """  # noqa: S608
+        return self._pg_query(db_name, sql)["name"].tolist()
 
     # === Dataset Discovery ===
 
@@ -213,9 +266,15 @@ class ReportingService:
         if metric_type not in ("retrieval", "generation"):
             raise ValueError(f"Invalid metric_type: '{metric_type}'. Must be 'retrieval' or 'generation'.")  # noqa: TRY003
 
-        return self._pg_query(db_name, f"SELECT name FROM metric WHERE type = '{metric_type}' ORDER BY name")[  # noqa: S608
-            "name"
-        ].tolist()
+        sql = f"""
+            {self._metric_scores_cte()}
+            SELECT DISTINCT m.name
+            FROM metric_scores s
+            JOIN metric m ON s.metric_id = m.id
+            WHERE m.type = '{metric_type}'
+            ORDER BY m.name
+            """  # noqa: S608
+        return self._pg_query(db_name, sql)["name"].tolist()
 
     def get_dataset_stats(self, db_name: str) -> dict:
         """Return dataset statistics including query, chunk, and document counts.
@@ -259,8 +318,9 @@ class ReportingService:
         results = []
         for db_name in db_names:
             sql = f"""
+                {self._metric_scores_cte()}
                 SELECT s.metric_result as score, s.execution_time as time_ms
-                FROM summary s
+                FROM metric_scores s
                 JOIN pipeline p ON s.pipeline_id = p.id
                 JOIN metric m ON s.metric_id = m.id
                 WHERE p.name = '{escaped_pipeline}' AND m.name = '{escaped_metric}'
@@ -272,13 +332,19 @@ class ReportingService:
         return pd.concat(results, ignore_index=True) if results else pd.DataFrame()
 
     def get_all_metrics_leaderboard(
-        self, db_name: str, metric_type: Literal["retrieval", "generation"]
+        self,
+        db_name: str,
+        metric_type: Literal["retrieval", "generation"],
+        pipeline_names: list[str] | tuple[str, ...] | None = None,
+        metric_names: list[str] | tuple[str, ...] | None = None,
     ) -> pd.DataFrame:
-        """Get leaderboard with all metrics as columns.
+        """Get leaderboard with selected pipelines and metrics as columns.
 
         Args:
             db_name: Name of the PostgreSQL database.
             metric_type: One of 'retrieval' or 'generation'.
+            pipeline_names: Optional pipeline allowlist. ``None`` includes every pipeline.
+            metric_names: Optional metric allowlist. ``None`` includes every metric of the requested type.
 
         Returns:
             DataFrame with columns: rank, pipeline, <metric1>, <metric2>, ..., Average
@@ -286,13 +352,27 @@ class ReportingService:
         """
         if metric_type not in ("retrieval", "generation"):
             raise ValueError(f"Invalid metric_type: '{metric_type}'. Must be 'retrieval' or 'generation'.")  # noqa: TRY003
+        if pipeline_names is not None and not pipeline_names:
+            return pd.DataFrame()
+        if metric_names is not None and not metric_names:
+            return pd.DataFrame()
+
+        filters = [f"m.type = '{metric_type}'"]
+        if pipeline_names is not None:
+            escaped_pipelines = ", ".join(f"'{self._escape_sql_value(name)}'" for name in pipeline_names)
+            filters.append(f"p.name IN ({escaped_pipelines})")
+        if metric_names is not None:
+            escaped_metrics = ", ".join(f"'{self._escape_sql_value(name)}'" for name in metric_names)
+            filters.append(f"m.name IN ({escaped_metrics})")
+        where_clause = " AND ".join(filters)
 
         sql = f"""
+            {self._metric_scores_cte()}
             SELECT p.name as pipeline, m.name as metric, s.metric_result as score
-            FROM summary s
+            FROM metric_scores s
             JOIN pipeline p ON s.pipeline_id = p.id
             JOIN metric m ON s.metric_id = m.id
-            WHERE m.type = '{metric_type}'
+            WHERE {where_clause}
             """  # noqa: S608
         df = self._pg_query(db_name, sql)
 
@@ -335,8 +415,9 @@ class ReportingService:
         for db_name in db_names:
             escaped_dataset = self._escape_sql_value(db_name)
             sql = f"""
+                {self._metric_scores_cte()}
                 SELECT '{escaped_dataset}' as dataset, m.name as metric, s.metric_result as score
-                FROM summary s
+                FROM metric_scores s
                 JOIN pipeline p ON s.pipeline_id = p.id
                 JOIN metric m ON s.metric_id = m.id
                 WHERE p.name = '{escaped_pipeline}' AND m.type = '{pipeline_type}'
@@ -403,10 +484,11 @@ class ReportingService:
                 escaped_metric = self._escape_sql_value(metric_name)
 
                 sql = f"""
+                    {self._metric_scores_cte()}
                     SELECT
                         p.name as pipeline,
                         RANK() OVER (ORDER BY s.metric_result {order}) as rank
-                    FROM summary s
+                    FROM metric_scores s
                     JOIN pipeline p ON s.pipeline_id = p.id
                     JOIN metric m ON s.metric_id = m.id
                     WHERE m.name = '{escaped_metric}'

--- a/autorag_research/reporting/service_manager.py
+++ b/autorag_research/reporting/service_manager.py
@@ -1,0 +1,33 @@
+"""Reporting service lifecycle management for the leaderboard UI."""
+
+from autorag_research.reporting.service import ReportingService
+
+
+class _ServiceManager:
+    """Manage the ReportingService singleton without a module global."""
+
+    _instance: ReportingService | None = None
+
+    @classmethod
+    def get(cls) -> ReportingService:
+        """Get or create the reporting service."""
+        if cls._instance is None:
+            cls._instance = ReportingService()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Close and clear the reporting service."""
+        if cls._instance is not None:
+            cls._instance.close()
+            cls._instance = None
+
+
+def get_service() -> ReportingService:
+    """Get or create the reporting service."""
+    return _ServiceManager.get()
+
+
+def reset_service() -> None:
+    """Close and clear the reporting service."""
+    _ServiceManager.reset()

--- a/autorag_research/reporting/ui.py
+++ b/autorag_research/reporting/ui.py
@@ -3,109 +3,32 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
 from functools import partial
-from typing import Literal
 
 import gradio as gr
 import pandas as pd
-from hydra.utils import instantiate
-from omegaconf import DictConfig, OmegaConf
 
-from autorag_research.cli.config_resolver import ConfigResolver
-from autorag_research.cli.utils import get_config_dir
+from autorag_research.reporting.scope import (
+    LeaderboardScope,
+    MetricType,
+    initial_scope_metric_type,
+    load_leaderboard_scope,
+    scope_filters,
+    scope_metric_types,
+)
 from autorag_research.reporting.service import ReportingService
-
-METRIC_TYPES = Literal["retrieval", "generation"]
-
-
-@dataclass(frozen=True)
-class LeaderboardScope:
-    """Experiment-defined database, pipeline, and metric allowlists."""
-
-    db_name: str
-    pipeline_names: dict[str, tuple[str, ...]]
-    metric_names: dict[str, tuple[str, ...]]
-
-
-def _config_references(config: DictConfig, section: str, metric_type: METRIC_TYPES) -> list[str]:
-    """Return normalized config references for one experiment section and type."""
-    section_config = config.get(section, {})
-    references = section_config.get(metric_type, []) if isinstance(section_config, DictConfig) else []
-    if isinstance(references, str):
-        return [references]
-    return [str(reference) for reference in references]
-
-
-def load_leaderboard_scope(config_name: str) -> LeaderboardScope:
-    """Load leaderboard allowlists from an experiment YAML config."""
-    config_dir = get_config_dir()
-    experiment_path = config_dir / f"{config_name}.yaml"
-    if not experiment_path.exists():
-        raise FileNotFoundError(f"Config file not found: {experiment_path}")  # noqa: TRY003
-
-    experiment_config = OmegaConf.load(experiment_path)
-    if not isinstance(experiment_config, DictConfig):
-        raise TypeError(f"Experiment config must be a YAML mapping: {experiment_path}")  # noqa: TRY003
-
-    db_name = experiment_config.get("db_name")
-    if not db_name:
-        raise ValueError(f"Experiment config must define db_name: {experiment_path}")  # noqa: TRY003
-
-    resolver = ConfigResolver(config_dir=config_dir)
-    pipeline_names: dict[str, tuple[str, ...]] = {}
-    metric_names: dict[str, tuple[str, ...]] = {}
-    for metric_type in ("retrieval", "generation"):
-        pipeline_references = _config_references(experiment_config, "pipelines", metric_type)
-        resolved_pipeline_names = []
-        for reference in pipeline_references:
-            pipeline_config = resolver.resolve_config(["pipelines", metric_type], reference)
-            resolved_pipeline_names.append(str(pipeline_config.get("name", reference)))
-        pipeline_names[metric_type] = tuple(resolved_pipeline_names)
-
-        metric_references = _config_references(experiment_config, "metrics", metric_type)
-        resolved_metric_names = []
-        for reference in metric_references:
-            metric_config = resolver.resolve_config(["metrics", metric_type], reference)
-            resolved_metric_names.append(str(instantiate(metric_config).get_metric_name()))
-        metric_names[metric_type] = tuple(resolved_metric_names)
-
-    return LeaderboardScope(
-        db_name=str(db_name),
-        pipeline_names=pipeline_names,
-        metric_names=metric_names,
-    )
-
-
-# === Service Management ===
-class _ServiceManager:
-    """Manages ReportingService singleton without global variables."""
-
-    _instance: ReportingService | None = None
-
-    @classmethod
-    def get(cls) -> ReportingService:
-        """Get or create ReportingService singleton."""
-        if cls._instance is None:
-            cls._instance = ReportingService()
-        return cls._instance
-
-    @classmethod
-    def reset(cls) -> None:
-        """Reset the service singleton (useful for testing)."""
-        if cls._instance is not None:
-            cls._instance.close()
-            cls._instance = None
+from autorag_research.reporting.service_manager import get_service as _get_service
+from autorag_research.reporting.service_manager import reset_service as _reset_service
 
 
 def get_service() -> ReportingService:
-    """Get or create ReportingService singleton."""
-    return _ServiceManager.get()
+    """Get or create the reporting service."""
+    return _get_service()
 
 
 def reset_service() -> None:
-    """Reset the service singleton (useful for testing)."""
-    _ServiceManager.reset()
+    """Close and clear the reporting service."""
+    _reset_service()
 
 
 def format_dataset_stats(db_name: str) -> str:
@@ -119,22 +42,13 @@ def format_dataset_stats(db_name: str) -> str:
 # === UI Update Handlers ===
 
 
-def _scope_filters(
-    scope: LeaderboardScope | None, metric_type: METRIC_TYPES
-) -> tuple[tuple[str, ...] | None, tuple[str, ...] | None]:
-    """Return pipeline and metric allowlists for the selected metric type."""
-    if scope is None:
-        return None, None
-    return scope.pipeline_names.get(metric_type, ()), scope.metric_names.get(metric_type, ())
-
-
 def on_dataset_change(
-    db_name: str, metric_type: METRIC_TYPES, scope: LeaderboardScope | None = None
+    db_name: str, metric_type: MetricType, scope: LeaderboardScope | None = None
 ) -> tuple[pd.DataFrame, dict]:
     """Handle dataset selection change - returns leaderboard DataFrame and stats."""
     if not db_name:
         return pd.DataFrame(), gr.update(value="")
-    pipeline_names, metric_names = _scope_filters(scope, metric_type)
+    pipeline_names, metric_names = scope_filters(scope, metric_type)
     df = get_service().get_all_metrics_leaderboard(
         db_name,
         metric_type,
@@ -145,13 +59,11 @@ def on_dataset_change(
     return df, gr.update(value=stats)
 
 
-def on_metric_type_change(
-    db_name: str, metric_type: METRIC_TYPES, scope: LeaderboardScope | None = None
-) -> pd.DataFrame:
+def on_metric_type_change(db_name: str, metric_type: MetricType, scope: LeaderboardScope | None = None) -> pd.DataFrame:
     """Handle metric type selection change - returns leaderboard DataFrame."""
     if not db_name:
         return pd.DataFrame()
-    pipeline_names, metric_names = _scope_filters(scope, metric_type)
+    pipeline_names, metric_names = scope_filters(scope, metric_type)
     return get_service().get_all_metrics_leaderboard(
         db_name,
         metric_type,
@@ -161,12 +73,12 @@ def on_metric_type_change(
 
 
 def on_refresh_leaderboard(
-    db_name: str, metric_type: METRIC_TYPES, scope: LeaderboardScope | None = None
+    db_name: str, metric_type: MetricType, scope: LeaderboardScope | None = None
 ) -> tuple[pd.DataFrame, dict]:
     """Refresh leaderboard data."""
     if not db_name:
         return pd.DataFrame(), gr.update(value="")
-    pipeline_names, metric_names = _scope_filters(scope, metric_type)
+    pipeline_names, metric_names = scope_filters(scope, metric_type)
     df = get_service().get_all_metrics_leaderboard(
         db_name,
         metric_type,
@@ -206,12 +118,8 @@ def build_single_dataset_tab(
     scope: LeaderboardScope | None = None,
 ) -> tuple[gr.Tab, gr.Dropdown, gr.Dropdown, gr.Dataframe, gr.Textbox]:
     """Build the single dataset leaderboard tab."""
-    metric_types = [
-        metric_type
-        for metric_type in ("retrieval", "generation")
-        if scope is None or (scope.pipeline_names.get(metric_type) and scope.metric_names.get(metric_type))
-    ]
-    selected_metric_type = metric_types[0] if metric_types else "retrieval"
+    metric_types = scope_metric_types(scope)
+    selected_metric_type = initial_scope_metric_type(scope)
     dataset_change_handler = partial(on_dataset_change, scope=scope)
     metric_type_change_handler = partial(on_metric_type_change, scope=scope)
     refresh_handler = partial(on_refresh_leaderboard, scope=scope)
@@ -350,9 +258,7 @@ def build_borda_ranking_tab(all_datasets: list[str]) -> tuple[gr.Tab, gr.Checkbo
 def create_leaderboard_app(scope: LeaderboardScope | None = None) -> gr.Blocks:
     """Create the Gradio leaderboard application."""
     datasets = [scope.db_name] if scope is not None else get_service().list_available_datasets()
-    initial_metric_type: METRIC_TYPES = "retrieval"
-    if scope is not None and not (scope.pipeline_names.get("retrieval") and scope.metric_names.get("retrieval")):
-        initial_metric_type = "generation"
+    initial_metric_type = initial_scope_metric_type(scope)
 
     with gr.Blocks(title="AutoRAG-Research Leaderboard") as app:
         gr.Markdown("# 🏆 AutoRAG-Research Leaderboard")

--- a/autorag_research/reporting/ui.py
+++ b/autorag_research/reporting/ui.py
@@ -2,14 +2,79 @@
 
 from __future__ import annotations
 
+import argparse
+from dataclasses import dataclass
+from functools import partial
 from typing import Literal
 
 import gradio as gr
 import pandas as pd
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
 
+from autorag_research.cli.config_resolver import ConfigResolver
+from autorag_research.cli.utils import get_config_dir
 from autorag_research.reporting.service import ReportingService
 
 METRIC_TYPES = Literal["retrieval", "generation"]
+
+
+@dataclass(frozen=True)
+class LeaderboardScope:
+    """Experiment-defined database, pipeline, and metric allowlists."""
+
+    db_name: str
+    pipeline_names: dict[str, tuple[str, ...]]
+    metric_names: dict[str, tuple[str, ...]]
+
+
+def _config_references(config: DictConfig, section: str, metric_type: METRIC_TYPES) -> list[str]:
+    """Return normalized config references for one experiment section and type."""
+    section_config = config.get(section, {})
+    references = section_config.get(metric_type, []) if isinstance(section_config, DictConfig) else []
+    if isinstance(references, str):
+        return [references]
+    return [str(reference) for reference in references]
+
+
+def load_leaderboard_scope(config_name: str) -> LeaderboardScope:
+    """Load leaderboard allowlists from an experiment YAML config."""
+    config_dir = get_config_dir()
+    experiment_path = config_dir / f"{config_name}.yaml"
+    if not experiment_path.exists():
+        raise FileNotFoundError(f"Config file not found: {experiment_path}")  # noqa: TRY003
+
+    experiment_config = OmegaConf.load(experiment_path)
+    if not isinstance(experiment_config, DictConfig):
+        raise TypeError(f"Experiment config must be a YAML mapping: {experiment_path}")  # noqa: TRY003
+
+    db_name = experiment_config.get("db_name")
+    if not db_name:
+        raise ValueError(f"Experiment config must define db_name: {experiment_path}")  # noqa: TRY003
+
+    resolver = ConfigResolver(config_dir=config_dir)
+    pipeline_names: dict[str, tuple[str, ...]] = {}
+    metric_names: dict[str, tuple[str, ...]] = {}
+    for metric_type in ("retrieval", "generation"):
+        pipeline_references = _config_references(experiment_config, "pipelines", metric_type)
+        resolved_pipeline_names = []
+        for reference in pipeline_references:
+            pipeline_config = resolver.resolve_config(["pipelines", metric_type], reference)
+            resolved_pipeline_names.append(str(pipeline_config.get("name", reference)))
+        pipeline_names[metric_type] = tuple(resolved_pipeline_names)
+
+        metric_references = _config_references(experiment_config, "metrics", metric_type)
+        resolved_metric_names = []
+        for reference in metric_references:
+            metric_config = resolver.resolve_config(["metrics", metric_type], reference)
+            resolved_metric_names.append(str(instantiate(metric_config).get_metric_name()))
+        metric_names[metric_type] = tuple(resolved_metric_names)
+
+    return LeaderboardScope(
+        db_name=str(db_name),
+        pipeline_names=pipeline_names,
+        metric_names=metric_names,
+    )
 
 
 # === Service Management ===
@@ -54,27 +119,60 @@ def format_dataset_stats(db_name: str) -> str:
 # === UI Update Handlers ===
 
 
-def on_dataset_change(db_name: str, metric_type: METRIC_TYPES) -> tuple[pd.DataFrame, dict]:
+def _scope_filters(
+    scope: LeaderboardScope | None, metric_type: METRIC_TYPES
+) -> tuple[tuple[str, ...] | None, tuple[str, ...] | None]:
+    """Return pipeline and metric allowlists for the selected metric type."""
+    if scope is None:
+        return None, None
+    return scope.pipeline_names.get(metric_type, ()), scope.metric_names.get(metric_type, ())
+
+
+def on_dataset_change(
+    db_name: str, metric_type: METRIC_TYPES, scope: LeaderboardScope | None = None
+) -> tuple[pd.DataFrame, dict]:
     """Handle dataset selection change - returns leaderboard DataFrame and stats."""
     if not db_name:
         return pd.DataFrame(), gr.update(value="")
-    df = get_service().get_all_metrics_leaderboard(db_name, metric_type)
+    pipeline_names, metric_names = _scope_filters(scope, metric_type)
+    df = get_service().get_all_metrics_leaderboard(
+        db_name,
+        metric_type,
+        pipeline_names=pipeline_names,
+        metric_names=metric_names,
+    )
     stats = format_dataset_stats(db_name)
     return df, gr.update(value=stats)
 
 
-def on_metric_type_change(db_name: str, metric_type: METRIC_TYPES) -> pd.DataFrame:
+def on_metric_type_change(
+    db_name: str, metric_type: METRIC_TYPES, scope: LeaderboardScope | None = None
+) -> pd.DataFrame:
     """Handle metric type selection change - returns leaderboard DataFrame."""
     if not db_name:
         return pd.DataFrame()
-    return get_service().get_all_metrics_leaderboard(db_name, metric_type)
+    pipeline_names, metric_names = _scope_filters(scope, metric_type)
+    return get_service().get_all_metrics_leaderboard(
+        db_name,
+        metric_type,
+        pipeline_names=pipeline_names,
+        metric_names=metric_names,
+    )
 
 
-def on_refresh_leaderboard(db_name: str, metric_type: METRIC_TYPES) -> tuple[pd.DataFrame, dict]:
+def on_refresh_leaderboard(
+    db_name: str, metric_type: METRIC_TYPES, scope: LeaderboardScope | None = None
+) -> tuple[pd.DataFrame, dict]:
     """Refresh leaderboard data."""
     if not db_name:
         return pd.DataFrame(), gr.update(value="")
-    df = get_service().get_all_metrics_leaderboard(db_name, metric_type)
+    pipeline_names, metric_names = _scope_filters(scope, metric_type)
+    df = get_service().get_all_metrics_leaderboard(
+        db_name,
+        metric_type,
+        pipeline_names=pipeline_names,
+        metric_names=metric_names,
+    )
     stats = format_dataset_stats(db_name)
     return df, gr.update(value=stats)
 
@@ -104,21 +202,33 @@ def on_datasets_select_for_metrics(db_names: list[str]) -> dict:
 # === UI Component Builders ===
 
 
-def build_single_dataset_tab() -> tuple[gr.Tab, gr.Dropdown, gr.Dropdown, gr.Dataframe, gr.Textbox]:
+def build_single_dataset_tab(
+    scope: LeaderboardScope | None = None,
+) -> tuple[gr.Tab, gr.Dropdown, gr.Dropdown, gr.Dataframe, gr.Textbox]:
     """Build the single dataset leaderboard tab."""
+    metric_types = [
+        metric_type
+        for metric_type in ("retrieval", "generation")
+        if scope is None or (scope.pipeline_names.get(metric_type) and scope.metric_names.get(metric_type))
+    ]
+    selected_metric_type = metric_types[0] if metric_types else "retrieval"
+    dataset_change_handler = partial(on_dataset_change, scope=scope)
+    metric_type_change_handler = partial(on_metric_type_change, scope=scope)
+    refresh_handler = partial(on_refresh_leaderboard, scope=scope)
+
     with gr.Tab("Single Dataset") as tab:
         with gr.Row():
             dataset_dropdown = gr.Dropdown(
                 label="Dataset",
                 choices=[],
-                interactive=True,
+                interactive=scope is None,
                 scale=2,
             )
             metric_type_dropdown = gr.Dropdown(
                 label="Metric Type",
-                choices=["retrieval", "generation"],
-                value="retrieval",
-                interactive=True,
+                choices=metric_types,
+                value=selected_metric_type,
+                interactive=len(metric_types) > 1,
                 scale=1,
             )
             refresh_btn = gr.Button("🔄 Refresh", scale=1)
@@ -136,17 +246,17 @@ def build_single_dataset_tab() -> tuple[gr.Tab, gr.Dropdown, gr.Dropdown, gr.Dat
 
         # Event handlers
         dataset_dropdown.change(
-            fn=on_dataset_change,
+            fn=dataset_change_handler,
             inputs=[dataset_dropdown, metric_type_dropdown],
             outputs=[leaderboard_table, stats_display],
         )
         metric_type_dropdown.change(
-            fn=on_metric_type_change,
+            fn=metric_type_change_handler,
             inputs=[dataset_dropdown, metric_type_dropdown],
             outputs=[leaderboard_table],
         )
         refresh_btn.click(
-            fn=on_refresh_leaderboard,
+            fn=refresh_handler,
             inputs=[dataset_dropdown, metric_type_dropdown],
             outputs=[leaderboard_table, stats_display],
         )
@@ -237,10 +347,12 @@ def build_borda_ranking_tab(all_datasets: list[str]) -> tuple[gr.Tab, gr.Checkbo
 # === Main App Factory ===
 
 
-def create_leaderboard_app() -> gr.Blocks:
+def create_leaderboard_app(scope: LeaderboardScope | None = None) -> gr.Blocks:
     """Create the Gradio leaderboard application."""
-    # Pre-fetch available datasets
-    datasets = get_service().list_available_datasets()
+    datasets = [scope.db_name] if scope is not None else get_service().list_available_datasets()
+    initial_metric_type: METRIC_TYPES = "retrieval"
+    if scope is not None and not (scope.pipeline_names.get("retrieval") and scope.metric_names.get("retrieval")):
+        initial_metric_type = "generation"
 
     with gr.Blocks(title="AutoRAG-Research Leaderboard") as app:
         gr.Markdown("# 🏆 AutoRAG-Research Leaderboard")
@@ -252,9 +364,10 @@ def create_leaderboard_app() -> gr.Blocks:
                 _single_metric_type_dropdown,
                 single_leaderboard_table,
                 single_stats_display,
-            ) = build_single_dataset_tab()
-            _cross_tab, _cross_datasets_checkbox = build_cross_dataset_tab(datasets)
-            _borda_tab, _borda_datasets_checkbox, _borda_metrics_checkbox = build_borda_ranking_tab(datasets)
+            ) = build_single_dataset_tab(scope)
+            if scope is None:
+                _cross_tab, _cross_datasets_checkbox = build_cross_dataset_tab(datasets)
+                _borda_tab, _borda_datasets_checkbox, _borda_metrics_checkbox = build_borda_ranking_tab(datasets)
 
         # Initialize single dataset dropdown with available datasets
         app.load(
@@ -265,7 +378,7 @@ def create_leaderboard_app() -> gr.Blocks:
         # Auto-load leaderboard when app starts if datasets exist
         if datasets:
             app.load(
-                fn=lambda: on_dataset_change(datasets[0], "retrieval"),
+                fn=partial(on_dataset_change, datasets[0], initial_metric_type, scope=scope),
                 outputs=[single_leaderboard_table, single_stats_display],
             )
 
@@ -274,7 +387,14 @@ def create_leaderboard_app() -> gr.Blocks:
 
 def main() -> None:
     """Launch the leaderboard application."""
-    app = create_leaderboard_app()
+    parser = argparse.ArgumentParser(description="Launch the AutoRAG-Research leaderboard.")
+    parser.add_argument(
+        "--config-name",
+        help="Experiment config name used to restrict the database, pipelines, and metrics.",
+    )
+    args = parser.parse_args()
+    scope = load_leaderboard_scope(args.config_name) if args.config_name else None
+    app = create_leaderboard_app(scope)
     app.launch()
 
 

--- a/autorag_research/schema.py
+++ b/autorag_research/schema.py
@@ -12,13 +12,15 @@ GENERATION_CONTEXT_CHUNK_ID_KEYS = (
     GENERATION_CONTEXT_CHUNK_ID_KEY,
     "source_chunk_ids",
     "selected_subset_chunk_ids",
+    "selected_chunk_ids",
     "chunk_ids",
 )
 """Ordered metadata keys that identify final generation evidence.
 
 ``context_chunk_ids`` is the canonical contract for new generation pipelines.
-The remaining names are accepted by generation evaluation for compatibility
-with existing pipeline-specific metadata.
+``selected_chunk_ids`` is accepted for dynamic retrieval pipelines that store the
+post-selection evidence set under that name. The remaining names are accepted by
+generation evaluation for compatibility with existing pipeline-specific metadata.
 """
 
 GENERATION_LEGACY_RETRIEVED_CHUNK_ID_KEYS = ("retrieved_chunk_ids", "retrieval_chunk_ids")

--- a/autorag_research/util.py
+++ b/autorag_research/util.py
@@ -7,7 +7,7 @@ import logging
 import re
 import string
 from collections.abc import Awaitable, Callable, Iterable
-from typing import Any, TypeVar, cast
+from typing import Any, Literal, TypeVar, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -25,6 +25,34 @@ R = TypeVar("R")
 
 
 _PLUGIN_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class LoopBoundSemaphore:
+    """Provide one semaphore per event loop for a reusable async component."""
+
+    def __init__(self, max_concurrency: int):
+        if max_concurrency < 1:
+            msg = "max_concurrency must be at least 1"
+            raise ValueError(msg)
+        self._max_concurrency = max_concurrency
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._semaphore: asyncio.Semaphore | None = None
+
+    def get(self) -> asyncio.Semaphore:
+        """Return the semaphore associated with the running event loop."""
+        loop = asyncio.get_running_loop()
+        if self._loop is not loop:
+            self._loop = loop
+            self._semaphore = asyncio.Semaphore(self._max_concurrency)
+        if self._semaphore is None:
+            msg = "Semaphore was not initialized"
+            raise RuntimeError(msg)
+        return self._semaphore
+
+
+class _ConcurrencyFailure:
+    def __init__(self, error: Exception):
+        self.error = error
 
 
 def validate_plugin_name(name: str) -> bool:
@@ -131,11 +159,35 @@ def unpack_and_run(target_list: list[list[Any]], func: Callable, *args: tuple, *
     return result
 
 
+@overload
 async def run_with_concurrency_limit(
     items: Iterable[T],
     async_func: Callable[[T], Awaitable[R]],
     max_concurrency: int,
     error_message: str = "Task failed",
+    *,
+    raise_on_error: Literal[True],
+) -> list[R]: ...
+
+
+@overload
+async def run_with_concurrency_limit(
+    items: Iterable[T],
+    async_func: Callable[[T], Awaitable[R]],
+    max_concurrency: int,
+    error_message: str = "Task failed",
+    *,
+    raise_on_error: Literal[False] = False,
+) -> list[R | None]: ...
+
+
+async def run_with_concurrency_limit(
+    items: Iterable[T],
+    async_func: Callable[[T], Awaitable[R]],
+    max_concurrency: int,
+    error_message: str = "Task failed",
+    *,
+    raise_on_error: bool = False,
 ) -> list[R | None]:
     """Run async function on items with concurrency limit using semaphore.
 
@@ -148,6 +200,7 @@ async def run_with_concurrency_limit(
         async_func: Async function that takes an item and returns a result.
         max_concurrency: Maximum number of concurrent operations.
         error_message: Message to log when an operation fails.
+        raise_on_error: Re-raise the original exception instead of returning None.
 
     Returns:
         List of results (or None if failed) in same order as items.
@@ -168,8 +221,13 @@ async def run_with_concurrency_limit(
     """
     semaphore = asyncio.Semaphore(max_concurrency)
 
-    async def process_with_semaphore(item: T) -> R | None:
+    async def process_with_semaphore(item: T) -> R | None | _ConcurrencyFailure:
         async with semaphore:
+            if raise_on_error:
+                try:
+                    return await async_func(item)
+                except Exception as error:
+                    return _ConcurrencyFailure(error)
             try:
                 return await async_func(item)
             except Exception:
@@ -177,7 +235,13 @@ async def run_with_concurrency_limit(
                 return None
 
     tasks = [process_with_semaphore(item) for item in items]
-    return await asyncio.gather(*tasks)
+    results = await asyncio.gather(*tasks)
+    completed: list[R | None] = []
+    for result in results:
+        if isinstance(result, _ConcurrencyFailure):
+            raise result.error
+        completed.append(result)
+    return completed
 
 
 def to_async_func(func: Callable[..., R]) -> Callable[..., Awaitable[R]]:

--- a/configs/pipelines/generation/main_rag.yaml
+++ b/configs/pipelines/generation/main_rag.yaml
@@ -25,6 +25,7 @@ retrieval_pipeline_name: bm25
 llm: gpt-5.2
 top_k: 20
 batch_size: 10
+agent_max_concurrency: 4
 
 # Adaptive filtering parameter
 # n=0: threshold = mean (default, recommended by paper)

--- a/configs/pipelines/generation/spd_rag.yaml
+++ b/configs/pipelines/generation/spd_rag.yaml
@@ -19,6 +19,7 @@ retrieval_pipeline_name: bm25
 llm: gpt-5.2
 top_k: 10
 batch_size: 10
+agent_max_concurrency: 4
 
 # Map-reduce synthesis parameters
 max_synthesis_tokens: 4000

--- a/tests/autorag_research/data/test_crag.py
+++ b/tests/autorag_research/data/test_crag.py
@@ -1,6 +1,8 @@
 """Tests for CRAGIngestor."""
 
+import bz2
 import importlib
+import io
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +12,7 @@ from autorag_research.data.crag import (
     CRAGIngestor,
     _build_generation_gt,
     _format_search_result_contents,
+    _iter_crag_examples,
     _make_chunk_id,
     _make_query_id,
     _resolve_subset,
@@ -122,10 +125,30 @@ class TestIdsAndRegistry:
         assert meta.hf_repo is None
 
 
+class TestCRAGStreaming:
+    @patch("autorag_research.data.crag.urllib.request.urlopen")
+    def test_streaming_download_uses_timeout(self, mock_urlopen):
+        mock_urlopen.return_value = io.BytesIO(bz2.compress(b'{"interaction_id": "dev-1"}\n'))
+
+        assert list(_iter_crag_examples()) == [{"interaction_id": "dev-1"}]
+        mock_urlopen.assert_called_once_with(
+            "https://github.com/facebookresearch/CRAG/raw/refs/heads/main/data/crag_task_1_and_2_dev_v4.jsonl.bz2",
+            timeout=60,
+        )
+
+    @patch("autorag_research.data.crag.urllib.request.urlopen")
+    def test_streaming_rejects_oversized_json_record(self, mock_urlopen, monkeypatch):
+        monkeypatch.setattr("autorag_research.data.crag.CRAG_MAX_JSON_LINE_BYTES", 32, raising=False)
+        mock_urlopen.return_value = io.BytesIO(bz2.compress(b'{"value": "' + b"x" * 64 + b'"}\n'))
+
+        with pytest.raises(ValueError, match="CRAG JSONL record exceeds"):
+            list(_iter_crag_examples())
+
+
 class TestIngestUnit:
-    @patch("autorag_research.data.crag.load_dataset")
-    def test_ingest_filters_to_requested_split_and_skips_retrieval_gt(self, mock_load_dataset, mock_embedding_model):
-        mock_load_dataset.return_value = SAMPLE_EXAMPLES
+    @patch("autorag_research.data.crag._iter_crag_examples")
+    def test_ingest_filters_to_requested_split_and_skips_retrieval_gt(self, mock_iter_examples, mock_embedding_model):
+        mock_iter_examples.return_value = iter(SAMPLE_EXAMPLES)
         service = MagicMock()
         ingestor = CRAGIngestor(mock_embedding_model, batch_size=10)
         ingestor.set_service(service)
@@ -152,14 +175,14 @@ class TestIngestUnit:
         service.add_retrieval_gt.assert_not_called()
         service.clean.assert_called_once_with()
 
-    @patch("autorag_research.data.crag.load_dataset")
+    @patch("autorag_research.data.crag._iter_crag_examples")
     def test_ingest_warns_that_train_alias_duplicates_dev_examples(
         self,
-        mock_load_dataset,
+        mock_iter_examples,
         mock_embedding_model,
         caplog,
     ):
-        mock_load_dataset.return_value = []
+        mock_iter_examples.return_value = iter(())
         service = MagicMock()
         ingestor = CRAGIngestor(mock_embedding_model, batch_size=10)
         ingestor.set_service(service)

--- a/tests/autorag_research/evaluation/metrics/test_generation.py
+++ b/tests/autorag_research/evaluation/metrics/test_generation.py
@@ -362,7 +362,8 @@ def test_response_relevancy_mixed_noncommittal_keeps_score():
     assert scores[0] == pytest.approx(1.0)
 
 
-def test_response_relevancy_invalid_json_returns_nan():
+
+def test_response_relevancy_invalid_json_zeroes_score():
     metric_inputs = [
         MetricInput(
             query="Where was Albert Einstein born?",
@@ -373,7 +374,7 @@ def test_response_relevancy_invalid_json_returns_nan():
 
     scores = response_relevancy(metric_inputs, llm=llm, embedding_model=KeywordEmbeddings(), strictness=3)
 
-    assert scores[0] != scores[0]  # NaN check
+    assert scores == [0.0]
 
 
 def test_exact_match_uses_squad_normalization():

--- a/tests/autorag_research/evaluation/metrics/test_generation.py
+++ b/tests/autorag_research/evaluation/metrics/test_generation.py
@@ -277,6 +277,25 @@ def test_sem_score_from_string_configs():
     assert all(isinstance(score, float) for score in scores)
 
 
+class EmptyPredictionEmbeddings(Embeddings):
+    """Map empty predictions orthogonally to non-empty references."""
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0, 1.0] if text == "" else [1.0, 0.0] for text in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return [0.0, 1.0] if text == "" else [1.0, 0.0]
+
+
+@pytest.mark.parametrize("generated_texts", [None, ""])
+def test_sem_score_scores_missing_prediction_as_empty(generated_texts: str | None):
+    metric_inputs = [MetricInput(generated_texts=generated_texts, generation_gt=["answer"])]
+
+    scores = sem_score(metric_inputs, embedding_model=EmptyPredictionEmbeddings())
+
+    assert scores == [0.0]
+
+
 @pytest.mark.gpu
 def test_bert_score_en():
     base_test_metrics(

--- a/tests/autorag_research/evaluation/metrics/test_generation.py
+++ b/tests/autorag_research/evaluation/metrics/test_generation.py
@@ -2,7 +2,7 @@ import math
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -228,6 +228,30 @@ def test_rouge():
     base_test_metrics(rouge, [0.909, 0.35714, 1.0], similarity_generation_metric_inputs)
 
 
+@pytest.mark.parametrize("metric_func", [rouge, exact_match, token_f1])
+def test_reference_metrics_score_missing_prediction_as_empty(metric_func):
+    metric_inputs = [MetricInput(generated_texts=None, generation_gt=["answer"])]
+
+    assert metric_func(metric_inputs) == [0.0]
+
+
+def test_bert_score_scores_missing_prediction_as_empty(monkeypatch):
+    evaluator = MagicMock()
+    evaluator.compute.return_value = {"f1": [0.0]}
+    monkeypatch.setattr("autorag_research.evaluation.metrics.generation.evaluate.load", lambda _name: evaluator)
+
+    scores = bert_score([MetricInput(generated_texts=None, generation_gt=["answer"])], n_threads=1)
+
+    assert scores == [0.0]
+    evaluator.compute.assert_called_once_with(
+        predictions=[""],
+        references=["answer"],
+        lang="en",
+        nthreads=1,
+        batch_size=128,
+    )
+
+
 @patch.object(
     OpenAIEmbeddings,
     "embed_documents",
@@ -360,7 +384,6 @@ def test_response_relevancy_mixed_noncommittal_keeps_score():
     scores = response_relevancy(metric_inputs, llm=llm, embedding_model=KeywordEmbeddings(), strictness=3)
 
     assert scores[0] == pytest.approx(1.0)
-
 
 
 def test_response_relevancy_invalid_json_zeroes_score():

--- a/tests/autorag_research/orm/repository/test_base_repository.py
+++ b/tests/autorag_research/orm/repository/test_base_repository.py
@@ -4,9 +4,12 @@ Tests the count methods for single and multi-vector embeddings.
 Uses existing database data for read operations.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 from sqlalchemy.orm import Session
 
+import autorag_research.orm.repository.base as base_repository
 from autorag_research.orm.repository.base import _sanitize_dict, _sanitize_text_value
 from autorag_research.orm.repository.chunk import ChunkRepository
 from autorag_research.orm.repository.query import QueryRepository
@@ -172,6 +175,21 @@ class TestAddBulkSanitization:
         """Test add_bulk with empty list returns empty list."""
         result = chunk_repository.add_bulk([])
         assert result == []
+
+    def test_add_bulk_splits_large_insert(self, db_session: Session, chunk_repository: ChunkRepository, monkeypatch):
+        monkeypatch.setattr(base_repository, "_BULK_INSERT_CHUNK", 2)
+        execute = MagicMock(wraps=db_session.execute)
+        monkeypatch.setattr(db_session, "execute", execute)
+
+        ids = chunk_repository.add_bulk([{"contents": f"chunk {index}"} for index in range(3)])
+        db_session.flush()
+
+        assert len(ids) == 3
+        assert execute.call_count == 2
+
+        for chunk_id in ids:
+            db_session.delete(db_session.get(Chunk, chunk_id))
+        db_session.commit()
 
 
 class TestAddBulkSkipDuplicates:

--- a/tests/autorag_research/orm/service/test_generation_evaluation.py
+++ b/tests/autorag_research/orm/service/test_generation_evaluation.py
@@ -93,6 +93,7 @@ class TestGenerationEvaluationService:
             "context_chunk_ids",
             "source_chunk_ids",
             "selected_subset_chunk_ids",
+            "selected_chunk_ids",
             "chunk_ids",
         )
         assert GENERATION_LEGACY_RETRIEVED_CHUNK_ID_KEYS == ("retrieved_chunk_ids", "retrieval_chunk_ids")
@@ -232,6 +233,47 @@ class TestGenerationEvaluationService:
                             result_metadata={
                                 "retrieval_chunk_ids": [1, 2, 3],
                                 "selected_subset_chunk_ids": [2, 3],
+                            },
+                        )
+                    ]
+                )
+                self.chunk_results = Obj(get_by_query_and_pipeline=lambda query_ids, pipeline_id: [])
+                self.retrieval_relations = Obj(get_by_query_id=lambda query_id: [])
+                self.chunks = Obj(
+                    get_by_ids=lambda chunk_ids: [
+                        Obj(id=1, contents="retrieved only"),
+                        Obj(id=2, contents="selected two"),
+                        Obj(id=3, contents="selected three"),
+                    ]
+                )
+                self.queries = Obj(get_by_id=lambda query_id: Obj(contents="q1", generation_gt=["gt"]))
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                return None
+
+        monkeypatch.setattr(service, "_create_uow", lambda: FakeUow())
+
+        results = service._get_execution_results(pipeline_id=1, query_ids=[1])
+        assert results[1]["retrieved_contents"] == ["selected two", "selected three"]
+
+    def test_get_execution_results_uses_selected_chunk_ids_as_generation_context(self, service, monkeypatch):
+        class Obj:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        class FakeUow:
+            def __init__(self):
+                self.executor_results = Obj(
+                    get_by_queries_and_pipeline=lambda query_ids, pipeline_id: [
+                        Obj(
+                            query_id=1,
+                            generation_result="Generated answer",
+                            result_metadata={
+                                "selected_chunk_ids": [2, 3],
+                                "retrieved_chunk_ids": [1, 2, 3],
                             },
                         )
                     ]

--- a/tests/autorag_research/pipelines/generation/test_main_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_main_rag_pipeline.py
@@ -12,6 +12,7 @@ Test Strategy:
 - Edge case tests for filtering scenarios
 """
 
+import asyncio
 from statistics import mean, stdev
 from unittest.mock import MagicMock
 
@@ -159,17 +160,10 @@ class TestMAINRAGPipelineUnit:
         assert abs(threshold - expected) < 0.001
         assert threshold < expected_mean  # Lower threshold is more permissive
 
-    # ==================== LogprobsNotSupportedError Tests ====================
     @pytest.mark.asyncio
-    async def test_generate_raises_error_without_logprobs(
+    async def test_generate_uses_text_fallback_without_logprobs(
         self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results
     ):
-        """Test that _generate raises LogprobsNotSupportedError when LLM doesn't support logprobs.
-
-        The error should be raised during the Agent-2 (Judge) phase when multiple documents
-        are retrieved and filtering is needed.
-        """
-        from autorag_research.exceptions import LogprobsNotSupportedError
         from autorag_research.pipelines.generation.main_rag import MAINRAGPipeline
 
         # Create mock LLM WITHOUT logprobs
@@ -183,9 +177,10 @@ class TestMAINRAGPipelineUnit:
         )
         cleanup_pipeline_results.append(pipeline.pipeline_id)
 
-        # This should raise LogprobsNotSupportedError during the Judge phase
-        with pytest.raises(LogprobsNotSupportedError):
-            await pipeline._generate(query_id=1, top_k=3)
+        result = await pipeline._generate(query_id=1, top_k=3)
+
+        assert result.text == "Yes"
+        assert result.metadata["filtered_doc_count"] == 3
 
     # ==================== Pipeline Configuration Tests ====================
 
@@ -945,6 +940,62 @@ class TestMAINRAGParallelExecution:
         assert response.usage_metadata["total_tokens"] == 70
 
     @pytest.mark.asyncio
+    async def test_llm_concurrency_limit_is_shared_across_calls(
+        self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results
+    ):
+        from autorag_research.pipelines.generation.main_rag import MAINRAGPipeline
+
+        active_calls = 0
+        max_active_calls = 0
+        mock_llm = MagicMock()
+
+        async def mock_ainvoke(_messages):
+            nonlocal active_calls, max_active_calls
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+            await asyncio.sleep(0.01)
+            active_calls -= 1
+            return MagicMock(content="answer")
+
+        mock_llm.ainvoke = mock_ainvoke
+        pipeline = MAINRAGPipeline(
+            session_factory=session_factory,
+            name="test_shared_agent_concurrency",
+            llm=mock_llm,
+            retrieval_pipeline=mock_retrieval_pipeline,
+            agent_max_concurrency=2,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        await asyncio.gather(*[pipeline._aagent_predict("query", f"document-{index}") for index in range(8)])
+
+        assert max_active_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_parallel_agent_failure_preserves_provider_exception(
+        self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results
+    ):
+        from autorag_research.pipelines.generation.main_rag import MAINRAGPipeline
+
+        mock_llm = MagicMock()
+
+        async def mock_ainvoke(_messages):
+            msg = "provider returned 429"
+            raise ValueError(msg)
+
+        mock_llm.ainvoke = mock_ainvoke
+        pipeline = MAINRAGPipeline(
+            session_factory=session_factory,
+            name="test_parallel_provider_error",
+            llm=mock_llm,
+            retrieval_pipeline=mock_retrieval_pipeline,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        with pytest.raises(ValueError, match="provider returned 429"):
+            await pipeline._generate(query_id=1, top_k=3)
+
+    @pytest.mark.asyncio
     async def test_aagent_judge_returns_correct_score(
         self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results
     ):
@@ -999,11 +1050,9 @@ class TestMAINRAGParallelExecution:
         assert response.usage_metadata["total_tokens"] == 70
 
     @pytest.mark.asyncio
-    async def test_aagent_judge_raises_logprobs_not_supported(
+    async def test_aagent_judge_uses_text_fallback_without_logprobs(
         self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results
     ):
-        """Test that async _aagent_judge raises LogprobsNotSupportedError when no logprobs."""
-        from autorag_research.exceptions import LogprobsNotSupportedError
         from autorag_research.pipelines.generation.main_rag import MAINRAGPipeline
 
         mock_llm = MagicMock()
@@ -1030,8 +1079,10 @@ class TestMAINRAGParallelExecution:
         )
         cleanup_pipeline_results.append(pipeline.pipeline_id)
 
-        with pytest.raises(LogprobsNotSupportedError):
-            await pipeline._aagent_judge("test query", "test document", "test answer")
+        score, response = await pipeline._aagent_judge("test query", "test document", "test answer")
+
+        assert score == 1.0
+        assert response.content == "Yes"
 
     def test_run_with_batch_size(self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results):
         """Test that run() works correctly with batch_size parameter."""
@@ -1178,6 +1229,7 @@ class TestMAINRAGPipelineConfig:
         assert kwargs["llm"] == mock_llm
         assert kwargs["retrieval_pipeline"] == mock_retrieval
         assert kwargs["std_multiplier"] == 0.5
+        assert kwargs["agent_max_concurrency"] == 4
         assert "predictor_system_prompt" in kwargs
         assert "predictor_user_prompt" in kwargs
         assert "judge_system_prompt" in kwargs
@@ -1196,6 +1248,7 @@ class TestMAINRAGPipelineConfig:
         )
 
         assert config.std_multiplier == 0.0
+        assert config.agent_max_concurrency == 4
 
 
 class TestCalculateBinaryLogprobScore:

--- a/tests/autorag_research/pipelines/generation/test_spd_rag_pipeline.py
+++ b/tests/autorag_research/pipelines/generation/test_spd_rag_pipeline.py
@@ -1,5 +1,6 @@
 """Tests for SPD-RAG (Sub-Agent Per Document) generation pipeline."""
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -48,6 +49,62 @@ class TestSPDRAGPipelineUnit:
             session.commit()
         finally:
             session.close()
+
+    @pytest.mark.asyncio
+    async def test_llm_concurrency_limit_is_shared_across_calls(
+        self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results
+    ):
+        from autorag_research.pipelines.generation.spd_rag import SPDRAGPipeline
+
+        active_calls = 0
+        max_active_calls = 0
+        mock_llm = MagicMock()
+
+        async def mock_ainvoke(_messages):
+            nonlocal active_calls, max_active_calls
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+            await asyncio.sleep(0.01)
+            active_calls -= 1
+            return MagicMock(content="answer")
+
+        mock_llm.ainvoke = mock_ainvoke
+        pipeline = SPDRAGPipeline(
+            session_factory=session_factory,
+            name="test_spd_shared_agent_concurrency",
+            llm=mock_llm,
+            retrieval_pipeline=mock_retrieval_pipeline,
+            agent_max_concurrency=2,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        await asyncio.gather(*[pipeline._sub_agent_generate("query", f"document-{index}") for index in range(8)])
+
+        assert max_active_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_parallel_agent_failure_preserves_provider_exception(
+        self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results
+    ):
+        from autorag_research.pipelines.generation.spd_rag import SPDRAGPipeline
+
+        mock_llm = MagicMock()
+
+        async def mock_ainvoke(_messages):
+            msg = "provider returned 429"
+            raise ValueError(msg)
+
+        mock_llm.ainvoke = mock_ainvoke
+        pipeline = SPDRAGPipeline(
+            session_factory=session_factory,
+            name="test_spd_parallel_provider_error",
+            llm=mock_llm,
+            retrieval_pipeline=mock_retrieval_pipeline,
+        )
+        cleanup_pipeline_results.append(pipeline.pipeline_id)
+
+        with pytest.raises(ValueError, match="provider returned 429"):
+            await pipeline._generate(query_id=1, top_k=3)
 
     def test_pipeline_config_contains_required_fields(
         self, session_factory, mock_retrieval_pipeline, cleanup_pipeline_results
@@ -500,6 +557,7 @@ class TestSPDRAGPipelineConfig:
         assert kwargs["retrieval_pipeline"] == mock_retrieval
         assert kwargs["max_synthesis_tokens"] == 2048
         assert kwargs["synthesis_batch_size"] == 4
+        assert kwargs["agent_max_concurrency"] == 4
         assert "sub_agent_system_prompt" in kwargs
         assert "sub_agent_user_prompt" in kwargs
         assert "coordinator_system_prompt" in kwargs
@@ -519,3 +577,4 @@ class TestSPDRAGPipelineConfig:
 
         assert config.synthesis_batch_size == 3
         assert config.max_synthesis_tokens == 4000
+        assert config.agent_max_concurrency == 4

--- a/tests/autorag_research/reporting/test_service.py
+++ b/tests/autorag_research/reporting/test_service.py
@@ -129,6 +129,9 @@ class TestReportingService:
 
         assert not df.empty
         assert list(df.columns) == ["rank", "pipeline", "score", "time_ms"]
+        query = mock_conn.execute.call_args_list[-1][0][0]
+        assert "evaluation_result" in query
+        assert "FROM metric_scores s" in query
 
     def test_get_leaderboard_ascending(self, service_with_mock):
         """Test get_leaderboard with ascending order."""
@@ -436,6 +439,45 @@ class TestReportingService:
         query = call_args[0][0]
         assert "generation" in query
 
+    def test_get_all_metrics_leaderboard_filters_pipelines_and_metrics(self, service_with_mock):
+        """Test experiment allowlists are included in the leaderboard query."""
+        service, mock_conn = service_with_mock
+        mock_conn.execute.return_value.df.return_value = pd.DataFrame()
+
+        service.get_all_metrics_leaderboard(
+            "test-db",
+            "retrieval",
+            pipeline_names=["bm25", "vector_search", "hyde"],
+            metric_names=["retrieval_ndcg", "retrieval_recall", "retrieval_mrr"],
+        )
+
+        query = mock_conn.execute.call_args_list[-1][0][0]
+        assert "p.name IN" in query
+        assert "m.name IN" in query
+        assert "bm25" in query
+        assert "vector_search" in query
+        assert "hyde" in query
+        assert "retrieval_ndcg" in query
+        assert "retrieval_recall" in query
+        assert "retrieval_mrr" in query
+
+    @pytest.mark.parametrize("pipeline_names,metric_names", [([], None), (None, [])])
+    def test_get_all_metrics_leaderboard_empty_allowlist_returns_empty(
+        self, service_with_mock, pipeline_names, metric_names
+    ):
+        """Test an explicitly empty experiment section cannot expose all results."""
+        service, mock_conn = service_with_mock
+
+        df = service.get_all_metrics_leaderboard(
+            "test-db",
+            "retrieval",
+            pipeline_names=pipeline_names,
+            metric_names=metric_names,
+        )
+
+        assert df.empty
+        mock_conn.execute.assert_not_called()
+
     def test_get_all_metrics_leaderboard_empty_result(self, service_with_mock):
         """Test get_all_metrics_leaderboard returns empty DataFrame when no data."""
         service, mock_conn = service_with_mock
@@ -487,8 +529,8 @@ class TestReportingService:
             result = MagicMock()
             if "ATTACH" in query:
                 return result
-            # First call: get_pipeline_type (contains config->>'pipeline_type')
-            if "config" in query:
+            # First call: get_pipeline_type (selects evaluated metric type)
+            if "SELECT m.type as pipeline_type" in query:
                 result.df.return_value = pd.DataFrame({"pipeline_type": ["retrieval"]})
             # Subsequent calls: metric data for each dataset
             else:
@@ -544,7 +586,7 @@ class TestReportingService:
             result = MagicMock()
             if "ATTACH" in query:
                 return result
-            if "config" in query:
+            if "SELECT m.type as pipeline_type" in query:
                 result.df.return_value = pd.DataFrame({"pipeline_type": ["retrieval"]})
             else:
                 result.df.return_value = pd.DataFrame({

--- a/tests/autorag_research/reporting/test_service.py
+++ b/tests/autorag_research/reporting/test_service.py
@@ -1,7 +1,9 @@
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pandas as pd
 import pytest
+from sqlalchemy import text
 
 from autorag_research.orm.connection import DBConnection
 from autorag_research.reporting.service import ReportingService
@@ -129,9 +131,6 @@ class TestReportingService:
 
         assert not df.empty
         assert list(df.columns) == ["rank", "pipeline", "score", "time_ms"]
-        query = mock_conn.execute.call_args_list[-1][0][0]
-        assert "evaluation_result" in query
-        assert "FROM metric_scores s" in query
 
     def test_get_leaderboard_ascending(self, service_with_mock):
         """Test get_leaderboard with ascending order."""
@@ -186,9 +185,6 @@ class TestReportingService:
         result = service.get_pipeline_type("test-db", "naive_rag_pipeline")
 
         assert result == "generation"
-        query = mock_conn.execute.call_args_list[-1][0][0]
-        assert "executor_result" in query
-        assert "BOOL_OR(m.type = ''generation'')" in query
 
     def test_get_pipeline_type_not_found(self, service_with_mock):
         """Test get_pipeline_type returns None when pipeline not found."""
@@ -443,28 +439,6 @@ class TestReportingService:
         query = call_args[0][0]
         assert "generation" in query
 
-    def test_get_all_metrics_leaderboard_filters_pipelines_and_metrics(self, service_with_mock):
-        """Test experiment allowlists are included in the leaderboard query."""
-        service, mock_conn = service_with_mock
-        mock_conn.execute.return_value.df.return_value = pd.DataFrame()
-
-        service.get_all_metrics_leaderboard(
-            "test-db",
-            "retrieval",
-            pipeline_names=["bm25", "vector_search", "hyde"],
-            metric_names=["retrieval_ndcg", "retrieval_recall", "retrieval_mrr"],
-        )
-
-        query = mock_conn.execute.call_args_list[-1][0][0]
-        assert "p.name IN" in query
-        assert "m.name IN" in query
-        assert "bm25" in query
-        assert "vector_search" in query
-        assert "hyde" in query
-        assert "retrieval_ndcg" in query
-        assert "retrieval_recall" in query
-        assert "retrieval_mrr" in query
-
     @pytest.mark.parametrize("pipeline_names,metric_names", [([], None), (None, [])])
     def test_get_all_metrics_leaderboard_empty_allowlist_returns_empty(
         self, service_with_mock, pipeline_names, metric_names
@@ -608,3 +582,73 @@ class TestReportingService:
             for col in df.select_dtypes(include=["float64"]).columns:
                 for val in df[col]:
                     assert round(val, 3) == val
+
+
+class TestReportingServiceIntegration:
+    @pytest.fixture
+    def reporting_service(self, db_connection):
+        config = DBConnection(
+            host=db_connection.host,
+            port=db_connection.port,
+            username=db_connection.username,
+            password=db_connection.password,
+            database=db_connection.database,
+        )
+        with ReportingService(config) as service:
+            yield service
+
+    def test_get_all_metrics_leaderboard_prefers_evaluations_and_applies_allowlists(self, reporting_service):
+        df = reporting_service.get_all_metrics_leaderboard(
+            reporting_service.config.database,
+            "retrieval",
+            pipeline_names=("baseline",),
+            metric_names=("retrieval@k",),
+        )
+
+        assert df["pipeline"].tolist() == ["baseline"]
+        assert df["rank"].tolist() == [1]
+        assert df["retrieval@k"].tolist() == pytest.approx([0.8])
+        assert df["Average"].tolist() == pytest.approx([0.8])
+
+    def test_get_all_metrics_leaderboard_uses_legacy_summary_fallback(self, reporting_service):
+        df = reporting_service.get_all_metrics_leaderboard(
+            reporting_service.config.database,
+            "generation",
+            pipeline_names=("rerank",),
+            metric_names=("bleu",),
+        )
+
+        assert df["pipeline"].tolist() == ["rerank"]
+        assert df["bleu"].tolist() == pytest.approx([0.62])
+
+    def test_get_pipeline_type_detects_generation_metric_without_executor_result(
+        self,
+        reporting_service,
+        db_engine,
+    ):
+        pipeline_name = f"reporting_generation_{uuid4().hex}"
+        with db_engine.begin() as connection:
+            pipeline_id = connection.execute(
+                text("INSERT INTO pipeline (name, config) VALUES (:name, '{}'::jsonb) RETURNING id"),
+                {"name": pipeline_name},
+            ).scalar_one()
+            connection.execute(
+                text(
+                    "INSERT INTO evaluation_result (query_id, pipeline_id, metric_id, metric_result) "
+                    "VALUES (1, :pipeline_id, 1, 0.7), (2, :pipeline_id, 2, 0.6)"
+                ),
+                {"pipeline_id": pipeline_id},
+            )
+
+        try:
+            assert reporting_service.get_pipeline_type(reporting_service.config.database, pipeline_name) == "generation"
+        finally:
+            with db_engine.begin() as connection:
+                connection.execute(
+                    text("DELETE FROM evaluation_result WHERE pipeline_id = :pipeline_id"),
+                    {"pipeline_id": pipeline_id},
+                )
+                connection.execute(
+                    text("DELETE FROM pipeline WHERE id = :pipeline_id"),
+                    {"pipeline_id": pipeline_id},
+                )

--- a/tests/autorag_research/reporting/test_service.py
+++ b/tests/autorag_research/reporting/test_service.py
@@ -184,7 +184,11 @@ class TestReportingService:
         mock_conn.execute.return_value.df.return_value = pd.DataFrame({"pipeline_type": ["generation"]})
 
         result = service.get_pipeline_type("test-db", "naive_rag_pipeline")
+
         assert result == "generation"
+        query = mock_conn.execute.call_args_list[-1][0][0]
+        assert "executor_result" in query
+        assert "BOOL_OR(m.type = ''generation'')" in query
 
     def test_get_pipeline_type_not_found(self, service_with_mock):
         """Test get_pipeline_type returns None when pipeline not found."""
@@ -530,7 +534,7 @@ class TestReportingService:
             if "ATTACH" in query:
                 return result
             # First call: get_pipeline_type (selects evaluated metric type)
-            if "SELECT m.type as pipeline_type" in query:
+            if "END AS pipeline_type" in query:
                 result.df.return_value = pd.DataFrame({"pipeline_type": ["retrieval"]})
             # Subsequent calls: metric data for each dataset
             else:
@@ -586,7 +590,7 @@ class TestReportingService:
             result = MagicMock()
             if "ATTACH" in query:
                 return result
-            if "SELECT m.type as pipeline_type" in query:
+            if "END AS pipeline_type" in query:
                 result.df.return_value = pd.DataFrame({"pipeline_type": ["retrieval"]})
             else:
                 result.df.return_value = pd.DataFrame({

--- a/tests/autorag_research/reporting/test_ui.py
+++ b/tests/autorag_research/reporting/test_ui.py
@@ -7,9 +7,11 @@ import pandas as pd
 import pytest
 
 from autorag_research.reporting.ui import (
+    LeaderboardScope,
     create_leaderboard_app,
     format_dataset_stats,
     get_service,
+    load_leaderboard_scope,
     on_dataset_change,
     on_datasets_select_for_metrics,
     on_datasets_select_for_pipelines,
@@ -17,6 +19,20 @@ from autorag_research.reporting.ui import (
     on_refresh_leaderboard,
     reset_service,
 )
+
+
+class TestLeaderboardScope:
+    """Tests for experiment-scoped leaderboard configuration."""
+
+    def test_load_screencast_scope(self):
+        """Test the screencast config resolves its database, pipelines, and metrics."""
+        scope = load_leaderboard_scope("experiment_screencast")
+
+        assert scope.db_name == "emnlp_demo_scifact"
+        assert scope.pipeline_names["retrieval"] == ("bm25", "vector_search", "hyde")
+        assert scope.pipeline_names["generation"] == ()
+        assert scope.metric_names["retrieval"] == ("retrieval_ndcg", "retrieval_recall", "retrieval_mrr")
+        assert scope.metric_names["generation"] == ()
 
 
 class TestServiceManagement:
@@ -117,6 +133,32 @@ class TestUIUpdateHandlers:
 
         pd.testing.assert_frame_equal(df, expected_df)
         assert "100 queries" in stats_update["value"]
+
+    def test_on_dataset_change_applies_experiment_scope(self):
+        """Test scoped leaderboard handlers pass pipeline and metric allowlists."""
+        self.mock_service.get_all_metrics_leaderboard.return_value = pd.DataFrame()
+        self.mock_service.get_dataset_stats.return_value = {
+            "query_count": 300,
+            "chunk_count": 5183,
+            "document_count": 0,
+        }
+        scope = LeaderboardScope(
+            db_name="emnlp_demo_scifact",
+            pipeline_names={"retrieval": ("bm25", "vector_search", "hyde"), "generation": ()},
+            metric_names={
+                "retrieval": ("retrieval_ndcg", "retrieval_recall", "retrieval_mrr"),
+                "generation": (),
+            },
+        )
+
+        on_dataset_change("emnlp_demo_scifact", "retrieval", scope)
+
+        self.mock_service.get_all_metrics_leaderboard.assert_called_once_with(
+            "emnlp_demo_scifact",
+            "retrieval",
+            pipeline_names=("bm25", "vector_search", "hyde"),
+            metric_names=("retrieval_ndcg", "retrieval_recall", "retrieval_mrr"),
+        )
 
     def test_on_dataset_change_empty_db_returns_empty(self):
         """Test on_dataset_change returns empty for empty db_name."""
@@ -239,3 +281,19 @@ class TestAppCreation:
 
             assert isinstance(app, gr.Blocks)
             assert app.title == "AutoRAG-Research Leaderboard"
+
+    def test_create_leaderboard_app_with_scope_skips_dataset_discovery(self):
+        """Test a scoped app exposes only its configured database."""
+        scope = LeaderboardScope(
+            db_name="emnlp_demo_scifact",
+            pipeline_names={"retrieval": ("bm25", "vector_search", "hyde"), "generation": ()},
+            metric_names={
+                "retrieval": ("retrieval_ndcg", "retrieval_recall", "retrieval_mrr"),
+                "generation": (),
+            },
+        )
+        with patch("autorag_research.reporting.ui.get_service") as mock_get:
+            app = create_leaderboard_app(scope)
+
+        assert isinstance(app, gr.Blocks)
+        mock_get.assert_not_called()

--- a/tests/autorag_research/reporting/test_ui.py
+++ b/tests/autorag_research/reporting/test_ui.py
@@ -24,15 +24,15 @@ from autorag_research.reporting.ui import (
 class TestLeaderboardScope:
     """Tests for experiment-scoped leaderboard configuration."""
 
-    def test_load_screencast_scope(self):
-        """Test the screencast config resolves its database, pipelines, and metrics."""
-        scope = load_leaderboard_scope("experiment_screencast")
+    def test_load_default_experiment_scope(self):
+        """Test the shipped experiment config resolves its database, pipelines, and metrics."""
+        scope = load_leaderboard_scope("experiment")
 
-        assert scope.db_name == "emnlp_demo_scifact"
-        assert scope.pipeline_names["retrieval"] == ("bm25", "vector_search", "hyde")
-        assert scope.pipeline_names["generation"] == ()
-        assert scope.metric_names["retrieval"] == ("retrieval_ndcg", "retrieval_recall", "retrieval_mrr")
-        assert scope.metric_names["generation"] == ()
+        assert scope.db_name == "beir_scifact_test"
+        assert scope.pipeline_names["retrieval"] == ("bm25",)
+        assert scope.pipeline_names["generation"] == ("basic_rag",)
+        assert scope.metric_names["retrieval"] == ("retrieval_recall", "retrieval_ndcg")
+        assert scope.metric_names["generation"] == ("rouge_rougeL",)
 
 
 class TestServiceManagement:

--- a/tests/autorag_research/reporting/test_ui.py
+++ b/tests/autorag_research/reporting/test_ui.py
@@ -40,7 +40,7 @@ class TestServiceManagement:
 
     def test_get_service_creates_singleton(self):
         """Test that get_service creates a singleton instance."""
-        with patch("autorag_research.reporting.ui.ReportingService") as mock_cls:
+        with patch("autorag_research.reporting.service_manager.ReportingService") as mock_cls:
             mock_service = MagicMock()
             mock_cls.return_value = mock_service
 
@@ -58,7 +58,7 @@ class TestServiceManagement:
 
     def test_reset_service_closes_and_clears(self):
         """Test that reset_service closes the service and clears singleton."""
-        with patch("autorag_research.reporting.ui.ReportingService") as mock_cls:
+        with patch("autorag_research.reporting.service_manager.ReportingService") as mock_cls:
             mock_service = MagicMock()
             mock_cls.return_value = mock_service
 

--- a/tests/autorag_research/test_executor.py
+++ b/tests/autorag_research/test_executor.py
@@ -520,6 +520,42 @@ class TestMetricEvaluationRules:
         assert result.total_metrics_evaluated == 2
 
 
+class TestRetrievalCompletionFallback:
+    @pytest.mark.parametrize(
+        ("run_result", "expected_success"),
+        [
+            ({"pipeline_id": 999, "total_queries": 1, "failed_queries": []}, True),
+            ({"pipeline_id": 999, "total_queries": 1}, False),
+            ({"pipeline_id": 999, "total_queries": 0, "failed_queries": []}, False),
+        ],
+    )
+    def test_requires_explicit_successful_run_result(self, session_factory, run_result, expected_success):
+        @dataclass
+        class MockRetrievalPipeline(BaseRetrievalPipelineConfig):
+            def get_pipeline_class(self) -> type:
+                return MagicMock
+
+            def get_pipeline_kwargs(self) -> dict[str, Any]:
+                return {}
+
+        config = ExecutorConfig(
+            pipelines=[MockRetrievalPipeline(name="test_retrieval_completion_fallback")],
+            metrics=[],
+            max_retries=0,
+            health_check_queries=0,
+        )
+        executor = Executor(session_factory, config)
+        mock_pipeline = MagicMock()
+        mock_pipeline.pipeline_id = 999
+        mock_pipeline.run.return_value = run_result
+        config.pipelines[0].get_pipeline_class = lambda: lambda **kwargs: mock_pipeline
+        executor._verify_pipeline_completion = MagicMock(return_value=False)
+
+        result = executor.run()
+
+        assert result.pipeline_results[0].success is expected_success
+
+
 class TestHealthCheck:
     """Test suite for health check functionality."""
 

--- a/tests/autorag_research/test_util.py
+++ b/tests/autorag_research/test_util.py
@@ -66,6 +66,29 @@ class TestRunWithConcurrencyLimit:
         assert results == [2, 4, None, 8, 10]
 
     @pytest.mark.asyncio
+    async def test_can_propagate_original_exception(self):
+        completed: list[int] = []
+
+        async def fail(_item: int) -> int:
+            msg = "provider returned 429"
+            raise ValueError(msg)
+
+        async def finish(item: int) -> int:
+            await asyncio.sleep(0.01)
+            completed.append(item)
+            return item
+
+        async def process(item: int) -> int:
+            if item == 1:
+                return await fail(item)
+            return await finish(item)
+
+        with pytest.raises(ValueError, match="provider returned 429"):
+            await run_with_concurrency_limit([1, 2], process, max_concurrency=2, raise_on_error=True)
+
+        assert completed == [2]
+
+    @pytest.mark.asyncio
     async def test_empty_input(self):
         """Test that empty input returns empty list."""
 


### PR DESCRIPTION
Collects the functional code changes previously mixed into the EMNLP demo work.
Paper drafts (EMNLP demo, NeurIPS) and experiment settings/results are intentionally excluded and kept local only.

## Changes
- **ORM ingestion**: chunk multi-row INSERTs under PostgreSQL's 65535 param limit; install pgvector extensions on DB create; fix image_chunk column mapping.
- **Executor**: accept empty-result retrieval runs (no failed queries) as complete.
- **CRAG ingestor**: stream the bz2 JSON dump directly and cap chunk size.
- **Metrics**: score off ground truth so empty predictions still evaluate; return 0.0 (not NaN) for empty response relevancy; accept `selected_chunk_ids` context evidence.
- **Generation pipelines**: parallelize per-document agent calls (MAIN-RAG, SPD-RAG) and fall back to text score when logprobs are unavailable.
- **Reporting**: aggregate metric scores from per-query rows with legacy summary fallback; support scoping the leaderboard to a single experiment config.

Tests updated for metrics, generation evaluation, and reporting service/UI.