### PR TITLE
fix(packaging): correct canonical project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ dependencies = [
 autorag-research = "autorag_research.cli.app:main"
 
 [project.urls]
-Homepage = "https://vkehfdl1.github.io/AutoRAG-Research/"
-Repository = "https://github.com/vkehfdl1/AutoRAG-Research"
-Documentation = "https://vkehfdl1.github.io/AutoRAG-Research/"
+Homepage = "https://nomadamas.github.io/AutoRAG-Research/"
+Repository = "https://github.com/NomaDamas/AutoRAG-Research"
+Documentation = "https://nomadamas.github.io/AutoRAG-Research/"
 
 [project.optional-dependencies]
 gpu = [

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+def test_project_urls_use_canonical_organization_mapping() -> None:
+    # Given the project's machine-readable TOML metadata.
+    pyproject_path = Path(__file__).parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as pyproject_file:
+        project_metadata = tomllib.load(pyproject_file)
+
+    # When the project URLs are read from the parsed metadata.
+    project_urls = project_metadata["project"]["urls"]
+
+    # Then the exact canonical URL mapping is present.
+    assert project_urls == {
+        "Homepage": "https://nomadamas.github.io/AutoRAG-Research/",
+        "Repository": "https://github.com/NomaDamas/AutoRAG-Research",
+        "Documentation": "https://nomadamas.github.io/AutoRAG-Research/",
+    }


### PR DESCRIPTION
## Summary

- update the package Homepage, Repository, and Documentation URLs to the canonical `NomaDamas` locations
- add a parsed metadata regression test for the exact `[project.urls]` mapping

## Root cause

The package metadata still referenced the maintainer's former personal GitHub namespace, so PyPI exposed stale project links.

## Verification

- `make check`
- `uv run pytest tests/test_project_metadata.py -q` (`1 passed`)
- `uv build --no-sources`; inspected the wheel `METADATA` and confirmed the three canonical `Project-URL` entries
- `curl -fsSIL https://nomadamas.github.io/AutoRAG-Research/` (`HTTP/2 200`)
- Docker-backed suite: `1697 passed`; the remaining 5 failures are existing live OpenAI tests returning HTTP 401 for the configured key

The corrected links will appear on PyPI after the next package release.

Closes #377
