### PR TITLE
ci(release): use trusted PyPI publishing

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -4,63 +4,86 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
-
-  set-version:
+  build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out release
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
 
-      - name: Export tag
-        id: vars
-        run: echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
-        if: ${{ github.event_name == 'release' }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          version: "0.9.7"
+          enable-cache: false
 
-      - name: Update project version
-        run: |
-          sed -i "s/^version = \".*\"/version = \"$RELEASE_VERSION\"/" pyproject.toml
+      - name: Set release version
         env:
-          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-        if: ${{ github.event_name == 'release' }}
-
-      - name: Upload updated pyproject.toml
-        uses: actions/upload-artifact@v4
-        with:
-          name: pyproject-toml
-          path: pyproject.toml
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: [set-version]
-    steps:
-      - name: Check out
-        uses: actions/checkout@v4
-
-      - name: Set up the environment
-        uses: ./.github/actions/setup-python-env
-
-      - name: Download updated pyproject.toml
-        uses: actions/download-artifact@v4
-        with:
-          name: pyproject-toml
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+        run: uv version --frozen -- "$RELEASE_VERSION"
 
       - name: Build package
-        run: uv build
+        run: uv build --no-sources
 
-      - name: Publish package
-        run: uv publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      - name: Upload package distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: python-package-distributions
+          path: dist
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-24.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/autorag-research
+    permissions:
+      id-token: write
+    steps:
+      - name: Download package distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+          attestations: true
 
   deploy-docs:
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
-      - name: Check out
-        uses: actions/checkout@v4
+      - name: Check out release
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }} # zizmor: ignore[artipacked] -- mkdocs gh-deploy requires checkout credentials
 
-      - name: Set up the environment
-        uses: ./.github/actions/setup-python-env
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          version: "0.9.7"
+          python-version: "3.12"
+          enable-cache: false
+
+      - name: Install documentation dependencies
+        run: uv sync --frozen --all-extras
 
       - name: Deploy documentation
         run: uv run mkdocs gh-deploy --force

--- a/docs/contributing/pypi-release.md
+++ b/docs/contributing/pypi-release.md
@@ -1,0 +1,156 @@
+# PyPI Release
+
+AutoRAG-Research publishes Python distributions through the `release-main` GitHub Actions workflow at
+`.github/workflows/on-release-main.yml`. Publishing a GitHub Release starts the workflow; publishing a tag or
+running a workflow manually does not.
+
+## Trusted Publisher Setup
+
+The PyPI project must have this GitHub Trusted Publisher configured:
+
+| Field | Value |
+|-------|-------|
+| Owner | `NomaDamas` |
+| Repository | `AutoRAG-Research` |
+| Workflow | `on-release-main.yml` |
+| Environment | `pypi` |
+
+The `pypi` environment name must also exist in GitHub and must match the publisher configuration exactly. Keep any
+required reviewers on that environment limited to release maintainers who are authorized to approve a PyPI publish.
+
+### Maintainer permissions
+
+- The release actor needs GitHub repository **write** access to create and publish a release.
+- A protected `pypi` environment may require approval from one of its configured reviewers before the publish job can
+  run.
+- A PyPI project owner, or another account authorized to manage the project's publishing settings, must configure the
+  Trusted Publisher. After configuration, the workflow's trusted publisher identity is the upload principal; maintainers
+  do not need a PyPI token.
+- The workflow needs `id-token: write` only on the publish job. No long-lived PyPI credential is required.
+
+## Release Procedure
+
+### 1. Use a PEP 440 version tag
+
+The workflow passes the GitHub release tag to `uv version --frozen`, so the tag must be a valid
+[PEP 440](https://peps.python.org/pep-0440/) version.
+Use a version such as `0.2.0` or `0.2.0rc1`; do not use labels such as `latest` or `release-0.2.0`.
+
+Check the tag and release notes before publishing the GitHub Release. Once the release is published, the workflow
+checks out that tag and derives the package version from it.
+
+### 2. Publish the GitHub Release
+
+The `published` release event runs the workflow in this order:
+
+1. **Build once.** The `build` job checks out the release tag, sets the version, runs `uv build --no-sources`, and
+   uploads the resulting `dist/` directory as the `python-package-distributions` artifact.
+2. **Publish the same artifact.** The `publish` job downloads that artifact, enters the `pypi` environment, and
+   calls `pypa/gh-action-pypi-publish` with `id-token: write`. PyPI Trusted Publishing exchanges the GitHub OIDC
+   identity for short-lived publish authorization; the workflow does not use `PYPI_TOKEN`.
+3. **Attach provenance.** The publish action is configured with `attestations: true`, so the uploaded distributions
+   receive [PEP 740](https://peps.python.org/pep-0740/) digital attestations tied to the publishing identity.
+4. **Deploy documentation.** The existing documentation deployment runs only after the publish job succeeds.
+
+The publish job does not rebuild the package. The uploaded artifact is the release input and must be treated as
+immutable once it has been handed to the publish job.
+
+## Verify PyPI Provenance
+
+For a published distribution, copy its direct file URL from the PyPI release page and run the PyPI attestation
+verifier:
+
+```bash
+WHEEL_DIRECT_URL="https://files.pythonhosted.org/.../autorag_research-<version>-<tags>.whl"
+pypi-attestations verify pypi \
+  --repository https://github.com/NomaDamas/AutoRAG-Research \
+  "$WHEEL_DIRECT_URL"
+```
+
+The command downloads the distribution and its provenance, checks that the trusted publisher identifies this
+repository, and cryptographically verifies the distribution against its attestations. Repeat the check for the source
+archive when both distribution types are present. The provenance JSON for a file is also available through the PyPI
+Integrity API at:
+
+```text
+https://pypi.org/integrity/autorag-research/<version>/<filename>/provenance
+```
+
+The repository, workflow, and environment shown in the provenance must correspond to the configured publisher tuple
+above. A missing or mismatched provenance record is a release incident; do not treat a successful upload alone as
+proof of provenance.
+
+## Updating Action SHAs
+
+All external actions in the release workflow are pinned to full commit SHAs. Update a pin as follows:
+
+1. Review the upstream action release notes and the commit that the release is intended to reference.
+2. Resolve the selected ref to a full 40-character commit SHA. For an annotated tag, use the peeled `^{}` result:
+
+   ```bash
+   git ls-remote https://github.com/actions/checkout.git \
+     refs/tags/v4 'refs/tags/v4^{}'
+   ```
+
+   For a maintained branch, query the exact `refs/heads/<branch>` ref. For example, resolve the PyPA publish action's
+   `release/v1` branch with:
+
+   ```bash
+   git ls-remote https://github.com/pypa/gh-action-pypi-publish.git \
+     refs/heads/release/v1
+   ```
+
+   Branches move, so review the resolved commit and its upstream changes before pinning that commit.
+
+3. Update the `uses:` line and its version comment in `.github/workflows/on-release-main.yml`.
+4. Update the matching entry in `AUDITED_ACTIONS` in `tests/test_release_workflow.py` so the workflow and its audit
+   test remain in agreement.
+5. Run both checks from the repository root:
+
+   ```bash
+   uv run pytest tests/test_release_workflow.py
+   actionlint .github/workflows/on-release-main.yml
+   ```
+
+Do not replace a reviewed SHA with a moving branch or tag reference, and do not update only the workflow while leaving
+the audit test stale.
+
+## Tokenless Recovery
+
+If the publish job fails because PyPI cannot match the GitHub identity, repair the configuration rather than adding a
+credential:
+
+1. Compare the PyPI publisher with the exact tuple `NomaDamas` / `AutoRAG-Research` / `on-release-main.yml` /
+   `pypi`.
+2. Check that the publish job still names the GitHub environment `pypi`, has `id-token: write`, and invokes the PyPA
+   publish action without a password.
+3. If the `build` job succeeded, rerun the failed `publish` job from the same workflow run. It must download and use
+   the existing `python-package-distributions` artifact; do not rerun a modified build to produce replacement files.
+
+Never restore `PYPI_TOKEN` or add another long-lived PyPI token path as a recovery measure. If the publisher or
+environment mismatch cannot be repaired safely, stop the release and escalate with the workflow run and PyPI project
+details.
+
+## Partial or Failed Releases
+
+Treat every distribution filename and its bytes as immutable after any file may have reached PyPI:
+
+- Preserve the successful build artifact and its hashes.
+- Inspect which files are already present on PyPI before retrying.
+- Retry only with the same build artifact and do not rebuild, overwrite, or silently replace an existing filename.
+- If the original artifact cannot safely complete the release, stop and investigate instead of creating a second build
+  for the same version.
+
+## Rollback
+
+Do not delete a PyPI version and do not reuse its version number for different package contents. Roll back a bad
+release by yanking the affected version when appropriate, then publish the fix as a new valid PEP 440 version with a
+new build and new attestations.
+
+## References
+
+- [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/)
+- [PyPI digital attestations](https://docs.pypi.org/attestations/)
+- [PyPI Integrity API](https://docs.pypi.org/api/integrity/)
+- [PEP 440](https://peps.python.org/pep-0440/)
+- [PEP 740](https://peps.python.org/pep-0740/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - Contributing:
       - contributing/index.md
       - contributing/development-setup.md
+      - PyPI Release: contributing/pypi-release.md
 
 plugins:
   - search

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,254 @@
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parents[1] / ".github" / "workflows" / "on-release-main.yml"
+SHA_REFERENCE = re.compile(r"^[^@\s]+@[0-9a-fA-F]{40}$")
+AUDITED_ACTIONS = {
+    "actions/checkout": ("34e114876b0b11c390a56381ad16ebd13914f8d5", "v4"),
+    "astral-sh/setup-uv": ("d0cc045d04ccac9d8b7881df0226f9e82c39688e", "v6"),
+    "actions/upload-artifact": ("ea165f8d65b6e75b540449e92b4886f43607fa02", "v4"),
+    "actions/download-artifact": ("d3f86a106a0bac45b974a628896c90dbdf5c8093", "v4"),
+    "pypa/gh-action-pypi-publish": ("cef221092ed1bacb1cc03d23a2d87d1d172e277b", "release/v1"),
+}
+
+
+@pytest.fixture
+def workflow_source() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def workflow(workflow_source: str):
+    return yaml.load(workflow_source, Loader=yaml.BaseLoader)  # noqa: S506
+
+
+def _steps(workflow: dict, job_name: str) -> list[dict]:
+    return workflow["jobs"].get(job_name, {}).get("steps", [])
+
+
+def _run_lines(workflow: dict, job_name: str) -> list[str]:
+    return [
+        line.strip() for step in _steps(workflow, job_name) for line in step.get("run", "").splitlines() if line.strip()
+    ]
+
+
+def _steps_using(workflow: dict, job_name: str, action: str) -> list[dict]:
+    return [step for step in _steps(workflow, job_name) if step.get("uses", "").split("@", maxsplit=1)[0] == action]
+
+
+def _external_uses(workflow: dict) -> list[str]:
+    return [
+        step["uses"]
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if "uses" in step and not step["uses"].startswith("./")
+    ]
+
+
+def test_release_workflow_defaults_to_denying_permissions(workflow: dict) -> None:
+    # Given the release workflow is loaded with its top-level policy.
+    # When the default permission grant is inspected.
+    # Then jobs begin with no ambient GitHub token permissions.
+    assert workflow.get("permissions") == {}
+
+
+def test_release_workflow_has_build_publish_deploy_graph(workflow: dict) -> None:
+    # Given the release workflow job definitions.
+    jobs = workflow["jobs"]
+
+    # When the release dependency graph is inspected.
+    # Then the workflow builds, publishes, and deploys in that order.
+    assert set(jobs) == {"build", "publish", "deploy-docs"}
+    assert "needs" not in jobs.get("build", {})
+    assert jobs.get("publish", {}).get("needs") == "build"
+    assert jobs.get("deploy-docs", {}).get("needs") == "publish"
+
+
+def test_release_workflow_scopes_permissions_per_job(workflow: dict) -> None:
+    # Given the build, publish, and deploy jobs.
+    jobs = workflow["jobs"]
+
+    # When each job's explicit permission scope is inspected.
+    # Then every job receives only the access required for its release stage.
+    assert jobs.get("build", {}).get("permissions") == {"contents": "read"}
+    assert jobs.get("publish", {}).get("permissions") == {"id-token": "write"}
+    assert jobs.get("deploy-docs", {}).get("permissions") == {"contents": "write"}
+
+
+def test_release_workflow_publishes_through_the_pypi_environment(workflow: dict) -> None:
+    # Given the publish job's deployment environment.
+    environment = workflow["jobs"].get("publish", {}).get("environment", {})
+
+    # When its protection boundary and deployment URL are inspected.
+    # Then Trusted Publishing is gated by the named PyPI environment.
+    assert environment == {
+        "name": "pypi",
+        "url": "https://pypi.org/p/autorag-research",
+    }
+
+
+def test_release_workflow_does_not_use_token_secrets_or_sed(workflow_source: str) -> None:
+    # Given the unchanged release workflow source.
+    # When the source is searched for legacy mutation and token-publishing paths.
+    # Then neither path is present in the workflow contract.
+    assert "PYPI_TOKEN" not in workflow_source
+    assert "UV_PUBLISH_TOKEN" not in workflow_source
+    assert "sed" not in workflow_source
+
+
+def test_release_workflow_versions_once_from_the_release_tag(workflow: dict) -> None:
+    # Given the build job's shell commands.
+    version_commands = [line for line in _run_lines(workflow, "build") if re.match(r"^uv\s+version\b", line)]
+
+    # When the release-version command is counted.
+    # Then exactly one frozen command derives the project version from the release tag.
+    assert version_commands == ['uv version --frozen -- "$RELEASE_VERSION"']
+
+
+def test_release_workflow_passes_the_release_tag_through_step_env(workflow: dict) -> None:
+    # Given the build job's release-version step.
+    version_steps = [step for step in _steps(workflow, "build") if re.match(r"^uv\s+version\b", step.get("run", ""))]
+
+    # When the command inputs are inspected.
+    # Then the untrusted release tag reaches the shell only through an environment variable.
+    assert len(version_steps) == 1
+    assert version_steps[0].get("env") == {"RELEASE_VERSION": "${{ github.event.release.tag_name }}"}
+
+
+def test_release_workflow_keeps_expressions_out_of_run_commands(workflow: dict) -> None:
+    # Given every shell command in the release workflow.
+    run_commands = [
+        step.get("run", "") for job in workflow["jobs"].values() for step in job.get("steps", []) if "run" in step
+    ]
+
+    # When shell command source is inspected.
+    # Then GitHub expressions are not interpolated directly into shell commands.
+    assert run_commands
+    assert all("${{" not in command for command in run_commands)
+
+
+def test_release_workflow_disables_setup_uv_caching(workflow: dict) -> None:
+    # Given the build and documentation setup-uv steps.
+    setup_uv_steps = [
+        step for job_name in ("build", "deploy-docs") for step in _steps_using(workflow, job_name, "astral-sh/setup-uv")
+    ]
+
+    # When the cache policy is inspected.
+    # Then every setup-uv invocation explicitly disables caching.
+    assert len(setup_uv_steps) == 2
+    assert all(step.get("with", {}).get("enable-cache") == "false" for step in setup_uv_steps)
+
+
+def test_release_workflow_does_not_persist_build_checkout_credentials(workflow: dict) -> None:
+    # Given the build job checkout step.
+    checkout_steps = _steps_using(workflow, "build", "actions/checkout")
+
+    # When its credential persistence policy is inspected.
+    # Then the build workspace cannot retain the GitHub token for later commands.
+    assert len(checkout_steps) == 1
+    assert checkout_steps[0].get("with", {}).get("persist-credentials") == "false"
+
+
+def test_release_workflow_serializes_each_release_tag(workflow: dict) -> None:
+    # Given the workflow-level concurrency policy.
+    concurrency = workflow.get("concurrency", {})
+
+    # When release grouping and cancellation behavior are inspected.
+    # Then each release tag has an independent, non-canceling concurrency group.
+    assert concurrency == {
+        "group": "release-${{ github.event.release.tag_name }}",
+        "cancel-in-progress": "false",
+    }
+
+
+def test_release_workflow_builds_the_release_ref_with_uv_0_9_7(workflow: dict) -> None:
+    # Given the build job's checkout and uv setup steps.
+    checkout_steps = _steps_using(workflow, "build", "actions/checkout")
+    setup_uv_steps = _steps_using(workflow, "build", "astral-sh/setup-uv")
+
+    # When their immutable build inputs are inspected.
+    # Then the release tag is checked out and the audited uv version is installed.
+    assert len(checkout_steps) == 1
+    assert checkout_steps[0].get("with", {}).get("ref") == "${{ github.event.release.tag_name }}"
+    assert len(setup_uv_steps) == 1
+    assert setup_uv_steps[0].get("with", {}).get("version") == "0.9.7"
+
+
+def test_release_workflow_builds_once_without_sources(workflow: dict) -> None:
+    # Given the build job's shell commands.
+    build_commands = [line for line in _run_lines(workflow, "build") if re.match(r"^uv\s+build\b", line)]
+
+    # When the package-build command is counted.
+    # Then exactly one source-independent uv build is required.
+    assert build_commands == ["uv build --no-sources"]
+
+
+def test_release_workflow_transfers_the_built_distribution(workflow: dict) -> None:
+    # Given the build and publish job steps.
+    upload_steps = _steps_using(workflow, "build", "actions/upload-artifact")
+    download_steps = _steps_using(workflow, "publish", "actions/download-artifact")
+
+    # When the artifact handoff is inspected.
+    # Then the publish job downloads the distribution produced by the build job.
+    assert len(upload_steps) == 1
+    assert len(download_steps) == 1
+    assert upload_steps[0]["with"]["path"] == "dist"
+    assert download_steps[0]["with"]["name"] == upload_steps[0]["with"]["name"]
+    assert download_steps[0]["with"]["path"] == "dist"
+
+
+def test_release_workflow_uses_pypa_trusted_publishing_with_attestations(workflow: dict) -> None:
+    # Given the publish job steps.
+    publisher_steps = _steps_using(workflow, "publish", "pypa/gh-action-pypi-publish")
+
+    # When the package publisher is inspected.
+    # Then PyPI Trusted Publishing is used and attestations are not disabled.
+    assert len(publisher_steps) == 1
+    publisher = publisher_steps[0]
+    assert re.fullmatch(r"pypa/gh-action-pypi-publish@[0-9a-fA-F]{40}", publisher["uses"])
+    assert publisher.get("with", {}).get("packages-dir") == "dist"
+    assert publisher.get("with", {}).get("attestations") == "true"
+
+
+def test_release_workflow_deploys_docs_with_pinned_uv_environment(workflow: dict) -> None:
+    # Given the documentation deployment job.
+    checkout_steps = _steps_using(workflow, "deploy-docs", "actions/checkout")
+    setup_uv_steps = _steps_using(workflow, "deploy-docs", "astral-sh/setup-uv")
+    run_lines = _run_lines(workflow, "deploy-docs")
+
+    # When its toolchain and commands are inspected.
+    # Then it installs Python and locked dependencies before the existing MkDocs deployment.
+    assert len(checkout_steps) == 1
+    assert len(setup_uv_steps) == 1
+    assert checkout_steps[0].get("with", {}).get("persist-credentials", "true") == "true"
+    assert setup_uv_steps[0].get("with", {}).get("version") == "0.9.7"
+    assert setup_uv_steps[0].get("with", {}).get("python-version")
+    assert "uv sync --frozen --all-extras" in run_lines
+    assert "uv run mkdocs gh-deploy --force" in run_lines
+
+
+def test_release_workflow_pins_every_external_action_to_audited_commit(
+    workflow: dict,
+    workflow_source: str,
+) -> None:
+    # Given every external action reference in the release workflow.
+    external_uses = _external_uses(workflow)
+
+    # When each reference and its review comment are checked.
+    # Then every external action uses exactly an audited commit with its version comment.
+    assert external_uses
+    assert all(SHA_REFERENCE.fullmatch(reference) for reference in external_uses)
+    expected_references = {
+        f"{action}@{sha}": version_comment for action, (sha, version_comment) in AUDITED_ACTIONS.items()
+    }
+    assert set(external_uses) == set(expected_references)
+
+    for reference, version_comment in expected_references.items():
+        pinned_lines = re.findall(
+            rf"(?m)^\s*uses:\s+{re.escape(reference)}\s+#\s+{re.escape(version_comment)}\s*$",
+            workflow_source,
+        )
+        assert len(pinned_lines) == external_uses.count(reference)


### PR DESCRIPTION
## Summary

- replace long-lived PyPI token publishing with environment-bound GitHub OIDC Trusted Publishing
- build the release artifact once, transfer the same distributions to the publish job, and request PEP 740 attestations
- apply least-privilege permissions, full-SHA action pins, cache isolation, safe tag handling, and per-tag concurrency
- document publisher setup, SHA maintenance, provenance verification, tokenless recovery, partial releases, and rollback

## Root cause

The release workflow used `PYPI_TOKEN`, mutable action tags, ambient permissions, and a two-stage manifest/build flow without durable provenance.

## Verification

- `make check`
- `uv run pytest tests/test_release_workflow.py -q` (`17 passed`)
- `actionlint .github/workflows/on-release-main.yml`
- `uvx zizmor .github/workflows/on-release-main.yml` (zero active findings)
- workflow-pinned uv `0.9.7`: versioned and built wheel/sdist `0.0.2`, then restored `pyproject.toml` and `uv.lock` byte-for-byte
- adversarial option-shaped tag `--help` exits nonzero as an invalid version after the `--` delimiter
- `uv run mkdocs build -s` with temporary output
- Docker-backed suite: `1708 passed`; the remaining 5 failures are existing live OpenAI tests returning HTTP 401 for the configured key

## Rollout prerequisites

Before the first production OIDC release, repository/PyPI administrators must:

- create the GitHub environment `pypi`
- configure the PyPI Trusted Publisher tuple `NomaDamas / AutoRAG-Research / on-release-main.yml / pypi`
- verify wheel and sdist provenance after the controlled release

The repository currently exposes only the `github-pages` environment, so those external settings and live attestations cannot be proven by this PR alone.

Closes #378
